### PR TITLE
add config var 'wgCitizenTableNowrapClasses'

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Name | Description | Values | Default
 `$wgCitizenThemeColor` | The color defined in the `theme-color` meta tag | Hex color code | `#131a21`
 `$wgCitizenEnableCJKFonts` | Enable included Noto Sans CJK for wikis that serves CJK languages | `true` - enable; `false` - disable | `false`
 `$wgCitizenEnablePreferences` | Enable the preferences menu | `true` - enable; `false` - disable | `true`
+`$wgCitizenTableNowrapClasses` | Defines table css classes ignored by citizen table wrapper | List of css classes. Extend with `$wgCitizenTableNowrapClasses[] = 'my_class';` | `["citizen-table-nowrap", "mw-changeslist-line", "infobox", "cargoDynamicTable", "dataTable"]`
 
 ### Search suggestions
 Name | Description | Values | Default

--- a/includes/Hooks/ResourceLoaderHooks.php
+++ b/includes/Hooks/ResourceLoaderHooks.php
@@ -47,6 +47,7 @@ class ResourceLoaderHooks {
 		return [
 			'wgCitizenEnablePreferences' => $config->get( 'CitizenEnablePreferences' ),
 			'wgCitizenSearchModule' => $config->get( 'CitizenSearchModule' ),
+			'wgCitizenTableNowrapClasses' => $config->get( 'CitizenTableNowrapClasses' ),
 		];
 	}
 

--- a/includes/Hooks/SkinHooks.php
+++ b/includes/Hooks/SkinHooks.php
@@ -31,8 +31,6 @@ use MediaWiki\Hook\SkinBuildSidebarHook;
 use MediaWiki\Hook\SkinEditSectionLinksHook;
 use MediaWiki\Hook\SkinTemplateNavigation__UniversalHook;
 use MediaWiki\Skins\Hook\SkinPageReadyConfigHook;
-use MediaWiki\ResourceLoader\Hook\ResourceLoaderGetConfigVarsHook;
-use Config;
 
 /**
  * Hooks to run relating the skin
@@ -43,8 +41,7 @@ class SkinHooks implements
 	SkinBuildSidebarHook,
 	SkinEditSectionLinksHook,
 	SkinPageReadyConfigHook,
-	SkinTemplateNavigation__UniversalHook,
-	ResourceLoaderGetConfigVarsHook
+	SkinTemplateNavigation__UniversalHook
 {
 	/**
 	 * Adds the inline theme switcher script to the page
@@ -424,25 +421,5 @@ class SkinHooks implements
 		if ( is_string( $item ) ) {
 			$item = trim( $item );
 		}
-	}
-
-	/**
-	 * This hook is called at the end of
-	 * ResourceLoaderStartUpModule::getConfigSettings(). Use this hook to export static
-	 * configuration variables to JavaScript. Things that depend on the current page
-	 * or request state must be added through MakeGlobalVariablesScript instead.
-	 * Skin is made available for skin specific config.
-	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ResourceLoaderGetConfigVars
-	 *
-	 * @param array &$vars [ variable name => value ]
-	 * @param Skin $skin
-	 * @param Config $config since 1.34
-	 * @return bool|void True or no return value to continue or false to abort
-	 */
-	public function onResourceLoaderGetConfigVars( array &$vars, $skin, Config $config ): void {
-		// makes wgCitizenTableNowrapClasses available for use in
-		// resources/skins.citizen.scripts/tables.js:wrapTable()
-		$vars['wgCitizenTableNowrapClasses'] = $config->get( 'CitizenTableNowrapClasses' );
 	}
 }

--- a/includes/Hooks/SkinHooks.php
+++ b/includes/Hooks/SkinHooks.php
@@ -31,6 +31,8 @@ use MediaWiki\Hook\SkinBuildSidebarHook;
 use MediaWiki\Hook\SkinEditSectionLinksHook;
 use MediaWiki\Hook\SkinTemplateNavigation__UniversalHook;
 use MediaWiki\Skins\Hook\SkinPageReadyConfigHook;
+use MediaWiki\ResourceLoader\Hook\ResourceLoaderGetConfigVarsHook;
+use Config;
 
 /**
  * Hooks to run relating the skin
@@ -41,7 +43,8 @@ class SkinHooks implements
 	SkinBuildSidebarHook,
 	SkinEditSectionLinksHook,
 	SkinPageReadyConfigHook,
-	SkinTemplateNavigation__UniversalHook
+	SkinTemplateNavigation__UniversalHook,
+	ResourceLoaderGetConfigVarsHook
 {
 	/**
 	 * Adds the inline theme switcher script to the page
@@ -421,5 +424,25 @@ class SkinHooks implements
 		if ( is_string( $item ) ) {
 			$item = trim( $item );
 		}
+	}
+
+	/**
+	 * This hook is called at the end of
+	 * ResourceLoaderStartUpModule::getConfigSettings(). Use this hook to export static
+	 * configuration variables to JavaScript. Things that depend on the current page
+	 * or request state must be added through MakeGlobalVariablesScript instead.
+	 * Skin is made available for skin specific config.
+	 *
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ResourceLoaderGetConfigVars
+	 *
+	 * @param array &$vars [ variable name => value ]
+	 * @param Skin $skin
+	 * @param Config $config since 1.34
+	 * @return bool|void True or no return value to continue or false to abort
+	 */
+	public function onResourceLoaderGetConfigVars( array &$vars, $skin, Config $config ): void {
+		// makes wgCitizenTableNowrapClasses available for use in
+		// resources/skins.citizen.scripts/tables.js:wrapTable()
+		$vars['wgCitizenTableNowrapClasses'] = $config->get( 'CitizenTableNowrapClasses' );
 	}
 }

--- a/resources/skins.citizen.scripts/tables.js
+++ b/resources/skins.citizen.scripts/tables.js
@@ -1,3 +1,5 @@
+const config = require( './config.json' );
+
 /**
  * Set up scroll affordance for an overflowed element
  * TODO: Move this out of tables when this is used by more stuff
@@ -61,7 +63,7 @@ function setupOverflowState( element ) {
  */
 function wrapTable( table ) {
 	// Load ignored classes from config
-	const ignoredClasses = mw.config.get('wgCitizenTableNowrapClasses');
+	const ignoredClasses = config.wgCitizenTableNowrapClasses;
 
 	// Check table and parent for ignored classes
 	const hasIgnoredClass = ( ignoreClass ) => {

--- a/resources/skins.citizen.scripts/tables.js
+++ b/resources/skins.citizen.scripts/tables.js
@@ -60,16 +60,8 @@ function setupOverflowState( element ) {
  * @return {void}
  */
 function wrapTable( table ) {
-	// TODO: Make this a config flag
-	const ignoredClasses = [
-		'citizen-table-nowrap',
-		'mw-changeslist-line',
-		'infobox',
-		// Extension:Cargo
-		// dataTable from Extension:Cargo and some other has issue with the wrapper
-		'cargoDynamicTable',
-		'dataTable'
-	];
+	// Load ignored classes from config
+	const ignoredClasses = mw.config.get('wgCitizenTableNowrapClasses');
 
 	// Check table and parent for ignored classes
 	const hasIgnoredClass = ( ignoreClass ) => {

--- a/skin.json
+++ b/skin.json
@@ -80,8 +80,7 @@
 		"SkinBuildSidebar": "SkinHooks",
 		"SkinEditSectionLinks": "SkinHooks",
 		"SkinPageReadyConfig": "SkinHooks",
-		"SkinTemplateNavigation::Universal": "SkinHooks",
-		"ResourceLoaderGetConfigVars": "SkinHooks"
+		"SkinTemplateNavigation::Universal": "SkinHooks"
 	},
 	"ResourceModules": {
 		"skins.citizen.styles": {

--- a/skin.json
+++ b/skin.json
@@ -80,7 +80,8 @@
 		"SkinBuildSidebar": "SkinHooks",
 		"SkinEditSectionLinks": "SkinHooks",
 		"SkinPageReadyConfig": "SkinHooks",
-		"SkinTemplateNavigation::Universal": "SkinHooks"
+		"SkinTemplateNavigation::Universal": "SkinHooks",
+		"ResourceLoaderGetConfigVars": "SkinHooks"
 	},
 	"ResourceModules": {
 		"skins.citizen.styles": {
@@ -602,6 +603,18 @@
 			"value": true,
 			"description": "Enables or disable preferences module",
 			"descriptionmsg": "citizen-config-enablepreferences",
+			"public": true
+		},
+		"TableNowrapClasses": {
+			"value": [
+				"citizen-table-nowrap",
+				"mw-changeslist-line",
+				"infobox",
+				"cargoDynamicTable",
+				"dataTable"
+			],
+			"description": "Defines table css classes ignored by citizen table wrapper",
+			"descriptionmsg": "citizen-config-tablenowrapclasses",
 			"public": true
 		}
 	},


### PR DESCRIPTION
- replaces the static css class list in resources/skins.citizen.scripts/tables.js:wrapTable()
- allows to disable wrapping for custom tables classes