### PR TITLE
Update ext.score.popup.less

### DIFF
--- a/skinStyles/extensions/Score/ext.score.popup.less
+++ b/skinStyles/extensions/Score/ext.score.popup.less
@@ -9,5 +9,5 @@
  */
 
 .skin-citizen-dark .mw-ext-score img {
-	filter: invert( 1 );
+	filter: hue-rotate( 180deg ) invert( 1 );
 }


### PR DESCRIPTION
add `hue-rotate(180deg)`
```
<score>
\relative {
  \key a \major 
  \omit Score.TimeSignature
  a b
  \override NoteHead #'color = #red
  cis  
}
</score>
```
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/4cd09681-97d7-436b-a8ed-6cb2929ca94b)
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/be9e865d-5d96-4182-a81d-92fbe621a66c)

