### PR TITLE
Dealing with long filenames of broken files

### DIFF
--- a/resources/skins.citizen.styles/skinning/content.media-common.less
+++ b/resources/skins.citizen.styles/skinning/content.media-common.less
@@ -4,8 +4,8 @@
  * Module: mediawiki.skinning.content.media-common
  * Version: REL1_39
  *
- * Date: 2022-11-18
-*/
+ * Date: 2023-07-23
+ */
 
 /**
  * Block media items
@@ -47,6 +47,7 @@ figure[ typeof~='mw:File/Frame' ] {
 		 */
 		> span.mw-broken-media {
 			display: inline-block;
+			overflow-wrap: break-word;
 			/* This is hardcoded in Linker::makeThumbLink2 for broken media */
 			width: 180px;
 		}
@@ -69,7 +70,9 @@ figure[ typeof~='mw:File/Frame' ] {
 @media ( min-width: @width-breakpoint-tablet ) {
 	figure[ typeof~='mw:File/Thumb' ],
 	figure[ typeof~='mw:File/Frame' ] {
-		text-align: start;
+		> figcaption {
+			text-align: start;
+		}
 
 		// When float is not explicitly set
 		.mw-content-ltr & {

--- a/resources/skins.citizen.styles/skinning/content.thumbnails-common.less
+++ b/resources/skins.citizen.styles/skinning/content.thumbnails-common.less
@@ -4,8 +4,8 @@
  * Module: mediawiki.skinning.content.thumbnails-common
  * Version: REL1_39
  *
- * Date: 2022-11-18
-*/
+ * Date: 2023-07-23
+ */
 
 /* @noflip */
 div.floatleft,
@@ -44,6 +44,10 @@ div.thumbinner {
 	// We use the same font size for both caption and inner
 	font-size: 0.8125rem;
 	text-align: center;
+
+	> a {
+		overflow-wrap: break-word;
+	}
 }
 
 // Do not float content in mobile view


### PR DESCRIPTION
Before:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/26bbef09-bb16-46bf-8d01-48c7cc183ccb)
After:
![image](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/assets/57343841/ce66b9d1-7249-4dfa-b0ad-65f0a25506dd)
