### PR TITLE
feat: add support for real user name

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Name | Description | Values | Default
 `$wgCitizenThemeColor` | The color defined in the `theme-color` meta tag | Hex color code | `#131a21`
 `$wgCitizenEnableCJKFonts` | Enable included Noto Sans CJK for wikis that serves CJK languages | `true` - enable; `false` - disable | `false`
 `$wgCitizenEnablePreferences` | Enable the preferences menu | `true` - enable; `false` - disable | `true`
+`$wgCitizenDisplayRealUserName` | Displays the user's real name in the user menu | `true` - enable; `false` - disable | `false`
 `$wgCitizenTableNowrapClasses` | Defines table css classes ignored by citizen table wrapper | List of css classes. Extend with `$wgCitizenTableNowrapClasses[] = 'my_class';` | `["citizen-table-nowrap", "mw-changeslist-line", "infobox", "cargoDynamicTable", "dataTable"]`
 
 ### Search suggestions

--- a/includes/Partials/Header.php
+++ b/includes/Partials/Header.php
@@ -82,7 +82,18 @@ final class Header extends Partial {
 	 */
 	private function getUserPageHTML( $isRegistered, $userPageData ): ?string {
 		if ( $isRegistered ) {
-			$html = $userPageData['html-items'];
+			if ( $this->getConfigValue( 'CitizenDisplayRealUserName' ) ) {
+				// Replace any occurrence of the user's name as html text
+				// with its real name. It would be cleaner to adapt the
+				// generation of the html-items directly
+				$html = str_replace(
+					">" . $this->user->getName() . "<",
+					">" . $this->user->getRealName(). "<",
+					$userPageData['html-items']
+				);
+			} else {
+				$html = $userPageData['html-items'];
+			}
 		} else {
 			// There must be a cleaner way to do this
 			$msg = $this->skin->msg( 'notloggedin' )->text();

--- a/skin.json
+++ b/skin.json
@@ -619,6 +619,12 @@
 			"descriptionmsg": "citizen-config-enablepreferences",
 			"public": true
 		},
+		"DisplayRealUserName": {
+                        "value": false,
+                        "description": "Shows the user's real name in the user menu",
+                        "descriptionmsg": "citizen-config-displayrealusername",
+                        "public": true
+		},
 		"TableNowrapClasses": {
 			"value": [
 				"citizen-table-nowrap",


### PR DESCRIPTION
add a config option to display the user's real name in the user menu. Useful in combination with [Extension:Realnames](https://www.mediawiki.org/wiki/Extension:Realnames)

not really happy with the string replace approach - not sure if there's an option to adapt the generation of `$userPageData['html-items']` directly