### PR TITLE
remove overflow-x hidden from body,html

### DIFF
--- a/resources/skins.citizen.styles/common/common.less
+++ b/resources/skins.citizen.styles/common/common.less
@@ -13,7 +13,6 @@ body {
 	margin: 0;
 	background: var( --background-color-dp-00 );
 	color: var( --color-base );
-	overflow-x: hidden; // prevent overflow from scrollbar
 }
 
 h1,


### PR DESCRIPTION
Removing this is necessary so that position sticky can be used on the page.

Reference: https://stackoverflow.com/a/47745433

This was presumably added because of the skin having some errant elements at some point. The only case I can find of this is .catlinks and #p-namespaces in an earlier patch, but their layout has since been changed.