### PR TITLE
Underline the link on hover and focus

### DIFF
--- a/resources/skins.citizen.styles/skinning/elements.less
+++ b/resources/skins.citizen.styles/skinning/elements.less
@@ -4,8 +4,8 @@
  * Module: mediawiki.skinning.elements
  * Version: REL1_39
  *
- * Date: 2022-11-14
-*/
+ * Date: 2023-06-07
+ */
 
 /* Links */
 // Some of the link styles are handled in content.links
@@ -19,6 +19,7 @@ a {
 
 	&:hover {
 		color: var( --color-link--hover );
+		text-decoration: underline;
 	}
 
 	&:active {

--- a/resources/skins.citizen.styles/skinning/elements.less
+++ b/resources/skins.citizen.styles/skinning/elements.less
@@ -17,9 +17,12 @@ a {
 		cursor: pointer; /* Always cursor:pointer even without href */
 	}
 
+	&:hover, &:focus {
+		text-decoration: underline;
+	}
+
 	&:hover {
 		color: var( --color-link--hover );
-		text-decoration: underline;
 	}
 
 	&:active {


### PR DESCRIPTION
Link text must present a non-color indicator (typically underline) on mouse hover and keyboard focus, see https://webaim.org/articles/contrast/#only
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/02c0c35b-d2ce-4137-8835-be51926ae1e2)
