### PR TITLE
Fix RTL flipping of the progressbar animation keyframe

### DIFF
--- a/resources/skins.citizen.styles/common/progressbar.less
+++ b/resources/skins.citizen.styles/common/progressbar.less
@@ -57,11 +57,13 @@
 	}
 
 	70% {
+		/* @noflip */
 		background-position: 110% 0;
 		background-size: 30% var( --height-progress-bar );
 	}
 
 	100% {
+		/* @noflip */
 		background-position: 110% 0;
 		background-size: 0 var( --height-progress-bar );
 	}


### PR DESCRIPTION
Adding `@noflip` will fix the animation of the progressbar.

Reproduce of the bug:
Set your wiki's language to a RTL language such as fa-persian and enter another page.