### PR TITLE
fix: Find toolbox explicitly

### DIFF
--- a/includes/Partials/PageTools.php
+++ b/includes/Partials/PageTools.php
@@ -78,10 +78,16 @@ final class PageTools extends Partial {
 				$actionshtml = $parentData['data-portlets']['data-actions'];
 				$namespaceshtml = $parentData['data-portlets']['data-namespaces'];
 				$variantshtml = $parentData['data-portlets']['data-variants'];
-				// The last item of the sidebar is the toolbox
+				// Finds the toolbox in the sidebar.
 				$sidebar = [ $parentData['data-portlets-sidebar']['data-portlets-first'],
 					...$parentData['data-portlets-sidebar']['array-portlets-rest'] ];
-				$toolboxhtml = $sidebar[count( $sidebar ) - 1];
+				$toolboxhtml = null;
+				foreach ( $sidebar as $portlet ) {
+					if ( $portlet['id'] === 'p-tb' ) {
+						$toolboxhtml = $portlet;
+						break;
+					}
+				}
 			}
 
 			if ( $viewshtml ) {


### PR DESCRIPTION
In my last PR #440, I chose the last item in the sidebar as the toolbox. This is not true in some wikis, as result, a wrong portlet is displayed.