### PR TITLE
Fix closed toc eating clicks with phantom div

### DIFF
--- a/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
+++ b/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
@@ -144,7 +144,7 @@
 			}
 
 			&checkbox:not( :checked ) ~ ul {
-				transform: none;
+				transform: translateX( -300px - @margin-side );
 			}
 		}
 
@@ -162,7 +162,7 @@
 			background: @base-100;
 			border-radius: 0 @border-radius-large @border-radius-large 0;
 			.boxshadow(3);
-			transform: translateX( -300px - @margin-side );
+			transform: none;
 			transition: @transition-transform;
 		}
 	}

--- a/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
+++ b/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
@@ -97,6 +97,7 @@
 		height: 100%;
 		margin-top: -@header-height;
 		padding: 0;
+		transform: translateX(-100%);
 
 		&:before,
 		&:after {
@@ -112,7 +113,7 @@
 			&label {
 				position: fixed;
 				z-index: 7;
-				right: 0;
+				right: -100vw;
 				bottom: 0;
 				margin: @margin-side;
 				padding: 0 @margin-side / 2;
@@ -144,7 +145,7 @@
 			}
 
 			&checkbox:not( :checked ) ~ ul {
-				transform: translateX( -300px - @margin-side );
+				transform: none;
 			}
 		}
 
@@ -162,7 +163,7 @@
 			background: @base-100;
 			border-radius: 0 @border-radius-large @border-radius-large 0;
 			.boxshadow(3);
-			transform: none;
+			transform: translateX(100%);
 			transition: @transition-transform;
 		}
 	}


### PR DESCRIPTION
Current behaviour removes the toc from view by applying a transform to the .toc > ul but *not* .toc itself.

This means that .toc is still covering the body when the toc is "closed", eating clicks on anything that would be covered by the toc when opened.