### PR TITLE
feat: Add drawer subsearch

### DIFF
--- a/includes/Partials/Drawer.php
+++ b/includes/Partials/Drawer.php
@@ -141,12 +141,19 @@ final class Drawer extends Partial {
 			}
 		}
 
-		return [
+		$portals = [
 			'msg-citizen-drawer-toggle' => $this->skin->msg( 'citizen-drawer-toggle' )->text(),
 			'data-portals-first' => $firstPortal,
 			'array-portals-rest' => $props,
 			'data-portals-languages' => $languages,
+			'data-drawer-subsearch' => false,
 		];
+
+		if ( $this->getConfigValue( 'CitizenEnableDrawerSubSearch' ) ) {
+			$portals['data-drawer-subsearch'] = true;
+		}
+
+		return $portals;
 	}
 
 	/**

--- a/includes/Partials/Theme.php
+++ b/includes/Partials/Theme.php
@@ -67,7 +67,7 @@ final class Theme extends Partial {
 
 		// Script content at 'skins.citizen.scripts.theme/inline.js
         // @phpcs:ignore Generic.Files.LineLength.TooLong
-		$this->out->getOutput()->addHeadItem( 'theme-switcher', '<script>window.switchTheme=(()=>{try{const t=document.cookie.match(/skin-citizen-theme=(dark|light|auto)/),e=null!==t?t.pop():null;null!==e&&(document.documentElement.classList.remove(...["auto","dark","light"].map(t=>"skin-citizen-"+t)),document.documentElement.classList.add("skin-citizen-"+e))}catch(t){}}),window.switchTheme();</script>' );
+		$this->out->getOutput()->addHeadItem( 'theme-switcher', '<script>window.switchTheme=()=>{var e=t=>["auto","dark","light"].map(e=>t+e);const t=document.getElementById("theme-toggle");try{const c=document.cookie.match(/skin-citizen-theme=(dark|light|auto)/);var n=null!==c?c.pop():null;null!==n&&(document.documentElement.classList.remove(...e("skin-citizen-")),document.documentElement.classList.add("skin-citizen-"+n),t.classList.remove(...e("theme-toggle")),t.classList.add("theme-toggle-"+n))}catch(e){}},window.switchTheme();</script>' );
 
 		// Add styles and scripts module
 		if ( $theme === 'auto' ) {

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -84,6 +84,14 @@ class SkinCitizen extends SkinMustache {
 			);
 		}
 
+		// Load Citizen Drawer SubSearch module if enabled
+		if ( $this->getConfigValue( 'CitizenEnableDrawerSubSearch' ) === true ) {
+			$options['scripts'] = array_merge(
+				$options['scripts'],
+				[ 'skins.citizen.scripts.drawer' ]
+			);
+		}
+
 		// Load table of content script if ToC presents
 		if ( $out->isTOCEnabled() ) {
 			// Add class to body that notifies the page has TOC

--- a/includes/templates/Drawer.mustache
+++ b/includes/templates/Drawer.mustache
@@ -23,6 +23,7 @@
 		{{>Logo}}
 	</section>
 	<section id="mw-drawer-menu">
+	    {{#data-drawer-subsearch}}<div style="display: flex; width: 100%;"><input type="text" id="drawer-search" style="margin: 0 auto;" /></div>{{/data-drawer-subsearch}}
 		{{#data-portals-first}}{{>Menu}}{{/data-portals-first}}
 		{{#array-portals-rest}}{{>Menu}}{{/array-portals-rest}}
 		{{#data-portals-languages}}{{>Menu}}{{/data-portals-languages}}

--- a/resources/skins.citizen.scripts.drawer/drawerSubSearch.js
+++ b/resources/skins.citizen.scripts.drawer/drawerSubSearch.js
@@ -1,0 +1,57 @@
+/**
+ * This enables searching for portals / portal entries in the drawer menu
+ */
+( function () {
+	document.getElementById( 'drawer-search' ).addEventListener( 'input', function ( e ) {
+		var searchVal;
+
+		if ( typeof e.target.value === 'undefined' ) {
+			return;
+		}
+
+		searchVal = e.target.value;
+
+		// If the input is empty, show all portals
+		if ( searchVal.length === 0 ) {
+			document.querySelectorAll( '.mw-portal' ).forEach( function ( portal ) {
+				portal.style.display = null;
+
+				portal.querySelectorAll( 'ul li' ).forEach( function ( li ) {
+					li.style.display = null;
+				} );
+			} );
+
+			return;
+		}
+
+		// For each Portal
+		document.querySelectorAll( '#mw-drawer-menu .mw-portal' ).forEach( function ( portal ) {
+			var allHidden = true;
+
+			// Check all entries
+			portal.querySelectorAll( 'ul li' ).forEach( function ( li ) {
+				// If the query is contained in the link text
+				if ( li.querySelector( 'a' ).innerText.toUpperCase().indexOf( searchVal.toUpperCase() ) >= 0 ) {
+					// If it's the case, at least one entry is visible
+					allHidden = false;
+				} else {
+					// Else, hide it
+					li.style.display = 'none';
+				}
+			} );
+
+			// If the portal contains only hidden links, hide it
+			if ( allHidden ) {
+				portal.style.display = 'none';
+			}
+
+			// But if the query is contained in the portal header, show the entire portal
+			if ( portal.querySelector( 'h3' ).innerText.toUpperCase().indexOf( searchVal.toUpperCase() ) >= 0 ) {
+				portal.querySelectorAll( 'ul li' ).forEach( function ( li ) {
+					li.style.display = null;
+				} );
+				portal.style.display = null;
+			}
+		} );
+	} );
+}() );

--- a/resources/skins.citizen.scripts.drawer/drawerSubSearch.js
+++ b/resources/skins.citizen.scripts.drawer/drawerSubSearch.js
@@ -34,6 +34,7 @@
 				if ( li.querySelector( 'a' ).innerText.toUpperCase().indexOf( searchVal.toUpperCase() ) >= 0 ) {
 					// If it's the case, at least one entry is visible
 					allHidden = false;
+					li.style.display = null;
 				} else {
 					// Else, hide it
 					li.style.display = 'none';
@@ -41,16 +42,14 @@
 			} );
 
 			// If the portal contains only hidden links, hide it
-			if ( allHidden ) {
-				portal.style.display = 'none';
-			}
+			portal.style.display = allHidden === true ? 'none' : null;
 
 			// But if the query is contained in the portal header, show the entire portal
 			if ( portal.querySelector( 'h3' ).innerText.toUpperCase().indexOf( searchVal.toUpperCase() ) >= 0 ) {
+				portal.style.display = null;
 				portal.querySelectorAll( 'ul li' ).forEach( function ( li ) {
 					li.style.display = null;
 				} );
-				portal.style.display = null;
 			}
 		} );
 	} );

--- a/resources/skins.citizen.scripts.theme/inline.js
+++ b/resources/skins.citizen.scripts.theme/inline.js
@@ -3,17 +3,30 @@
  * Citizen - Inline script used in SkinCitizen.php
  *
  * https://starcitizen.tools
+ *
+ * Mangle using https://jscompress.com/
  */
 window.switchTheme = () => {
+	// Generates an array of prefix-(auto|dark|light) strings
+	const classNames = (prefix) => {
+		return ['auto', 'dark', 'light'].map(themeType => {
+			return prefix + themeType;
+		});
+	}
+
+	const themeToggle = document.getElementById('theme-toggle');
+
 	try {
 		const cookieTheme = document.cookie.match(/skin-citizen-theme=(dark|light|auto)/);
 		const theme = cookieTheme !== null ? cookieTheme.pop() : null;
 
 		if (theme !== null) {
-			document.documentElement.classList.remove(...['auto', 'dark', 'light'].map(theme => {
-				return 'skin-citizen-' + theme;
-			}));
+			// First remove all theme classes
+			document.documentElement.classList.remove(...classNames('skin-citizen-'));
+			// Then add the right one
 			document.documentElement.classList.add('skin-citizen-' + theme);
+			themeToggle.classList.remove(...classNames('theme-toggle'))
+			themeToggle.classList.add('theme-toggle-' + theme);
 		}
 	} catch (e) {
 	}

--- a/resources/skins.citizen.scripts/checkboxHack.js
+++ b/resources/skins.citizen.scripts/checkboxHack.js
@@ -8,13 +8,19 @@ var DRAWER_ID = 'mw-drawer',
 /**
  * Uncheck CSS hack checkbox when clicked outside
  *
- * @param {HTMLElement} element
+ * @param {HTMLElement|HTMLElement[]} clickableElement
  * @param {HTMLElement} button
  * @param {HTMLElement} checkbox
  */
-function uncheckOnClickOutside( element, button, checkbox ) {
+function uncheckOnClickOutside( clickableElement, button, checkbox ) {
 	var listener = function ( e ) {
-		if ( e.target !== checkbox && e.target !== element ) {
+		var hideCond = e.target !== clickableElement;
+
+		if ( Array.isArray( clickableElement ) ) {
+			hideCond = clickableElement.indexOf( e.target ) === -1;
+		}
+
+		if ( e.target !== checkbox && hideCond ) {
 			if ( e.target !== button ) {
 				checkbox.checked = false;
 			}
@@ -22,18 +28,26 @@ function uncheckOnClickOutside( element, button, checkbox ) {
 		}
 	};
 
-	checkbox.addEventListener( 'click', function () {
-		if ( this.checked ) {
-			document.addEventListener( 'click', listener );
-		}
-	} );
-
-	document.addEventListener( 'keydown', function ( event ) {
+	var keyboardListener = function ( event ) {
 		if ( event.key === 'Escape' && checkbox.checked === true ) {
 			checkbox.checked = false;
 			document.removeEventListener( 'click', listener );
 		}
-	} );
+	};
+
+	var checkboxFn = function () {
+		if ( checkbox.checked ) {
+			document.addEventListener( 'click', listener );
+		} else {
+			document.removeEventListener( 'click', listener );
+		}
+	};
+
+	checkbox.removeEventListener( 'click', checkboxFn );
+	checkbox.addEventListener( 'click', checkboxFn );
+
+	document.removeEventListener( 'keydown', keyboardListener );
+	document.addEventListener( 'keydown', keyboardListener );
 }
 
 /**
@@ -43,11 +57,25 @@ function init() {
 	var drawer = document.getElementById( DRAWER_ID ),
 		drawerButton = document.getElementById( DRAWER_BUTTON_ID ),
 		drawerCheckbox = document.getElementById( DRAWER_CHECKBOX_ID ),
+		drawerSearch = document.getElementById( 'drawer-search' ),
 		personalMenu = document.getElementById( PERSONAL_MENU_ID ),
 		personalMenuButton = document.getElementById( PERSONAL_MENU_BUTTON_ID ),
-		personalMenuCheckbox = document.getElementById( PERSONAL_MENU_CHECKBOX_ID );
-	uncheckOnClickOutside( drawer, drawerButton, drawerCheckbox );
-	uncheckOnClickOutside( null, drawerButton, drawerCheckbox );
+		personalMenuCheckbox = document.getElementById( PERSONAL_MENU_CHECKBOX_ID ),
+		clickableDrawerElements = [];
+
+	drawer.querySelectorAll( '#mw-drawer-menu .mw-portal' ).forEach( function ( portal ) {
+		clickableDrawerElements.push( portal );
+	} );
+
+	drawer.querySelectorAll( '#mw-drawer-menu .mw-portal h3' ).forEach( function ( portalHeading ) {
+		clickableDrawerElements.push( portalHeading );
+	} );
+
+	if ( drawerSearch !== null ) {
+		clickableDrawerElements.push( drawerSearch );
+	}
+
+	uncheckOnClickOutside( clickableDrawerElements, drawerButton, drawerCheckbox );
 	uncheckOnClickOutside( personalMenu, personalMenuButton, personalMenuCheckbox );
 }
 

--- a/resources/skins.citizen.scripts/themeToggle.js
+++ b/resources/skins.citizen.scripts/themeToggle.js
@@ -2,21 +2,18 @@ function init() {
 	var theme = window.mw.cookie.get( 'skin-citizen-theme' );
 	var toggleBtn = document.getElementById( 'theme-toggle' );
 
-	// * theme-toggle-light
-	// * theme-toggle-dark
-	toggleBtn.classList.add( 'theme-toggle-' + theme );
-
 	toggleBtn.addEventListener( 'click', function ( clickEvent ) {
+		theme = window.mw.cookie.get( 'skin-citizen-theme' );
+
 		try {
 			theme = theme === 'dark' ? 'light' : 'dark';
 
-			clickEvent.target.classList.remove( 'theme-toggle-light', 'theme-toggle-dark' );
+			clickEvent.target.classList.remove( 'theme-toggle-light', 'theme-toggle-dark', 'theme-toggle-auto' );
 			// * theme-toggle-light
 			// * theme-toggle-dark
 			clickEvent.target.classList.add( 'theme-toggle-' + theme );
 
 			try {
-				window.mw.cookie.set( 'skin-citizen-theme', null );
 				window.mw.cookie.set( 'skin-citizen-theme', theme );
 				window.mw.cookie.set( 'skin-citizen-theme-override', '1' );
 			} catch ( e ) {
@@ -26,6 +23,12 @@ function init() {
 		} catch ( e ) {
 		}
 	} );
+
+	if ( theme !== 'auto' ) {
+		// * theme-toggle-light
+		// * theme-toggle-dark
+		toggleBtn.classList.add( 'theme-toggle-' + theme );
+	}
 }
 
 module.exports = {

--- a/skin.json
+++ b/skin.json
@@ -184,6 +184,11 @@
 				"resources/skins.citizen.scripts.toc/skins.citizen.scripts.toc.js"
 			]
 		},
+		"skins.citizen.scripts.drawer": {
+			"scripts": [
+				"resources/skins.citizen.scripts.drawer/drawerSubSearch.js"
+			]
+		},
 		"skins.citizen.icons": {
 			"class": "ResourceLoaderImageModule",
 			"selector": "{name}",
@@ -608,6 +613,12 @@
 			"value": "first",
 			"description": "Label of the portal to attach links to upload and special pages to",
 			"descriptionmsg": "citizen-config-portalattach",
+			"public": true
+		},
+		"EnableDrawerSubSearch": {
+			"value": false,
+			"description": "Enables to search the drawer for menu entries",
+			"descriptionmsg": "citizen-config-enabledrawersubsearch",
 			"public": true
 		}
 	},


### PR DESCRIPTION
An input in the drawer allows to search portal headings and links for matching text
- Hides all portals / links based on the search value

Feature can be enabled by setting `$wgCitizenEnableDrawerSubSearch = true;` in LocalSettings.

TBD: The input in `Drawer.mustache` needs to be styled