### PR TITLE
Make mw-sidebar-sitename flexible

### DIFF
--- a/resources/components/common.less
+++ b/resources/components/common.less
@@ -201,6 +201,7 @@ a {
 
 #mw-wrapper {
 	overflow: hidden;
+	perspective: 1px; // Antialiasing fix
 }
 
 #siteNotice {

--- a/resources/components/navigation.less
+++ b/resources/components/navigation.less
@@ -279,19 +279,21 @@
 #mw-sidebar-sitename {
 	position: fixed;
 	visibility: visible;
-	top: @sidebar-sitename-height + @header-height + @margin-side;
+	top: 0;
 	left: @margin-side;
 	font-size: 11px;
 	letter-spacing: 4px;
-	transform: translateY( 0 ) rotate( -90deg );
-	transform-origin: top left;
+	transform: translateY( 100% ) translateX( -100% ) rotate( -90deg );
+	transform-origin: top right;
 	transition: @transition-transform, @transition-opacity;
+	padding-right: 90px;
+	-webkit-font-smoothing: subpixel-antialiased;
 }
 
 // Nav up stuff
 .nav-up {
 	~ #mw-sidebar-sitename {
-		transform: translateY( -54px ) rotate( -90deg );
+		transform: translateY( -54px ) translateX( -100% ) rotate( -90deg );
 	}
 
 	#mw-header-menu-drawer-container {

--- a/resources/components/navigation.less
+++ b/resources/components/navigation.less
@@ -279,14 +279,13 @@
 #mw-sidebar-sitename {
 	position: fixed;
 	visibility: visible;
-	top: 0;
+	top: @header-height;
 	left: @margin-side;
 	font-size: 11px;
 	letter-spacing: 4px;
 	transform: translateY( 100% ) translateX( -100% ) rotate( -90deg );
 	transform-origin: top right;
 	transition: @transition-transform, @transition-opacity;
-	padding-right: 90px;
 	-webkit-font-smoothing: subpixel-antialiased;
 }
 

--- a/resources/components/navigation.less
+++ b/resources/components/navigation.less
@@ -292,7 +292,7 @@
 // Nav up stuff
 .nav-up {
 	~ #mw-sidebar-sitename {
-		transform: translateY( -54px ) translateX( -100% ) rotate( -90deg );
+		transform: translateY( @header-height - @margin-side ) translateX( -100% ) rotate( -90deg );
 	}
 
 	#mw-header-menu-drawer-container {
@@ -355,7 +355,7 @@
 	}
 
 	.nav-up ~ #mw-sidebar-sitename {
-		transform: translateY( -54px ) rotate( 90deg );
+		transform: translateY( @header-height - @margin-side ) rotate( 90deg );
 	}
 
 	#mw-header-menu-drawer {


### PR DESCRIPTION
This removes the need to overwrite the 'top' property in the global css.