### PR TITLE
feat: tweak toc

### DIFF
--- a/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
+++ b/resources/skins.citizen.styles.toc/skins.citizen.styles.toc.less
@@ -15,6 +15,7 @@
 		padding: @padding-page;
 		color: var( --color-base--subtle );
 		font-size: @ui-menu-text;
+		width: 100%;
 
 		&::-webkit-scrollbar {
 			width: 0; // Hide bar on toc
@@ -59,11 +60,6 @@
 			> a {
 				color: inherit !important;
 			}
-
-			a,
-			li {
-				color: var( --color-base );
-			}
 		}
 
 		a {
@@ -96,6 +92,7 @@
 			overflow: visible auto;
 			max-height: ~'calc( 100vh - var( --height-header ) * 2 )';
 			margin: @content-margin-top * 0.75 0 0 0 !important;
+			padding-right: 10px;
 			font-weight: 450;
 			overscroll-behavior: contain;
 		}
@@ -171,7 +168,6 @@
 				position: absolute;
 				z-index: 3;
 				width: ~'calc( 100% - var( --padding-page ) * 2 )';
-				max-width: var( --width-toc );
 				padding: 20px var( --padding-page ) 10px var( --padding-page );
 				background: var( --background-color-dp-04 );
 				border-radius: @border-radius-large @border-radius-large 0 0;
@@ -180,13 +176,39 @@
 			> ul {
 				display: block !important; // So that animation is visible
 				max-height: ~'calc( 100vh - var( --height-header ) * 3 )';
-				padding: 45px var( --padding-page ) 20px var( --padding-page ); // hardcoded for now
+				padding: 0 var( --padding-page ) 20px var( --padding-page ); // hardcoded for now
 				border: 1px solid var( --border-color-base--lighter );
-				margin: 0 !important;
+				margin: 45px 0 0 0 !important;
 				background: var( --background-color-dp-04 );
-				border-radius: @border-radius-large;
+				border-radius: 0 0 @border-radius-large @border-radius-large;
 				pointer-events: auto;
-				.boxshadow(3);
+
+				/**
+				 * Ideally we'd have this shadow on the .toc container, but the
+				 * container can't move with the checkbox.
+				 *
+				 * Assigning the regular box shadow here won't work because then the
+				 * .toctitle won't have any shadow and look weird. Giving .toctitle a
+				 * shadow causes it to go over the `> ul` which is no good.  So we need to
+				 * have a duplicate shadow here shifted up to reach the .toctitle. One
+				 * would think the shadows overlapping would look funny on the sides, but
+				 * it actually looks fine. (The trick *is* visible if you look very closely
+				 * for it, though.)
+				 *
+				 * Previous approach used padding-top equal to the height of the
+				 * .toctitle, with the .toctitle being absolutely positioned. But this
+				 * causes the `> ul` y-scrollbar to look funky in two ways: it clearly
+				 * pokes out from .toctitle's border-top-right-radius; and when it's
+				 * scrolled down slightly, it still appears on the scrollbar as if it's at
+				 * the top, exposing the hack.
+				 */
+				// .boxshadow(3);
+				// => box-shadow: 0 10px 20px rgba( 0, 0, 0, 0.0475 ), 0 6px 6px rgba( 0, 0, 0, 0.0575 );
+				box-shadow:
+					0 10px 20px rgba( 0, 0, 0, 0.0475 ),
+					0 6px 6px rgba( 0, 0, 0, 0.0575 ),
+					0 (10px - 45px) 20px rgba( 0, 0, 0, 0.0475 ),
+					0 (6px - 45px) 6px rgba( 0, 0, 0, 0.0575 );
 			}
 		}
 
@@ -213,11 +235,16 @@
 	@media ( max-width: @width-breakpoint-tablet ) {
 		.toc {
 			right: 0;
-			max-width: unset;
 
 			> ul {
 				max-height: 60vh;
 			}
+		}
+	}
+
+	@media ( max-width: @width-breakpoint-mobile ) {
+		.toc {
+			max-width: ~'calc(100vw - var( --padding-page ) * 2)';
 		}
 	}
 


### PR DESCRIPTION
3 different concerns addressed:

First: stop y-scrollbar on collapsible .toc extending into the .toctitle.

This looks weird because the rounded corner exposes the hack; and it makes the
scrollbar not accurately match its apparent position, because a part of it is
hidden. Hacking around with the box shadow is less visible.

Second: make .toc always fill out available space; add padding-right to the li elems.

In some cases, more often on Firefox, there's plenty of space for the .toc,
but it's not used. Instead we get a super thin .toc with text rubbing right up
against the scrollbar. Given that the layout already allocates space for the
.toc (from --width-toc), no reason not to just always use it with `width:
100%`.

Third: remove color change to li.active children.

The border already sufficiently encompasses all the children, so it's
redundant. The problem with it is that the color change is the same as the
hover color, which is the only visual indicator of which toc item is hovered.

(Screenshot below showing box-shadow hack is barely visible.)

![image](https://user-images.githubusercontent.com/387174/116675438-fb60e100-a9e4-11eb-9098-c92d2633703d.png)

(Screenshot below highlighting various concerns.)

![image](https://user-images.githubusercontent.com/387174/116675477-04ea4900-a9e5-11eb-85d6-0e83e36466b9.png)

