### PR TITLE
Disable #pt-talk-alert when Echo is enabled

### DIFF
--- a/skinStyles/extensions/Echo/ext.echo.ui.less
+++ b/skinStyles/extensions/Echo/ext.echo.ui.less
@@ -11,6 +11,10 @@
 @import '../../../resources/variables.less';
 @import '../../../resources/mixins.less';
 
+#pt-talk-alert {
+	display: none;
+}
+
 .mw-echo-ui-notificationBadgeButtonPopupWidget-popup {
 	top: unset !important;
 	bottom: var( --header-size ) !important;


### PR DESCRIPTION
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/b62e3250-6881-4673-8af5-bbf4bc793f67)
Style of #pt-talk-alert is too ugly. #pt-talk-alert is probably better to be disabled since it is somewhat redundant when Echo is enabled.