### PR TITLE
Allow to make thumbnail size configurable

### DIFF
--- a/includes/CitizenHooks.php
+++ b/includes/CitizenHooks.php
@@ -90,7 +90,7 @@ class CitizenHooks {
 	public static function onThumbnailBeforeProduceHTML( $thumb, &$attribs, &$linkAttribs ) {
 		try {
 			$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'Citizen' );
-			$thumbSize = $config->get( 'ThumbnailSize' );
+			$thumbSize = $config->get( 'CitizenThumbnailSize' );
 		} catch ( ConfigException $e ) {
 			wfLogWarning( sprintf( 'Could not get config for "$wgThumbnailSize". Defaulting to "10". %s',
 				$e->getMessage() ) );

--- a/includes/CitizenHooks.php
+++ b/includes/CitizenHooks.php
@@ -88,6 +88,15 @@ class CitizenHooks {
 	 * @return bool
 	 */
 	public static function onThumbnailBeforeProduceHTML( $thumb, &$attribs, &$linkAttribs ) {
+		try {
+			$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'Citizen' );
+			$thumbSize = $config->get( 'ThumbnailSize' );
+		} catch ( ConfigException $e ) {
+			wfLogWarning( sprintf( 'Could not get config for "$wgThumbnailSize". Defaulting to "10". %s',
+				$e->getMessage() ) );
+			$thumbSize = 10;
+		}
+
 		$file = $thumb->getFile();
 
 		if ( $file !== null ) {
@@ -112,7 +121,8 @@ class CitizenHooks {
 			$attribs['data-height'] = $attribs['height'];
 
 			// Replace src with small size image
-			$attribs['src'] = preg_replace( '#/\d+px-#', '/10px-', $attribs['src'] );
+			$attribs['src'] =
+				preg_replace( '#/\d+px-#', sprintf( '/%upx-', $thumbSize ), $attribs['src'] );
 
 			// So that the 10px thumbnail is enlarged to the right size
 			$attribs['width'] = $attribs['data-width'];

--- a/skin.json
+++ b/skin.json
@@ -164,6 +164,12 @@
 			"description": "Page tools visibility condition",
 			"descriptionmsg": "citizen-config-showpagetools",
 			"public": true
+		},
+		"ThumbnailSize": {
+			"value": 10,
+			"description": "Thumbnail size to use for lazy-loading",
+			"descriptionmsg": "citizen-config-thumbnailsize",
+			"public": true
 		}
 	},
 	"ConfigRegistry": {


### PR DESCRIPTION
This feature adds a setting for making the thumbnail size configurable.
MediaWiki generates 120px thumbnails per default on upload ($wgThumbLimits).
The used default of 10px can lead to 404 errors on wikis that do not generate thumbnails on the fly.

This change will open up the possibility of using the default generated 120px thumb, which is 'only' a ~2kb increase in size over the 10px version.