### PR TITLE
fix(Tables): Check if `element.parentNode` is null

### DIFF
--- a/resources/skins.citizen.scripts/tables.js
+++ b/resources/skins.citizen.scripts/tables.js
@@ -38,6 +38,10 @@ function setupOverflowState( element ) {
 			}
 		};
 
+		if ( element.parentNode === null ) {
+			return;
+		}
+
 		updateState();
 
 		// Update state on element scroll

--- a/skin.json
+++ b/skin.json
@@ -627,6 +627,7 @@
 			"value": [
 				"citizen-table-nowrap",
 				"mw-changeslist-line",
+				"mw-recentchanges-table",
 				"infobox",
 				"cargoDynamicTable",
 				"dataTable"


### PR DESCRIPTION
Happened on the recent changes table. While the added line in TableNowrapClasses also fixes this, I've left it in as a safeguard.