### PR TITLE
Fix broadtable not using full width

### DIFF
--- a/skinStyles/extensions/SemanticMediaWiki/ext.smw.table.styles.less
+++ b/skinStyles/extensions/SemanticMediaWiki/ext.smw.table.styles.less
@@ -5,6 +5,11 @@
 
 @import '../../../resources/variables.less';
 
+.content table.broadtable,
+.smw-ask-result table.broadtable {
+	display: table;
+}
+
 @media ( prefers-color-scheme: dark ) {
 	.smw-table-header {
 		background-color: @dark-bg-20;


### PR DESCRIPTION
SMW broadtable should display as table so it takes the full page width