### PR TITLE
Use member names instead of group names in user menu

### DIFF
--- a/includes/Partials/Header.php
+++ b/includes/Partials/Header.php
@@ -111,7 +111,7 @@ final class Header extends Partial {
 		}
 
 		$html = '';
-		$msgName = 'group-%s';
+		$msgName = 'group-%s-member';
 
 		// There must be a cleaner way
 		foreach ( $groups as $group ) {

--- a/includes/Partials/Header.php
+++ b/includes/Partials/Header.php
@@ -118,9 +118,13 @@ final class Header extends Partial {
 			$id = sprintf( $msgName, $group );
 			$msg = $this->skin->msg( $id )->text();
 			$title = $this->title->newFromText(
-					$this->skin->msg( sprintf( $msgName, $group ) )->text(),
+					$msg,
 					NS_PROJECT
 				);
+			if ( $msg ) {
+				// Member names are in lowercase
+				$msg = ucfirst( $msg );
+			}
 			if ( $title ) {
 				$href = $title->getLinkURL();
 				$html .= <<< HTML


### PR DESCRIPTION
Before:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/9b501ab8-4cb7-4936-a5b2-1f384cdeea9a)
After:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/12c8321f-bf6e-452f-a110-e6c1c92a94b5)
