### PR TITLE
Add installer name to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,8 @@
 			"phpcs -p -s",
 			"minus-x check ."
 		]
-	}
+	},
+	"extra": {
+		"installer-name": "Citizen"
+	}	
 }


### PR DESCRIPTION
When installing the skin via composer the created folder is named `citizen` instead of `Citizen`.  
See: https://www.mediawiki.org/wiki/Manual:Composer.json_best_practices#Skins for more info