### PR TITLE
Add missing variables.less import

### DIFF
--- a/skinStyles/extensions/UniversalLanguageSelector/ext.uls.pt.less
+++ b/skinStyles/extensions/UniversalLanguageSelector/ext.uls.pt.less
@@ -8,6 +8,8 @@
  * Date: 2022-05-17
 */
 
+@import '../../../resources/variables.less';
+
 // Needed to override specificity from original style
 .skin-citizen #pt-uls .uls-trigger {
 	display: flex;


### PR DESCRIPTION
Seeing variable @icon-size is undefined in file /srv/mediawiki/w/skins/Citizen/skinStyles/extensions/UniversalLanguageSelector/ext.uls.pt.less in ext.uls.pt.less on line 19.

Which I think is due to a missing import that contains the definition of @icon-size.