### PR TITLE
Show footer desc and tagline in the content language

### DIFF
--- a/includes/Partials/Footer.php
+++ b/includes/Partials/Footer.php
@@ -47,7 +47,8 @@ final class Footer extends Partial {
 
 		// Get messages
 		foreach ( $msg as $key ) {
-			$data["msg-citizen-footer-$key"] = $this->skin->msg( "citizen-footer-$key" )->parse();
+			$data["msg-citizen-footer-$key"] = $this->skin->msg( "citizen-footer-$key" )
+				->inContentLanguage()->parse();
 		}
 
 		// Based on SkinMustache

--- a/skin.json
+++ b/skin.json
@@ -42,8 +42,6 @@
 						"citizen-personalmenu-toggle",
 						"citizen-search-toggle",
 						"citizen-theme-toggle",
-						"citizen-footer-desc",
-						"citizen-footer-tagline",
 						"citizen-jumptotop"
 					]
 				}


### PR DESCRIPTION
The description and tagline in the footer are not easily edited in all possible languages. For instance, you can see untouched messages in https://starcitizen.tools/Star_Citizen:About?uselang=de or https://star-citizen.wiki/Star_Citizen_Wiki?uselang=en.

This makes the only messages in the content language to be used.