### PR TITLE
Use loose comparison for checking if CitizenShowPageTools is true

### DIFF
--- a/includes/Partials/PageTools.php
+++ b/includes/Partials/PageTools.php
@@ -77,8 +77,7 @@ final class PageTools extends Partial {
 			}
 		}
 
-		if ( $condition === true ) {
-
+		if ( $condition == true ) {
 			if ( !method_exists( SkinTemplate::class, 'runOnSkinTemplateNavigationHooks' ) ) {
 				$viewshtml = $skin->getPortletData( 'views', $contentNavigation[ 'views' ] ?? [] );
 				$actionshtml = $skin->getPortletData( 'actions', $contentNavigation[ 'actions' ] ?? [] );


### PR DESCRIPTION
To support this being set to `1`.

Use-case:
For Miraheze at least, ManageWiki does not support mixing `true` with string values, so it needs to be `1` and thus using strict comparison does not work for that.

miraheze/mw-config@a663626 for the commit that changed this on Miraheze with the result being now it is not shown since this is not `true` anymore.