### PR TITLE
Make toc closed by default on mobile

### DIFF
--- a/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
+++ b/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
@@ -144,7 +144,7 @@
 			}
 
 			&checkbox:not( :checked ) ~ ul {
-				transform: none;
+				transform: translateX( -300px - @margin-side );
 			}
 		}
 
@@ -162,7 +162,7 @@
 			background: @base-100;
 			border-radius: 0 @border-radius-large @border-radius-large 0;
 			.boxshadow(3);
-			transform: translateX( -300px - @margin-side );
+			transform: none;
 			transition: @transition-transform;
 		}
 	}


### PR DESCRIPTION
Fixes #195 for MediaWiki 1.35.

Not familiar enough with MediaWiki to know if this is a regression with older versions.