### PR TITLE
feat: PHPUnit Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, develop, feature/* ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  test:
+    name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_39'
+            php: 8.1
+            experimental: false
+          - mw: 'REL1_40'
+            php: 8.1
+            experimental: true
+          - mw: 'master'
+            php: 8.1
+            experimental: true
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: mediawiki
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, intl
+          tools: composer
+
+      - name: Cache MediaWiki
+        id: cache-mediawiki
+        uses: actions/cache@v3
+        with:
+          path: |
+            mediawiki
+            !mediawiki/extensions/
+            !mediawiki/vendor/
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v20
+
+      - name: Cache Composer cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache
+          key: composer-php${{ matrix.php }}
+
+      - uses: actions/checkout@v3
+        with:
+          path: EarlyCopy
+
+      - name: Install MediaWiki
+        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
+        working-directory: ~
+        run: bash EarlyCopy/.github/workflows/installWiki.sh ${{ matrix.mw }}
+
+      - uses: actions/checkout@v3
+        with:
+          path: mediawiki/skins/Citizen
+
+      - name: Composer update
+        run: composer update
+
+      - name: Run PHPUnit
+        run: composer phpunit:entrypoint -- --group Citizen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master, develop, feature/* ]
+    branches: [ main, develop, feature/* ]
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+MW_BRANCH=$1
+EXTENSION_NAME=$2
+
+wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
+
+tar -zxf $MW_BRANCH.tar.gz
+mv mediawiki-$MW_BRANCH mediawiki
+
+cd mediawiki
+
+composer install
+php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser
+
+# echo 'error_reporting(E_ALL| E_STRICT);' >> LocalSettings.php
+# echo 'ini_set("display_errors", 1);' >> LocalSettings.php
+echo '$wgShowExceptionDetails = true;' >> LocalSettings.php
+echo '$wgShowDBErrorBacktrace = true;' >> LocalSettings.php
+echo '$wgDevelopmentWarnings = true;' >> LocalSettings.php
+
+echo 'wfLoadSkin( "Citizen" );' >> LocalSettings.php
+
+cat <<EOT >> composer.local.json
+{
+  "require": {
+
+  },
+	"extra": {
+		"merge-plugin": {
+			"merge-dev": true,
+			"include": []
+		}
+	}
+}
+EOT

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
 	},
 	"scripts": {
 		"fix": [
-			"minus-x fix ."
+			"minus-x fix .",
+			"phpcbf"
 		],
 		"test": [
 			"parallel-lint . --exclude node_modules --exclude vendor",

--- a/includes/Partials/BodyContent.php
+++ b/includes/Partials/BodyContent.php
@@ -31,6 +31,7 @@ use DOMNode;
 use DOMXpath;
 use HtmlFormatter\HtmlFormatter;
 use MediaWiki\MediaWikiServices;
+use Title;
 use Wikimedia\Parsoid\Utils\DOMCompat;
 use Wikimedia\Services\NoSuchServiceException;
 
@@ -56,8 +57,8 @@ final class BodyContent extends Partial {
 	 * Helper function to decide if the page should be formatted
 	 *
 	 * @param Title $title
-	 * @return string
-	 */
+	 * @return bool
+     */
 	private function shouldFormatPage( $title ) {
 		try {
 			$mfCxt = MediaWikiServices::getInstance()->getService( 'MobileFrontend.Context' );

--- a/includes/Partials/BodyContent.php
+++ b/includes/Partials/BodyContent.php
@@ -58,7 +58,7 @@ final class BodyContent extends Partial {
 	 *
 	 * @param Title $title
 	 * @return bool
-     */
+	 */
 	private function shouldFormatPage( $title ) {
 		try {
 			$mfCxt = MediaWikiServices::getInstance()->getService( 'MobileFrontend.Context' );

--- a/includes/Partials/Drawer.php
+++ b/includes/Partials/Drawer.php
@@ -26,6 +26,8 @@ declare( strict_types=1 );
 namespace MediaWiki\Skins\Citizen\Partials;
 
 use Exception;
+use IntlException;
+use MediaWiki\MediaWikiServices;
 use NumberFormatter;
 
 /**
@@ -41,7 +43,6 @@ final class Drawer extends Partial {
 	 * Decorate sidebar template data
 	 *
 	 * @return array
-	 * @throws Exception
 	 */
 	public function decorateSidebarData( $sidebarData ) {
 		for ( $i = 0; $i < count( $sidebarData['array-portlets-rest'] ); $i++ ) {

--- a/includes/Partials/Drawer.php
+++ b/includes/Partials/Drawer.php
@@ -25,9 +25,7 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Partials;
 
-use Exception;
 use IntlException;
-use MediaWiki\MediaWikiServices;
 use NumberFormatter;
 
 /**

--- a/includes/Partials/Header.php
+++ b/includes/Partials/Header.php
@@ -54,7 +54,7 @@ final class Header extends Partial {
 	 *
 	 * TODO: Consider dropping Menu.mustache since the DOM doesn't make much sense
 	 *
-	 * @param $userPageData data-portlets.data-user-page
+	 * @param array $userPageData data-portlets.data-user-page
 	 * @return array
 	 */
 	public function getUserInfoData( $userPageData ): array {

--- a/includes/Partials/Header.php
+++ b/includes/Partials/Header.php
@@ -27,7 +27,6 @@ namespace MediaWiki\Skins\Citizen\Partials;
 
 use MediaWiki\MediaWikiServices;
 use Skin;
-use User;
 
 /**
  * Header partial of Skin Citizen

--- a/includes/Partials/PageTools.php
+++ b/includes/Partials/PageTools.php
@@ -153,7 +153,7 @@ final class PageTools extends Partial {
 	}
 
 	/**
-	 * Count languages avaliable
+	 * Count languages available
 	 * TODO: Consider having an option to count for variants?
 	 *
 	 * @return int

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -47,6 +47,10 @@ class SkinCitizen extends SkinMustache {
 	 * @inheritDoc
 	 */
 	public function __construct( $options = [] ) {
+        if (!isset($options['name'])) {
+            $options['name'] = 'Citizen';
+        }
+
 		// Add skin-specific features
 		$this->buildSkinFeatures( $options );
 		parent::__construct( $options );
@@ -57,7 +61,6 @@ class SkinCitizen extends SkinMustache {
 	 */
 	public function getTemplateData(): array {
 		$data = [];
-		$title = $this->getOutput()->getTitle();
 		$parentData = parent::getTemplateData();
 
 		$header = new Header( $this );

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -48,7 +48,7 @@ class SkinCitizen extends SkinMustache {
 	 */
 	public function __construct( $options = [] ) {
 		if ( !isset( $options['name'] ) ) {
-			$options['name'] = 'Citizen';
+			$options['name'] = 'citizen';
 		}
 
 		// Add skin-specific features

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -47,9 +47,9 @@ class SkinCitizen extends SkinMustache {
 	 * @inheritDoc
 	 */
 	public function __construct( $options = [] ) {
-        if (!isset($options['name'])) {
-            $options['name'] = 'Citizen';
-        }
+		if ( !isset( $options['name'] ) ) {
+			$options['name'] = 'Citizen';
+		}
 
 		// Add skin-specific features
 		$this->buildSkinFeatures( $options );

--- a/tests/phpunit/Hooks/ResourceLoaderHooksTest.php
+++ b/tests/phpunit/Hooks/ResourceLoaderHooksTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Hooks;
+
+use MediaWiki\ResourceLoader\Context;
+use MediaWiki\Skins\Citizen\Hooks\ResourceLoaderHooks;
+
+/**
+ * @group Citizen
+ */
+class ResourceLoaderHooksTest extends \MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\ResourceLoaderHooks
+	 * @return void
+	 */
+	public function testCitizenResourceLoaderConfig() {
+		$this->overrideConfigValues( [
+			'CitizenEnablePreferences' => false,
+			'CitizenSearchModule' => false,
+			'CitizenTableNowrapClasses' => false,
+		] );
+
+		$rlCtxMock = $this->getMockBuilder( Context::class )->disableOriginalConstructor()->getMock();
+
+		$config = ResourceLoaderHooks::getCitizenResourceLoaderConfig(
+			$rlCtxMock,
+			$this->getServiceContainer()->getMainConfig()
+		);
+
+		$this->assertArraySubmapSame( [
+			'wgCitizenEnablePreferences' => false,
+			'wgCitizenSearchModule' => false,
+			'wgCitizenTableNowrapClasses' => false,
+		], $config );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\ResourceLoaderHooks
+	 * @return void
+	 */
+	public function testCitizenResourceLoaderConfigAllTrue() {
+		$this->overrideConfigValues( [
+			'CitizenEnablePreferences' => true,
+			'CitizenSearchModule' => true,
+			'CitizenTableNowrapClasses' => true,
+		] );
+
+		$rlCtxMock = $this->getMockBuilder( Context::class )->disableOriginalConstructor()->getMock();
+
+		$config = ResourceLoaderHooks::getCitizenResourceLoaderConfig(
+			$rlCtxMock,
+			$this->getServiceContainer()->getMainConfig()
+		);
+
+		$this->assertArraySubmapSame( [
+			'wgCitizenEnablePreferences' => true,
+			'wgCitizenSearchModule' => true,
+			'wgCitizenTableNowrapClasses' => true,
+		], $config );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\ResourceLoaderHooks
+	 * @return void
+	 */
+	public function testCitizenPreferencesResourceLoaderConfig() {
+		$this->overrideConfigValues( [
+			'CitizenThemeDefault' => 'dark',
+		] );
+
+		$rlCtxMock = $this->getMockBuilder( Context::class )->disableOriginalConstructor()->getMock();
+
+		$config = ResourceLoaderHooks::getCitizenPreferencesResourceLoaderConfig(
+			$rlCtxMock,
+			$this->getServiceContainer()->getMainConfig()
+		);
+
+		$this->assertArraySubmapSame( [
+			'wgCitizenThemeDefault' => 'dark',
+		], $config );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\ResourceLoaderHooks
+	 * @return void
+	 */
+	public function testCitizenSearchResourceLoaderConfig() {
+		$this->overrideConfigValues( [
+			'CitizenSearchGateway' => 'CitizenSearchGateway',
+			'CitizenSearchDescriptionSource' => 'CitizenSearchDescriptionSource',
+			'CitizenMaxSearchResults' => 'CitizenMaxSearchResults',
+			'Script' => 'Script',
+			'ScriptPath' => 'ScriptPath',
+			'SearchSuggestCacheExpiry' => 'SearchSuggestCacheExpiry',
+		] );
+
+		$rlCtxMock = $this->getMockBuilder( Context::class )->disableOriginalConstructor()->getMock();
+
+		$config = ResourceLoaderHooks::getCitizenSearchResourceLoaderConfig(
+			$rlCtxMock,
+			$this->getServiceContainer()->getMainConfig()
+		);
+
+		$this->assertArraySubmapSame( [
+			'wgCitizenSearchGateway' => 'CitizenSearchGateway',
+			'wgCitizenSearchDescriptionSource' => 'CitizenSearchDescriptionSource',
+			'wgCitizenMaxSearchResults' => 'CitizenMaxSearchResults',
+			'wgScript' => 'Script',
+			'wgScriptPath' => 'ScriptPath',
+			'isMediaSearchExtensionEnabled' => false,
+		], $config );
+	}
+}

--- a/tests/phpunit/Hooks/SkinHooksTest.php
+++ b/tests/phpunit/Hooks/SkinHooksTest.php
@@ -1,0 +1,485 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Hooks;
+
+use MediaWiki\Request\ContentSecurityPolicy;
+use MediaWiki\Skins\Citizen\Hooks\SkinHooks;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWiki\Title\Title;
+use OutputPage;
+use RequestContext;
+use ResourceLoaderContext;
+use SkinTemplate;
+
+/**
+ * @group Citizen
+ */
+class SkinHooksTest extends \MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testOnBeforePageDisplayNameMissmatch() {
+		$outMock = $this->getMockBuilder( OutputPage::class )->disableOriginalConstructor()->getMock();
+		$outMock->expects( $this->never() )->method( 'getCSP' );
+		$hooks = new SkinHooks();
+
+		$hooks->onBeforePageDisplay( $outMock, new SkinCitizen( [ 'name' => 'foo' ] ) );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testOnBeforePageDisplay() {
+		if ( version_compare( '1.39', MW_VERSION, '<=' ) ) {
+			$this->markTestSkipped( 'Failing on 1.39?' );
+		}
+
+		$cspMock = $this->getMockBuilder( ContentSecurityPolicy::class )->disableOriginalConstructor()->getMock();
+		$cspMock->expects( $this->once() )->method( 'getNonce' )->willReturn( 'faux-nonce' );
+
+		$outMock = $this->getMockBuilder( OutputPage::class )
+			->setConstructorArgs( [ RequestContext::getMain() ] )
+			->onlyMethods( [ 'getCSP' ] )
+			->getMock();
+		$outMock->expects( $this->once() )->method( 'getCSP' )->willReturn( $cspMock );
+
+		$hooks = new SkinHooks();
+
+		$hooks->onBeforePageDisplay( $outMock, new SkinCitizen() );
+
+		$this->assertArrayHasKey( 'skin.citizen.inline', $outMock->getHeadItemsArray() );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSidebarBeforeOutputNameMissmatch() {
+		$sidebar = [];
+		$hooks = new SkinHooks();
+
+		$hooks->onSidebarBeforeOutput( new SkinCitizen( [ 'name' => 'foo' ] ), $sidebar );
+
+		$this->assertEmpty( $sidebar );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSidebarBeforeOutput() {
+		$sidebar = [
+			'TOOLBOX' => [
+				'whatlinkshere' => [],
+				'recentchangeslinked' => [],
+				'print' => [],
+			]
+		];
+		$hooks = new SkinHooks();
+
+		$hooks->onSidebarBeforeOutput( new SkinCitizen(), $sidebar );
+
+		$this->assertArrayHasKey( 'TOOLBOX', $sidebar );
+		$this->assertArrayHasKey( 'whatlinkshere', $sidebar['TOOLBOX'] );
+		$this->assertArrayHasKey( 'icon', $sidebar['TOOLBOX']['whatlinkshere'] );
+		$this->assertEquals( 'articleRedirect', $sidebar['TOOLBOX']['whatlinkshere']['icon'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinBuildSidebarNameMissmatch() {
+		$hooks = new SkinHooks();
+		$bar = [];
+		$hooks->onSkinBuildSidebar( new SkinCitizen( [ 'name' => 'foo' ] ), $bar );
+
+		$this->assertEmpty( $bar );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinBuildSidebarDisabledUploads() {
+		$this->overrideConfigValues( [
+			'EnableUploads' => false,
+		] );
+
+		$hooks = new SkinHooks();
+		$bar = [
+			'foo' => [],
+		];
+		$hooks->onSkinBuildSidebar( new SkinCitizen(), $bar );
+
+		$this->assertArrayHasKey( 'navigation', $bar );
+		$this->assertArrayHasKey( 'specialpages', $bar['navigation'] );
+		$this->assertIsArray( $bar['navigation']['specialpages'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinBuildSidebarEnabledUploads() {
+		$this->overrideConfigValues( [
+			'EnableUploads' => true,
+		] );
+
+		$hooks = new SkinHooks();
+		$bar = [
+			'foo' => [],
+		];
+		$hooks->onSkinBuildSidebar( new SkinCitizen(), $bar );
+
+		$this->assertArrayHasKey( 'navigation', $bar );
+		$this->assertArrayHasKey( 'upload', $bar['navigation'] );
+		$this->assertIsArray( $bar['navigation']['upload'] );
+		$this->assertEquals( 'upload', $bar['navigation']['upload']['icon'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinEditSectionLinksNameMissmatch() {
+		$res = [];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinEditSectionLinks(
+			new SkinCitizen( [ 'name' => 'foo' ] ),
+			Title::makeTitle( NS_MAIN, 'Foo' ),
+			'',
+			'',
+			$res,
+			$this->getServiceContainer()->getContentLanguage()
+		);
+
+		$this->assertEmpty( $res );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinEditSectionLinksVEEditSection() {
+		$res = [
+			'editsection' => [
+				'attribs' => [
+					'class' => 'foo',
+				],
+			],
+			'veeditsection' => [
+				'attribs' => [
+					'class' => 've-foo',
+				],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinEditSectionLinks(
+			new SkinCitizen(),
+			Title::makeTitle( NS_MAIN, 'Foo' ),
+			'',
+			'',
+			$res,
+			$this->getServiceContainer()->getContentLanguage()
+		);
+
+		$this->assertStringContainsString(
+			'citizen-editsection-icon',
+			$res['veeditsection']['attribs']['class']
+		);
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinEditSectionLinksEditSection() {
+		$res = [
+			'editsection' => [
+				'attribs' => [
+					'class' => 'foo',
+				],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinEditSectionLinks(
+			new SkinCitizen(),
+			Title::makeTitle( NS_MAIN, 'Foo' ),
+			'',
+			'',
+			$res,
+			$this->getServiceContainer()->getContentLanguage()
+		);
+
+		$this->assertStringContainsString(
+			'citizen-editsection-icon',
+			$res['editsection']['attribs']['class']
+		);
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinPageReadyConfigNameMissmatch() {
+		$ctx = $this->getMockBuilder( ResourceLoaderContext::class )->disableOriginalConstructor()->getMock();
+		$ctx->expects( $this->once() )->method( 'getSkin' )->willReturn( 'foo' );
+		$res = [];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinPageReadyConfig(
+			$ctx,
+			$res
+		);
+
+		$this->assertEmpty( $res );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinPageReadyConfig() {
+		$ctx = $this->getMockBuilder( ResourceLoaderContext::class )->disableOriginalConstructor()->getMock();
+		$ctx->expects( $this->once() )->method( 'getSkin' )->willReturn( 'citizen' );
+		$res = [];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinPageReadyConfig(
+			$ctx,
+			$res
+		);
+
+		$this->assertArrayHasKey( 'search', $res );
+		$this->assertFalse( $res['search'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalNameMissmatch() {
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'foo' );
+
+		$links = [];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertEmpty( $links );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalActions() {
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+
+		$links = [
+			'actions' => [
+				'delete' => [],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArraySubmapSame( [
+			'actions' => [
+				'delete' => [
+					'icon' => 'trash',
+					'link-html' => '<span class="citizen-ui-icon mw-ui-icon-trash mw-ui-icon-wikimedia-trash"></span>'
+				]
+			]
+		], $links );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalAssociatedPagesMenu() {
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+
+		$links = [
+			'associated-pages' => [
+				'main' => [],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArraySubmapSame( [
+			'associated-pages' => [
+				'main' => [
+					'icon' => 'article',
+					'link-html' => '<span class="citizen-ui-icon mw-ui-icon-article mw-ui-icon-wikimedia-article"></span>'
+				]
+			]
+		], $links );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalUserMenuTemp() {
+		$mockUser = $this->getMockBuilder( \User::class )->disableOriginalConstructor()->getMock();
+		$mockUser->expects( $this->once() )->method( 'isTemp' )->willReturn( true );
+
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+		$template->expects( $this->once() )->method( 'getUser' )->willReturn( $mockUser );
+
+		$links = [
+			'user-menu' => [
+				'tmpuserpage' => [],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArrayNotHasKey( 'tmpuserpage', $links['user-menu'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalUserMenuAnon() {
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+		$template->expects( $this->once() )->method( 'getUser' )->willReturn(
+			$this->getServiceContainer()->getUserFactory()->newAnonymous()
+		);
+
+		$links = [
+			'user-menu' => [
+				'anonuserpage' => [],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArrayNotHasKey( 'anonuserpage', $links['user-menu'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalUserMenuRegistered() {
+		$mockUser = $this->getMockBuilder( \User::class )->disableOriginalConstructor()->getMock();
+		$mockUser->expects( $this->once() )->method( 'isRegistered' )->willReturn( true );
+
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+		$template->expects( $this->once() )->method( 'getUser' )->willReturn( $mockUser );
+
+		$links = [
+			'user-menu' => [
+				'userpage' => [],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArrayNotHasKey( 'userpage', $links['user-menu'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalUserInterfacePreferencesMenu() {
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+
+		$links = [
+			'user-interface-preferences' => [],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArrayHasKey( 'user-interface-preferences', $links );
+		$this->assertEmpty( $links['user-interface-preferences'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalViews() {
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+
+		$links = [
+			'views' => [
+				'view' => [],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArraySubmapSame( [
+			'views' => [
+				'view' => [
+					'icon' => 'article',
+					'link-html' => '<span class="citizen-ui-icon mw-ui-icon-article mw-ui-icon-wikimedia-article"></span>'
+				]
+			]
+		], $links );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Hooks\SkinHooks
+	 * @return void
+	 */
+	public function testSkinTemplateNavigation__UniversalViewsVEEdit() {
+		$template = $this->getMockBuilder( SkinTemplate::class )->disableOriginalConstructor()->getMock();
+		$template->expects( $this->once() )->method( 'getSkinName' )->willReturn( 'citizen' );
+
+		$links = [
+			'views' => [
+				've-edit' => [
+					'class' => ''
+				],
+				'edit' => [
+					'class' => ''
+				],
+			],
+		];
+
+		$hooks = new SkinHooks();
+		$hooks->onSkinTemplateNavigation__Universal( $template, $links );
+
+		$this->assertArraySubmapSame( [
+			'views' => [
+				've-edit' => [
+					'class' => 'citizen-ve-edit-merged',
+				],
+				'edit' => [
+					'class' => 'citizen-ve-edit-merged',
+				],
+			],
+		], $links );
+	}
+}

--- a/tests/phpunit/Partials/BodyContentTest.php
+++ b/tests/phpunit/Partials/BodyContentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Tests\Partials;
 
@@ -9,78 +9,76 @@ use MediaWiki\Skins\Citizen\SkinCitizen;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use MWException;
-use OutputPage;
 use RequestContext;
 use Wikimedia\AtEase\AtEase;
 
 /**
  * @group Citizen
  */
-class BodyContentTest extends MediaWikiIntegrationTestCase
-{
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
-     * @return void
-     * @throws MWException
-     */
-    public function testDecorateBodyContentTitleNull() {
-        RequestContext::resetMain();
-        RequestContext::getMain()->setTitle(null);
+class BodyContentTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testDecorateBodyContentTitleNull() {
+		RequestContext::resetMain();
+		RequestContext::getMain()->setTitle( null );
 
-        $partial = new BodyContent(new SkinCitizen([
-            'name' => 'SkinCitizen'
-        ]));
+		$partial = new BodyContent( new SkinCitizen( [
+			'name' => 'SkinCitizen'
+		] ) );
 
-        $this->assertEquals('<Foo>', $partial->decorateBodyContent('<Foo>'));
-    }
+		$this->assertEquals( '<Foo>', $partial->decorateBodyContent( '<Foo>' ) );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
-     * @return void
-     * @throws MWException
-     */
-    public function testDecorateBodyContentCollapseNotEnabled() {
-        $this->overrideConfigValues([
-            'CitizenEnableCollapsibleSections' => false,
-        ]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testDecorateBodyContentCollapseNotEnabled() {
+		$this->overrideConfigValues( [
+			'CitizenEnableCollapsibleSections' => false,
+		] );
 
-        RequestContext::resetMain();
-        RequestContext::getMain()->setTitle(null);
+		RequestContext::resetMain();
+		RequestContext::getMain()->setTitle( null );
 
-        $partial = new BodyContent(new SkinCitizen([
-            'name' => 'SkinCitizen'
-        ]));
+		$partial = new BodyContent( new SkinCitizen( [
+			'name' => 'SkinCitizen'
+		] ) );
 
-        $this->assertEquals('<Foo>', $partial->decorateBodyContent('<Foo>'));
-    }
+		$this->assertEquals( '<Foo>', $partial->decorateBodyContent( '<Foo>' ) );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
-     * @return void
-     * @throws MWException
-     */
-    public function testDecorateBodyContentCollapseEnabledContentPage() {
-        $this->overrideConfigValues([
-            'CitizenEnableCollapsibleSections' => true,
-        ]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testDecorateBodyContentCollapseEnabledContentPage() {
+		$this->overrideConfigValues( [
+			'CitizenEnableCollapsibleSections' => true,
+		] );
 
-        $title = Title::newFromText('BodyContent');
+		$title = Title::newFromText( 'BodyContent' );
 
-        RequestContext::resetMain();
-        RequestContext::getMain()->setTitle($title);
+		RequestContext::resetMain();
+		RequestContext::getMain()->setTitle( $title );
 
-        $partial = new BodyContent(new SkinCitizen([
-            'name' => 'SkinCitizen'
-        ]));
+		$partial = new BodyContent( new SkinCitizen( [
+			'name' => 'SkinCitizen'
+		] ) );
 
-        $html = <<<HTML
+		$html = <<<HTML
 <div class="mw-parser-output">
 <div class="mw-heading"><h2><span class="mw-headline" id="Sidebar" data-mw-thread-id="h-Sidebar"><span data-mw-comment-start="" id="h-Sidebar"></span>Sidebar<span data-mw-comment-end="h-Sidebar"></span></span></h2><!--__DTELLIPSISBUTTON__--></div>
 </div>
 HTML;
 
-        AtEase::suppressWarnings();
-        $this->assertStringContainsString('section-indicator', $partial->decorateBodyContent($html));
-        AtEase::restoreWarnings();
-    }
+		AtEase::suppressWarnings();
+		$this->assertStringContainsString( 'section-indicator', $partial->decorateBodyContent( $html ) );
+		AtEase::restoreWarnings();
+	}
 }

--- a/tests/phpunit/Partials/BodyContentTest.php
+++ b/tests/phpunit/Partials/BodyContentTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Skins\Citizen\Tests\Partials;
+
+use MediaWiki\Skins\Citizen\Partials\BodyContent;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use MWException;
+use OutputPage;
+use RequestContext;
+use Wikimedia\AtEase\AtEase;
+
+/**
+ * @group Citizen
+ */
+class BodyContentTest extends MediaWikiIntegrationTestCase
+{
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
+     * @return void
+     * @throws MWException
+     */
+    public function testDecorateBodyContentTitleNull() {
+        RequestContext::resetMain();
+        RequestContext::getMain()->setTitle(null);
+
+        $partial = new BodyContent(new SkinCitizen([
+            'name' => 'SkinCitizen'
+        ]));
+
+        $this->assertEquals('<Foo>', $partial->decorateBodyContent('<Foo>'));
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
+     * @return void
+     * @throws MWException
+     */
+    public function testDecorateBodyContentCollapseNotEnabled() {
+        $this->overrideConfigValues([
+            'CitizenEnableCollapsibleSections' => false,
+        ]);
+
+        RequestContext::resetMain();
+        RequestContext::getMain()->setTitle(null);
+
+        $partial = new BodyContent(new SkinCitizen([
+            'name' => 'SkinCitizen'
+        ]));
+
+        $this->assertEquals('<Foo>', $partial->decorateBodyContent('<Foo>'));
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\BodyContent
+     * @return void
+     * @throws MWException
+     */
+    public function testDecorateBodyContentCollapseEnabledContentPage() {
+        $this->overrideConfigValues([
+            'CitizenEnableCollapsibleSections' => true,
+        ]);
+
+        $title = Title::newFromText('BodyContent');
+
+        RequestContext::resetMain();
+        RequestContext::getMain()->setTitle($title);
+
+        $partial = new BodyContent(new SkinCitizen([
+            'name' => 'SkinCitizen'
+        ]));
+
+        $html = <<<HTML
+<div class="mw-parser-output">
+<div class="mw-heading"><h2><span class="mw-headline" id="Sidebar" data-mw-thread-id="h-Sidebar"><span data-mw-comment-start="" id="h-Sidebar"></span>Sidebar<span data-mw-comment-end="h-Sidebar"></span></span></h2><!--__DTELLIPSISBUTTON__--></div>
+</div>
+HTML;
+
+        AtEase::suppressWarnings();
+        $this->assertStringContainsString('section-indicator', $partial->decorateBodyContent($html));
+        AtEase::restoreWarnings();
+    }
+}

--- a/tests/phpunit/Partials/DrawerTest.php
+++ b/tests/phpunit/Partials/DrawerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Skins\Citizen\Tests\Partials;
+
+use MediaWiki\Skins\Citizen\Partials\Drawer;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+
+/**
+ * @group Citizen
+ */
+class DrawerTest extends \MediaWikiIntegrationTestCase
+{
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::decorateSidebarData
+     * @return void
+     */
+    public function testDecorateSidebarDataEmpty() {
+        $partial = new Drawer(new SkinCitizen());
+
+        $this->assertEmpty($partial->decorateSidebarData([
+            'array-portlets-rest' => [],
+        ])['array-portlets-rest']);
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::decorateSidebarData
+     * @return void
+     */
+    public function testDecorateSidebarRemovePageTools() {
+        $partial = new Drawer(new SkinCitizen());
+
+        $sidebarData = [
+            'array-portlets-rest' => [
+                [ 'id' => 'foo' ],
+                ['id' => 'p-tb'],
+            ],
+        ];
+
+        $this->assertNotEmpty($partial->decorateSidebarData($sidebarData));
+        $this->assertArrayHasKey('array-portlets-rest', $partial->decorateSidebarData($sidebarData));
+        $this->assertNotContains(['id' => 'pt-tb'], $partial->decorateSidebarData($sidebarData)['array-portlets-rest']);
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatsData
+     * @return void
+     */
+    public function testGetSiteStatsDataDisabled() {
+        $this->overrideConfigValues([
+            'CitizenEnableDrawerSiteStats' => false,
+        ]);
+
+        $partial = new Drawer(new SkinCitizen());
+        $this->assertEmpty($partial->getSiteStatsData());
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatsData
+     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatValue
+     * @return void
+     */
+    public function testGetSiteStatsDataNoFormat() {
+        $this->overrideConfigValues([
+            'CitizenEnableDrawerSiteStats' => true,
+            'CitizenUseNumberFormatter' => false,
+        ]);
+
+        $partial = new Drawer(new SkinCitizen());
+        $data = $partial->getSiteStatsData();
+
+        $this->assertArrayHasKey('array-drawer-sitestats-item', $data);
+        $this->assertCount(4, $data['array-drawer-sitestats-item']);
+
+        foreach ($data['array-drawer-sitestats-item'] as $stat) {
+            $this->assertArrayHasKey('id', $stat);
+            $this->assertArrayHasKey('icon', $stat);
+            $this->assertArrayHasKey('value', $stat);
+            $this->assertArrayHasKey('label', $stat);
+
+            $this->assertTrue(in_array($stat['id'], ['articles', 'images', 'users', 'edits'], true));
+        }
+    }
+}

--- a/tests/phpunit/Partials/DrawerTest.php
+++ b/tests/phpunit/Partials/DrawerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Tests\Partials;
 
@@ -10,76 +10,75 @@ use MediaWiki\Skins\Citizen\SkinCitizen;
 /**
  * @group Citizen
  */
-class DrawerTest extends \MediaWikiIntegrationTestCase
-{
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::decorateSidebarData
-     * @return void
-     */
-    public function testDecorateSidebarDataEmpty() {
-        $partial = new Drawer(new SkinCitizen());
+class DrawerTest extends \MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::decorateSidebarData
+	 * @return void
+	 */
+	public function testDecorateSidebarDataEmpty() {
+		$partial = new Drawer( new SkinCitizen() );
 
-        $this->assertEmpty($partial->decorateSidebarData([
-            'array-portlets-rest' => [],
-        ])['array-portlets-rest']);
-    }
+		$this->assertEmpty( $partial->decorateSidebarData( [
+			'array-portlets-rest' => [],
+		] )['array-portlets-rest'] );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::decorateSidebarData
-     * @return void
-     */
-    public function testDecorateSidebarRemovePageTools() {
-        $partial = new Drawer(new SkinCitizen());
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::decorateSidebarData
+	 * @return void
+	 */
+	public function testDecorateSidebarRemovePageTools() {
+		$partial = new Drawer( new SkinCitizen() );
 
-        $sidebarData = [
-            'array-portlets-rest' => [
-                [ 'id' => 'foo' ],
-                ['id' => 'p-tb'],
-            ],
-        ];
+		$sidebarData = [
+			'array-portlets-rest' => [
+				[ 'id' => 'foo' ],
+				[ 'id' => 'p-tb' ],
+			],
+		];
 
-        $this->assertNotEmpty($partial->decorateSidebarData($sidebarData));
-        $this->assertArrayHasKey('array-portlets-rest', $partial->decorateSidebarData($sidebarData));
-        $this->assertNotContains(['id' => 'pt-tb'], $partial->decorateSidebarData($sidebarData)['array-portlets-rest']);
-    }
+		$this->assertNotEmpty( $partial->decorateSidebarData( $sidebarData ) );
+		$this->assertArrayHasKey( 'array-portlets-rest', $partial->decorateSidebarData( $sidebarData ) );
+		$this->assertNotContains( [ 'id' => 'pt-tb' ], $partial->decorateSidebarData( $sidebarData )['array-portlets-rest'] );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatsData
-     * @return void
-     */
-    public function testGetSiteStatsDataDisabled() {
-        $this->overrideConfigValues([
-            'CitizenEnableDrawerSiteStats' => false,
-        ]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatsData
+	 * @return void
+	 */
+	public function testGetSiteStatsDataDisabled() {
+		$this->overrideConfigValues( [
+			'CitizenEnableDrawerSiteStats' => false,
+		] );
 
-        $partial = new Drawer(new SkinCitizen());
-        $this->assertEmpty($partial->getSiteStatsData());
-    }
+		$partial = new Drawer( new SkinCitizen() );
+		$this->assertEmpty( $partial->getSiteStatsData() );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatsData
-     * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatValue
-     * @return void
-     */
-    public function testGetSiteStatsDataNoFormat() {
-        $this->overrideConfigValues([
-            'CitizenEnableDrawerSiteStats' => true,
-            'CitizenUseNumberFormatter' => false,
-        ]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatsData
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Drawer::getSiteStatValue
+	 * @return void
+	 */
+	public function testGetSiteStatsDataNoFormat() {
+		$this->overrideConfigValues( [
+			'CitizenEnableDrawerSiteStats' => true,
+			'CitizenUseNumberFormatter' => false,
+		] );
 
-        $partial = new Drawer(new SkinCitizen());
-        $data = $partial->getSiteStatsData();
+		$partial = new Drawer( new SkinCitizen() );
+		$data = $partial->getSiteStatsData();
 
-        $this->assertArrayHasKey('array-drawer-sitestats-item', $data);
-        $this->assertCount(4, $data['array-drawer-sitestats-item']);
+		$this->assertArrayHasKey( 'array-drawer-sitestats-item', $data );
+		$this->assertCount( 4, $data['array-drawer-sitestats-item'] );
 
-        foreach ($data['array-drawer-sitestats-item'] as $stat) {
-            $this->assertArrayHasKey('id', $stat);
-            $this->assertArrayHasKey('icon', $stat);
-            $this->assertArrayHasKey('value', $stat);
-            $this->assertArrayHasKey('label', $stat);
+		foreach ( $data['array-drawer-sitestats-item'] as $stat ) {
+			$this->assertArrayHasKey( 'id', $stat );
+			$this->assertArrayHasKey( 'icon', $stat );
+			$this->assertArrayHasKey( 'value', $stat );
+			$this->assertArrayHasKey( 'label', $stat );
 
-            $this->assertTrue(in_array($stat['id'], ['articles', 'images', 'users', 'edits'], true));
-        }
-    }
+			$this->assertContains( $stat['id'], [ 'articles', 'images', 'users', 'edits' ] );
+		}
+	}
 }

--- a/tests/phpunit/Partials/FooterTest.php
+++ b/tests/phpunit/Partials/FooterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Tests\Partials;
 
@@ -11,34 +11,33 @@ use MediaWikiIntegrationTestCase;
 /**
  * @group Citizen
  */
-class FooterTest extends MediaWikiIntegrationTestCase
-{
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\Footer::decorateFooterData
-     * @return void
-     */
-    public function testDecorateFooterData() {
-        $partial = new Footer(new SkinCitizen());
+class FooterTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Footer::decorateFooterData
+	 * @return void
+	 */
+	public function testDecorateFooterData() {
+		$partial = new Footer( new SkinCitizen() );
 
-        $data = [
-            'data-info' => [
-                'array-items' => [
-                    ['name' => 'copyright']
-                ]
-            ]
-        ];
+		$data = [
+			'data-info' => [
+				'array-items' => [
+					[ 'name' => 'copyright' ]
+				]
+			]
+		];
 
-        $out = $partial->decorateFooterData($data);
+		$out = $partial->decorateFooterData( $data );
 
-        $this->assertArraySubmapSame([
-            'data-info' => [
-                'array-items' => [
-                    [
-                        'name' => 'copyright',
-                        'label' => wfMessage('citizen-page-info-copyright')->text()
-                    ]
-                ],
-            ]
-        ], $out);
-    }
+		$this->assertArraySubmapSame( [
+			'data-info' => [
+				'array-items' => [
+					[
+						'name' => 'copyright',
+						'label' => wfMessage( 'citizen-page-info-copyright' )->text()
+					]
+				],
+			]
+		], $out );
+	}
 }

--- a/tests/phpunit/Partials/FooterTest.php
+++ b/tests/phpunit/Partials/FooterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Skins\Citizen\Tests\Partials;
+
+use MediaWiki\Skins\Citizen\Partials\Footer;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @group Citizen
+ */
+class FooterTest extends MediaWikiIntegrationTestCase
+{
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\Footer::decorateFooterData
+     * @return void
+     */
+    public function testDecorateFooterData() {
+        $partial = new Footer(new SkinCitizen());
+
+        $data = [
+            'data-info' => [
+                'array-items' => [
+                    ['name' => 'copyright']
+                ]
+            ]
+        ];
+
+        $out = $partial->decorateFooterData($data);
+
+        $this->assertArraySubmapSame([
+            'data-info' => [
+                'array-items' => [
+                    [
+                        'name' => 'copyright',
+                        'label' => wfMessage('citizen-page-info-copyright')->text()
+                    ]
+                ],
+            ]
+        ], $out);
+    }
+}

--- a/tests/phpunit/Partials/HeaderTest.php
+++ b/tests/phpunit/Partials/HeaderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Skins\Citizen\Tests\Partials;
+
+use MediaWiki\Skins\Citizen\Partials\Header;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+
+/**
+ * @group Citizen
+ */
+class HeaderTest extends \MediaWikiIntegrationTestCase
+{
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\Header::decorateSearchBoxData
+     * @return void
+     */
+    public function testDecorateSearchBoxData() {
+        $partial = new Header(new SkinCitizen());
+        $out = $partial->decorateSearchBoxData([]);
+
+        $this->assertArrayHasKey('msg-citizen-search-toggle-shortcut', $out);
+        $this->assertEquals('[/]', $out['msg-citizen-search-toggle-shortcut']);
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserInfoData
+     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserPageHTML
+     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserGroupsHTML
+     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserContributionsHTML
+     * @return void
+     */
+    public function testGetUserInfoData() {
+        $partial = new Header(new SkinCitizen());
+        $out = $partial->getUserInfoData([]);
+
+        $this->assertArrayHasKey('id', $out);
+    }
+}

--- a/tests/phpunit/Partials/HeaderTest.php
+++ b/tests/phpunit/Partials/HeaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Tests\Partials;
 
@@ -10,31 +10,30 @@ use MediaWiki\Skins\Citizen\SkinCitizen;
 /**
  * @group Citizen
  */
-class HeaderTest extends \MediaWikiIntegrationTestCase
-{
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\Header::decorateSearchBoxData
-     * @return void
-     */
-    public function testDecorateSearchBoxData() {
-        $partial = new Header(new SkinCitizen());
-        $out = $partial->decorateSearchBoxData([]);
+class HeaderTest extends \MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Header::decorateSearchBoxData
+	 * @return void
+	 */
+	public function testDecorateSearchBoxData() {
+		$partial = new Header( new SkinCitizen() );
+		$out = $partial->decorateSearchBoxData( [] );
 
-        $this->assertArrayHasKey('msg-citizen-search-toggle-shortcut', $out);
-        $this->assertEquals('[/]', $out['msg-citizen-search-toggle-shortcut']);
-    }
+		$this->assertArrayHasKey( 'msg-citizen-search-toggle-shortcut', $out );
+		$this->assertEquals( '[/]', $out['msg-citizen-search-toggle-shortcut'] );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserInfoData
-     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserPageHTML
-     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserGroupsHTML
-     * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserContributionsHTML
-     * @return void
-     */
-    public function testGetUserInfoData() {
-        $partial = new Header(new SkinCitizen());
-        $out = $partial->getUserInfoData([]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserInfoData
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserPageHTML
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserGroupsHTML
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Header::getUserContributionsHTML
+	 * @return void
+	 */
+	public function testGetUserInfoData() {
+		$partial = new Header( new SkinCitizen() );
+		$out = $partial->getUserInfoData( [] );
 
-        $this->assertArrayHasKey('id', $out);
-    }
+		$this->assertArrayHasKey( 'id', $out );
+	}
 }

--- a/tests/phpunit/Partials/PageTitleTest.php
+++ b/tests/phpunit/Partials/PageTitleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Partials;
+
+use MediaWiki\Skins\Citizen\Partials\PageTitle;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use MWException;
+use RequestContext;
+
+/**
+ * @group Citizen
+ */
+class PageTitleTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTitle
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testDecorateTitleNoParenthesis() {
+		$title = Title::makeTitle( NS_PROJECT, 'Foo' );
+		RequestContext::resetMain();
+		RequestContext::getMain()->setTitle( $title );
+		$partial = new PageTitle( new SkinCitizen() );
+
+		$text = $partial->decorateTitle( 'Foo Title (paren)' );
+
+		$this->assertStringNotContainsString( 'mw-page-title-parenthesis', $text );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTitle
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testDecorateTitle() {
+		$title = Title::makeTitle( NS_MAIN, 'Foo' );
+		RequestContext::resetMain();
+		RequestContext::getMain()->setTitle( $title );
+		$partial = new PageTitle( new SkinCitizen() );
+
+		$text = $partial->decorateTitle( 'Foo Title (paren)' );
+
+		$this->assertStringContainsString( 'mw-page-title-parenthesis', $text );
+	}
+}

--- a/tests/phpunit/Partials/PageToolsTest.php
+++ b/tests/phpunit/Partials/PageToolsTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Partials;
+
+use MediaWiki\Skins\Citizen\Partials\PageTools;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use MWException;
+use RequestContext;
+
+/**
+ * @group Citizen
+ */
+class PageToolsTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTools
+	 * @return void
+	 */
+	public function testGetPageToolsData() {
+		$partial = new PageTools( new SkinCitizen() );
+
+		$parentData = [
+			'data-portlets-sidebar' => [
+				'array-portlets-rest' => [],
+			],
+		];
+
+		$data = $partial->getPageToolsData( $parentData );
+
+		$this->assertArrayHasKey( 'pagetools-visible', $data );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTools
+	 * @return void
+	 */
+	public function testGetPageToolsDataToolsNotEmpty() {
+		$partial = new PageTools( new SkinCitizen() );
+
+		$parentData = [
+			'data-portlets-sidebar' => [
+				'array-portlets-rest' => [
+					[ 'id' => 'p-tb' ],
+				],
+			],
+		];
+
+		$data = $partial->getPageToolsData( $parentData );
+
+		$this->assertArrayHasKey( 'pagetools-overflow', $data );
+		$this->assertTrue( $data['pagetools-overflow'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTools
+	 * @return void
+	 */
+	public function testGetPageToolsDataConditionLoginUserAnon() {
+		RequestContext::resetMain();
+		RequestContext::getMain()->setUser( $this->getServiceContainer()->getUserFactory()->newAnonymous() );
+
+		$this->overrideConfigValues( [
+			'CitizenShowPageTools' => 'login',
+		] );
+
+		$partial = new PageTools( new SkinCitizen() );
+
+		$parentData = [
+			'data-portlets-sidebar' => [
+				'array-portlets-rest' => [],
+			],
+		];
+
+		$data = $partial->getPageToolsData( $parentData );
+
+		$this->assertArrayHasKey( 'pagetools-visible', $data );
+		$this->assertFalse( $data['pagetools-visible'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTools
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testGetPageToolsDataConditionLoginUserRegistered() {
+		$user = $this->getServiceContainer()->getUserFactory()->newFromName( 'FooUser' );
+		$user->addToDatabase();
+
+		RequestContext::resetMain();
+		RequestContext::getMain()->setUser( $user );
+
+		$this->overrideConfigValues( [
+			'CitizenShowPageTools' => 'login',
+		] );
+
+		$partial = new PageTools( new SkinCitizen() );
+
+		$parentData = [
+			'data-portlets-sidebar' => [
+				'array-portlets-rest' => [],
+			],
+		];
+
+		$data = $partial->getPageToolsData( $parentData );
+
+		$this->assertArrayHasKey( 'pagetools-visible', $data );
+		$this->assertTrue( $data['pagetools-visible'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTools
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testGetPageToolsDataConditionPermissionHas() {
+		$user = $this->getServiceContainer()->getUserFactory()->newFromName( 'FooUser' );
+		$user->addToDatabase();
+
+		$title = Title::makeTitle( NS_MAIN, 'Foo' );
+
+		RequestContext::resetMain();
+		RequestContext::getMain()->setUser( $user );
+		RequestContext::getMain()->setTitle( $title );
+
+		$this->overrideConfigValues( [
+			'CitizenShowPageTools' => 'permission-read',
+		] );
+
+		$partial = new PageTools( new SkinCitizen() );
+
+		$parentData = [
+			'data-portlets-sidebar' => [
+				'array-portlets-rest' => [],
+			],
+		];
+
+		$data = $partial->getPageToolsData( $parentData );
+
+		$this->assertArrayHasKey( 'pagetools-visible', $data );
+		$this->assertTrue( $data['pagetools-visible'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTools
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testGetPageToolsDataConditionPermissionNotHas() {
+		$user = $this->getServiceContainer()->getUserFactory()->newFromName( 'FooUser' );
+		$user->addToDatabase();
+
+		$title = Title::makeTitle( NS_MAIN, 'Foo' );
+
+		RequestContext::resetMain();
+		RequestContext::getMain()->setUser( $user );
+		RequestContext::getMain()->setTitle( $title );
+
+		$this->overrideConfigValues( [
+			'CitizenShowPageTools' => 'permission-editinterface',
+		] );
+
+		$partial = new PageTools( new SkinCitizen() );
+
+		$parentData = [
+			'data-portlets-sidebar' => [
+				'array-portlets-rest' => [],
+			],
+		];
+
+		$data = $partial->getPageToolsData( $parentData );
+
+		$this->assertArrayHasKey( 'pagetools-visible', $data );
+		$this->assertFalse( $data['pagetools-visible'] );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\PageTools
+	 * @return void
+	 * @throws MWException
+	 */
+	public function testGetPageToolsDataLanguageCount() {
+		$partial = new PageTools( new SkinCitizen() );
+
+		$parentData = [
+			'data-portlets-sidebar' => [
+				'array-portlets-rest' => [],
+			],
+			'data-portlets' => [
+				'data-languages' => [
+					'is-empty' => false,
+				],
+			],
+		];
+
+		$data = $partial->getPageToolsData( $parentData );
+
+		$this->assertArrayHasKey( 'has-languages', $data );
+		$this->assertArrayHasKey( 'html-language-count', $data );
+	}
+}

--- a/tests/phpunit/Partials/TaglineTest.php
+++ b/tests/phpunit/Partials/TaglineTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Partials;
+
+use MediaWiki\Skins\Citizen\Partials\Tagline;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWiki\Title\Title;
+use OutputPage;
+use RequestContext;
+
+/**
+ * @group Citizen
+ */
+class TaglineTest extends \MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Tagline
+	 * @return void
+	 */
+	public function testGetTagLineEmpty() {
+		$partial = new Tagline( new SkinCitizen() );
+
+		$this->assertEmpty( $partial->getTagline() );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Tagline
+	 * @return void
+	 */
+	public function testGetTagLineShortDesc() {
+		$title = Title::makeTitle( NS_MAIN, 'Foo' );
+
+		RequestContext::resetMain();
+
+		$out = new OutputPage( RequestContext::getMain() );
+		$out->setProperty( 'shortdesc', '<foo-desc>' );
+
+		RequestContext::getMain()->setOutput( $out );
+		RequestContext::getMain()->setTitle( $title );
+
+		$partial = new Tagline( new SkinCitizen() );
+
+		$this->assertEquals( '<foo-desc>', $partial->getTagline() );
+	}
+
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Tagline
+	 * @return void
+	 */
+	public function testGetTagLineNoNSText() {
+		$title = $this->getMockBuilder( Title::class )->disableOriginalConstructor()->getMock();
+		$title->expects( $this->once() )->method( 'getNsText' )->willReturn( false );
+
+		RequestContext::resetMain();
+
+		$out = new OutputPage( RequestContext::getMain() );
+		$out->setProperty( 'shortdesc', null );
+
+		RequestContext::getMain()->setOutput( $out );
+		RequestContext::getMain()->setTitle( $title );
+
+		$partial = new Tagline( new SkinCitizen() );
+
+		$this->assertEquals(
+			wfMessage( 'tagline' )->text(),
+			$partial->getTagline()
+		);
+	}
+}

--- a/tests/phpunit/SkinCitizenTest.php
+++ b/tests/phpunit/SkinCitizenTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Skins\Citizen\Tests;
+
+use Exception;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWiki\Title\Title;
+use RequestContext;
+
+/**
+ * @group Citizen
+ */
+class SkinCitizenTest extends \MediaWikiIntegrationTestCase
+{
+    /**
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+     * @return void
+     */
+    public function testConstructor() {
+        $skin = new SkinCitizen([
+            'name' => 'Citizen',
+        ]);
+
+        $this->assertInstanceOf(SkinCitizen::class, $skin);
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+     * @covers \MediaWiki\Skins\Citizen\Partials\Metadata
+     * @covers \MediaWiki\Skins\Citizen\Partials\Theme
+     * @return void
+     * @throws Exception
+     */
+    public function testBuildSkinFeatures() {
+        $this->overrideConfigValues([
+            'CitizenThemeDefault' => 'dark',
+            'CitizenThemeColor' => '#ffaabb',
+            'CitizenEnableManifest' => true,
+        ]);
+
+        $skin = new SkinCitizen([
+            'name' => 'Citizen',
+        ]);
+        $title = Title::newFromText('TestTitle');
+        $skin->setRelevantTitle($title);
+
+        $options = $skin->getOptions();
+        $out = $skin->getOutput();
+
+        $this->assertFalse($options['toc']);
+
+        $this->assertContains(['theme-color', '#ffaabb'], $out->getMetaTags());
+        $this->assertContains([
+            'rel' => 'manifest',
+            'href' => $this->getServiceContainer()->getUrlUtils()->expand( wfAppendQuery( wfScript( 'api' ),
+                [ 'action' => 'webapp-manifest' ] ), PROTO_RELATIVE ),
+            ], $out->getLinkTags());
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+     * @covers \MediaWiki\Skins\Citizen\Partials\Metadata
+     * @covers \MediaWiki\Skins\Citizen\Partials\Theme
+     * @return void
+     * @throws Exception
+     */
+    public function testBuildSkinFeaturesNotAddManifest() {
+        $this->overrideConfigValues([
+            'CitizenEnableManifest' => false,
+        ]);
+
+        $skin = new SkinCitizen([
+            'name' => 'Citizen',
+        ]);
+
+        $this->assertEmpty($skin->getOutput()->getLinkTags());
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+     * @return void
+     * @throws Exception
+     */
+    public function testBuildSkinFeaturesEnableCjk() {
+        $this->overrideConfigValues([
+            'CitizenEnableCJKFonts' => true,
+        ]);
+
+        $skin = new SkinCitizen([
+            'name' => 'Citizen',
+        ]);
+
+        $this->assertArrayHasKey('styles', $skin->getOptions());
+        $this->assertContains('skins.citizen.styles.fonts.cjk', $skin->getOptions()['styles']);
+    }
+
+    /**
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+     * @return void
+     * @throws Exception
+     */
+    public function testBuildSkinFeaturesEnableCollapsibleSections() {
+        $title = Title::newFromText('BuildSkinFeaturesEnableCollapsibleSections');
+        RequestContext::resetMain();
+        RequestContext::getMain()->setTitle($title);
+
+        $this->overrideConfigValues([
+            'CitizenEnableCollapsibleSections' => true,
+        ]);
+
+        $skin = new SkinCitizen([
+            'name' => 'Citizen',
+        ]);
+
+        $this->assertArrayHasKey('bodyClasses', $skin->getOptions());
+        $this->assertContains('citizen-sections-enabled', $skin->getOptions()['bodyClasses']);
+    }
+}

--- a/tests/phpunit/SkinCitizenTest.php
+++ b/tests/phpunit/SkinCitizenTest.php
@@ -7,12 +7,14 @@ namespace MediaWiki\Skins\Citizen\Tests;
 use Exception;
 use MediaWiki\Skins\Citizen\SkinCitizen;
 use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
 use RequestContext;
 
 /**
+ * TODO: Fully test tagline logic
  * @group Citizen
  */
-class SkinCitizenTest extends \MediaWikiIntegrationTestCase {
+class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen
 	 * @return void

--- a/tests/phpunit/SkinCitizenTest.php
+++ b/tests/phpunit/SkinCitizenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Tests;
 
@@ -12,113 +12,112 @@ use RequestContext;
 /**
  * @group Citizen
  */
-class SkinCitizenTest extends \MediaWikiIntegrationTestCase
-{
-    /**
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
-     * @return void
-     */
-    public function testConstructor() {
-        $skin = new SkinCitizen([
-            'name' => 'Citizen',
-        ]);
+class SkinCitizenTest extends \MediaWikiIntegrationTestCase {
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+	 * @return void
+	 */
+	public function testConstructor() {
+		$skin = new SkinCitizen( [
+			'name' => 'Citizen',
+		] );
 
-        $this->assertInstanceOf(SkinCitizen::class, $skin);
-    }
+		$this->assertInstanceOf( SkinCitizen::class, $skin );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
-     * @covers \MediaWiki\Skins\Citizen\Partials\Metadata
-     * @covers \MediaWiki\Skins\Citizen\Partials\Theme
-     * @return void
-     * @throws Exception
-     */
-    public function testBuildSkinFeatures() {
-        $this->overrideConfigValues([
-            'CitizenThemeDefault' => 'dark',
-            'CitizenThemeColor' => '#ffaabb',
-            'CitizenEnableManifest' => true,
-        ]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Metadata
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Theme
+	 * @return void
+	 * @throws Exception
+	 */
+	public function testBuildSkinFeatures() {
+		$this->overrideConfigValues( [
+			'CitizenThemeDefault' => 'dark',
+			'CitizenThemeColor' => '#ffaabb',
+			'CitizenEnableManifest' => true,
+		] );
 
-        $skin = new SkinCitizen([
-            'name' => 'Citizen',
-        ]);
-        $title = Title::newFromText('TestTitle');
-        $skin->setRelevantTitle($title);
+		$skin = new SkinCitizen( [
+			'name' => 'Citizen',
+		] );
+		$title = Title::newFromText( 'TestTitle' );
+		$skin->setRelevantTitle( $title );
 
-        $options = $skin->getOptions();
-        $out = $skin->getOutput();
+		$options = $skin->getOptions();
+		$out = $skin->getOutput();
 
-        $this->assertFalse($options['toc']);
+		$this->assertFalse( $options['toc'] );
 
-        $this->assertContains(['theme-color', '#ffaabb'], $out->getMetaTags());
-        $this->assertContains([
-            'rel' => 'manifest',
-            'href' => $this->getServiceContainer()->getUrlUtils()->expand( wfAppendQuery( wfScript( 'api' ),
-                [ 'action' => 'webapp-manifest' ] ), PROTO_RELATIVE ),
-            ], $out->getLinkTags());
-    }
+		$this->assertContains( [ 'theme-color', '#ffaabb' ], $out->getMetaTags() );
+		$this->assertContains( [
+			'rel' => 'manifest',
+			'href' => $this->getServiceContainer()->getUrlUtils()->expand( wfAppendQuery( wfScript( 'api' ),
+				[ 'action' => 'webapp-manifest' ] ), PROTO_RELATIVE ),
+			], $out->getLinkTags() );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
-     * @covers \MediaWiki\Skins\Citizen\Partials\Metadata
-     * @covers \MediaWiki\Skins\Citizen\Partials\Theme
-     * @return void
-     * @throws Exception
-     */
-    public function testBuildSkinFeaturesNotAddManifest() {
-        $this->overrideConfigValues([
-            'CitizenEnableManifest' => false,
-        ]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Metadata
+	 * @covers \MediaWiki\Skins\Citizen\Partials\Theme
+	 * @return void
+	 * @throws Exception
+	 */
+	public function testBuildSkinFeaturesNotAddManifest() {
+		$this->overrideConfigValues( [
+			'CitizenEnableManifest' => false,
+		] );
 
-        $skin = new SkinCitizen([
-            'name' => 'Citizen',
-        ]);
+		$skin = new SkinCitizen( [
+			'name' => 'Citizen',
+		] );
 
-        $this->assertEmpty($skin->getOutput()->getLinkTags());
-    }
+		$this->assertEmpty( $skin->getOutput()->getLinkTags() );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
-     * @return void
-     * @throws Exception
-     */
-    public function testBuildSkinFeaturesEnableCjk() {
-        $this->overrideConfigValues([
-            'CitizenEnableCJKFonts' => true,
-        ]);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+	 * @return void
+	 * @throws Exception
+	 */
+	public function testBuildSkinFeaturesEnableCjk() {
+		$this->overrideConfigValues( [
+			'CitizenEnableCJKFonts' => true,
+		] );
 
-        $skin = new SkinCitizen([
-            'name' => 'Citizen',
-        ]);
+		$skin = new SkinCitizen( [
+			'name' => 'Citizen',
+		] );
 
-        $this->assertArrayHasKey('styles', $skin->getOptions());
-        $this->assertContains('skins.citizen.styles.fonts.cjk', $skin->getOptions()['styles']);
-    }
+		$this->assertArrayHasKey( 'styles', $skin->getOptions() );
+		$this->assertContains( 'skins.citizen.styles.fonts.cjk', $skin->getOptions()['styles'] );
+	}
 
-    /**
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen
-     * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
-     * @return void
-     * @throws Exception
-     */
-    public function testBuildSkinFeaturesEnableCollapsibleSections() {
-        $title = Title::newFromText('BuildSkinFeaturesEnableCollapsibleSections');
-        RequestContext::resetMain();
-        RequestContext::getMain()->setTitle($title);
+	/**
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen::buildSkinFeatures
+	 * @return void
+	 * @throws Exception
+	 */
+	public function testBuildSkinFeaturesEnableCollapsibleSections() {
+		$title = Title::newFromText( 'BuildSkinFeaturesEnableCollapsibleSections' );
+		RequestContext::resetMain();
+		RequestContext::getMain()->setTitle( $title );
 
-        $this->overrideConfigValues([
-            'CitizenEnableCollapsibleSections' => true,
-        ]);
+		$this->overrideConfigValues( [
+			'CitizenEnableCollapsibleSections' => true,
+		] );
 
-        $skin = new SkinCitizen([
-            'name' => 'Citizen',
-        ]);
+		$skin = new SkinCitizen( [
+			'name' => 'Citizen',
+		] );
 
-        $this->assertArrayHasKey('bodyClasses', $skin->getOptions());
-        $this->assertContains('citizen-sections-enabled', $skin->getOptions()['bodyClasses']);
-    }
+		$this->assertArrayHasKey( 'bodyClasses', $skin->getOptions() );
+		$this->assertContains( 'citizen-sections-enabled', $skin->getOptions()['bodyClasses'] );
+	}
 }


### PR DESCRIPTION
This PR adds unit tests for Citizen's `Partial` classes, `Hooks`, and `SkinCitizen`. 

Further, a ci test matrix is added, running PHP Unit on pushes to `main`, `develop`, and `feature/*`, as well as on any PR.  
The matrix tests Citizen on PHP 8.1 with the MW versions `master`, `REL1_39`, and `REL1_40`.

The tests in this PR cover 81% of all files and 66% of all lines.

---
Minor changes:
- The composer command `fix` has been updated to run `phpcbf`.
- Some class names have been imported
- Some if statements were refactored to exit early