### PR TITLE
Style for bad images

### DIFF
--- a/resources/skins.citizen.styles/skinning/content.media-screen.less
+++ b/resources/skins.citizen.styles/skinning/content.media-screen.less
@@ -4,8 +4,8 @@
  * Module: mediawiki.skinning.content.media-screen
  * Version: REL1_39
  *
- * Date: 2022-11-18
-*/
+ * Date: 2023-07-23
+ */
 figure[ typeof~='mw:File' ],
 figure[ typeof~='mw:File/Frameless' ],
 figure[ typeof~='mw:File/Thumb' ],

--- a/resources/skins.citizen.styles/skinning/content.media-screen.less
+++ b/resources/skins.citizen.styles/skinning/content.media-screen.less
@@ -42,20 +42,32 @@ figure[ typeof~='mw:File/Frame' ] {
 	> span:first-child {
 		display: block;
 		border-radius: var( --border-radius--small );
+	}
 
-		// Broken file styles
+	// Broken file styles
+	> a:first-child:not( .mw-file-description ) {
+		padding: var( --space-sm );
+		border: 1px solid var( --border-color-base--darker );
+
+		&:hover {
+			background-color: var( --color-primary--hover );
+			color: #fff;
+		}
+
+		&:active {
+			background-color: var( --color-primary--active );
+			color: #fff;
+		}
+
 		&.new {
-			padding: var( --space-sm );
-			border: 1px dashed var( --border-color-base--darker );
+			border-style: dashed;
 
 			&:hover {
 				background-color: var( --color-destructive--hover );
-				color: #fff;
 			}
 
 			&:active {
 				background-color: var( --color-destructive--active );
-				color: #fff;
 			}
 		}
 	}

--- a/resources/skins.citizen.styles/skinning/content.thumbnails-screen.less
+++ b/resources/skins.citizen.styles/skinning/content.thumbnails-screen.less
@@ -29,18 +29,30 @@
 		}
 
 		// Broken file styles
-		&.new {
+		&:not( .image ) {
 			padding: var( --space-sm );
-			border: 1px dashed var( --border-color-base--darker );
+			border: 1px solid var( --border-color-base--darker );
 
 			&:hover {
-				background-color: var( --color-destructive--hover );
+				background-color: var( --color-primary--hover );
 				color: #fff;
 			}
 
 			&:active {
-				background-color: var( --color-destructive--active );
+				background-color: var( --color-primary--active );
 				color: #fff;
+			}
+
+			&.new {
+				border-style: dashed;
+
+				&:hover {
+					background-color: var( --color-destructive--hover );
+				}
+
+				&:active {
+					background-color: var( --color-destructive--active );
+				}
 			}
 		}
 	}

--- a/resources/skins.citizen.styles/skinning/content.thumbnails-screen.less
+++ b/resources/skins.citizen.styles/skinning/content.thumbnails-screen.less
@@ -4,8 +4,8 @@
  * Module: mediawiki.skinning.content.thumbnails-screen
  * Version: REL1_39
  *
- * Date: 2022-11-18
-*/
+ * Date: 2023-07-23
+ */
 
 .thumbinner {
 	> a {


### PR DESCRIPTION
Files in MediaWiki:Bad_image_list just show links to description pages
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/be9d7200-68e4-42b0-a104-f059ca15dc73)
