### PR TITLE
Fix max-width of OOUI TextInputWidget

### DIFF
--- a/resources/skins.citizen.styles/common/hacks.less
+++ b/resources/skins.citizen.styles/common/hacks.less
@@ -20,3 +20,8 @@ a.feedlink {
 .oo-ui-widget {
 	font-size: 0.875rem;
 }
+
+// Replace 50em (50 * 0.875rem) with 50rem
+.oo-ui-textInputWidget {
+	max-width: 50rem;
+}

--- a/skinStyles/mediawiki/special/mediawiki.special.search.styles.less
+++ b/skinStyles/mediawiki/special/mediawiki.special.search.styles.less
@@ -5,7 +5,7 @@
  * Module: mediawiki.special.search.styles
  * Version: 1.39.0
  *
- * Date: 2022-10-20
+ * Date: 2023-06-20
 */
 
 @import '../../../resources/mixins.less';

--- a/skinStyles/mediawiki/special/mediawiki.special.search.styles.less
+++ b/skinStyles/mediawiki/special/mediawiki.special.search.styles.less
@@ -21,11 +21,6 @@
 	justify-content: space-between;
 	gap: var( --space-xl );
 
-	// Fix weird space between input field and button
-	.oo-ui-actionFieldLayout .oo-ui-textInputWidget {
-		max-width: none;
-	}
-
 	.oo-ui-widget {
 		font-size: 1rem; // HACK: Override the 14px hack we use for OOUI
 	}


### PR DESCRIPTION
On Special:UrlShortener:
Before:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/da3fffa3-7a48-4f41-8eb4-36a409e83abe)
After:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/4dd36591-0a4b-4f61-8b84-6c1eeeb457c1)
