### PR TITLE
Don't double invert checkbox inputs

### DIFF
--- a/skinStyles/oojs/oojs-ui-core.less
+++ b/skinStyles/oojs/oojs-ui-core.less
@@ -64,7 +64,7 @@
 }
 
 @media ( prefers-color-scheme: dark ) {
-	.oo-ui-iconElement-icon,
+	.oo-ui-iconElement-icon:not( .oo-ui-checkboxInputWidget-checkIcon ),
 	.oo-ui-indicator-down {
 		filter: invert( 1 ) hue-rotate( 180deg );
 	}


### PR DESCRIPTION
Checkbox labels have a darkmode background color. Inverting it would mean light mode again