### PR TITLE
Add lazy load attribute to menu logo

### DIFF
--- a/templates/Drawer__logo.mustache
+++ b/templates/Drawer__logo.mustache
@@ -16,6 +16,6 @@
 				}}{{#1x}}{{.}}{{/1x}}{{!
 			}}{{/svg}}{{!
 		}}{{/icon}}"{{!
-		}}alt="" aria-hidden="true" height="80" width="80">
+		}}alt="" aria-hidden="true" height="80" width="80" decoding="async" loading="lazy">
 </a>
 {{/data-logos}}

--- a/templates/Drawer__logo.mustache
+++ b/templates/Drawer__logo.mustache
@@ -16,6 +16,6 @@
 				}}{{#1x}}{{.}}{{/1x}}{{!
 			}}{{/svg}}{{!
 		}}{{/icon}}"{{!
-		}}alt="" aria-hidden="true" height="80" width="80" decoding="async" loading="lazy">
+		}}alt="" aria-hidden="true" height="80" width="80" loading="lazy">
 </a>
 {{/data-logos}}


### PR DESCRIPTION
Hi.

I've run Page Speed Insights on my wiki, and got a warning "Defer offscreen images":
```
Consider lazy-loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. 

aside#citizen-drawer__card > header.citizen-drawer__header > a.mw-logo > img.mw-logo-icon<img  class="mw-logo-icon"  src="//media.crystalls.info/w/images/logo_icon.png" alt=""  aria-hidden="true" height="80" width="80">
```

This is because logo is not being used until user opens the menu. So I've added `loading="lazy"` and `decoding="async"` attributes to img tag of wiki logo to notify browser that downloading can be deferred.

Example: https://en.crystalls.info/Welcome