### PR TITLE
Don't "merge" edit buttons when JS is disabled

### DIFF
--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -204,7 +204,7 @@
 }
 
 // Merge two buttons together
-.citizen-ve-edit-merged {
+.client-js .citizen-ve-edit-merged {
 	&#ca-ve-edit {
 		> a {
 			border-bottom-right-radius: 0;


### PR DESCRIPTION
#ca-ve-edit is hidden when JS is disabled.
Before:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/9a59ec80-1ccb-4bd4-b109-530e08c29221)
After:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/884f6828-ed8a-4af5-8d91-e20c1c74fd57)
