### PR TITLE
Change header shadow from box-shadow to a gradient

### DIFF
--- a/resources/skins.citizen.styles/Header.less
+++ b/resources/skins.citizen.styles/Header.less
@@ -9,6 +9,11 @@
 	display: flex;
 	height: var( --height-header );
 	justify-content: space-between;
+	pointer-events: none;
+
+	& > * {
+		pointer-events: auto;
+	}
 
 	&-tools {
 		display: inherit;

--- a/resources/skins.citizen.styles/Header.less
+++ b/resources/skins.citizen.styles/Header.less
@@ -28,7 +28,21 @@
 		position: absolute;
 		right: 0;
 		left: 0;
-		box-shadow: 0 0 30px var( --height-header ) var( --background-color-dp-00 );
+		height: ~'calc( var( --height-header ) * 1.5 )';
+		/*
+		 * ease(x) := 1 - pow(1 - x, 2);
+		 */
+		background-image: linear-gradient(to bottom,
+			~"rgba(var(--background-color-dp-00-rgb),1)" 0%,
+			~"rgba(var(--background-color-dp-00-rgb),0.988)" 11.11%,
+			~"rgba(var(--background-color-dp-00-rgb),0.951)" 22.22%,
+			~"rgba(var(--background-color-dp-00-rgb),0.889)" 33.33%,
+			~"rgba(var(--background-color-dp-00-rgb),0.802)" 44.44%,
+			~"rgba(var(--background-color-dp-00-rgb),0.691)" 55.56%,
+			~"rgba(var(--background-color-dp-00-rgb),0.556)" 66.67%,
+			~"rgba(var(--background-color-dp-00-rgb),0.395)" 77.78%,
+			~"rgba(var(--background-color-dp-00-rgb),0.210)" 88.89%,
+			~"rgba(var(--background-color-dp-00-rgb),0)" 100%);
 		content: '';
 	}
 }

--- a/resources/skins.citizen.styles/common/rootvariables.less
+++ b/resources/skins.citizen.styles/common/rootvariables.less
@@ -10,6 +10,7 @@
  */
 :root {
 	/* Background Colors */
+	--background-color-dp-00-rgb: red(@background-color-dp-00), green(@background-color-dp-00), blue(@background-color-dp-00);
 	--background-color-dp-00: @background-color-dp-00;
 	--background-color-dp-01: @background-color-dp-01;
 	--background-color-dp-02: @background-color-dp-02;
@@ -86,6 +87,7 @@ html {
  */
 :root.skin-citizen-dark {
 	/* Background Colors */
+	--background-color-dp-00-rgb: red(@dark-background-color-dp-00), green(@dark-background-color-dp-00), blue(@dark-background-color-dp-00);
 	--background-color-dp-00: @dark-background-color-dp-00;
 	--background-color-dp-01: @dark-background-color-dp-01;
 	--background-color-dp-02: @dark-background-color-dp-02;


### PR DESCRIPTION
This improves the precision of the shadow since it has a well-defined height and can transition along an easing function.

Pointer events are ignored so that content underneath the shadow (and the header itself) can still be clicked.

There remains an issue in dark mode where the alpha blending between the background and the shadow multiplies their RGB values, resulting in a visible gradient. I tried using `mix-blend-mode: luminosity` to avoid this, but that creates issues when images in the body cover the shadow, and it's only supported in Firefox anyway. Changing the background color to #000 would solve this, but that's probably not desirable.