### PR TITLE
Let makeSections xpath query cope with multiple classes

### DIFF
--- a/includes/Partials/BodyContent.php
+++ b/includes/Partials/BodyContent.php
@@ -132,7 +132,7 @@ final class BodyContent extends Partial {
 	 */
 	private function makeSections( DOMDocument $doc, array $headingWrappers ) {
 		$xpath = new DOMXpath( $doc );
-		$containers = $xpath->query( '//div[@class="mw-parser-output"][1]' );
+		$containers = $xpath->query( 'body/div[contains(concat(" ",normalize-space(@class)," ")," mw-parser-output ")][1]' );
 
 		// Return if no parser output is found
 		if ( !$containers->length || $containers->item( 0 ) === null ) {

--- a/includes/Partials/BodyContent.php
+++ b/includes/Partials/BodyContent.php
@@ -132,7 +132,10 @@ final class BodyContent extends Partial {
 	 */
 	private function makeSections( DOMDocument $doc, array $headingWrappers ) {
 		$xpath = new DOMXpath( $doc );
-		$containers = $xpath->query( 'body/div[contains(concat(" ",normalize-space(@class)," ")," mw-parser-output ")][1]' );
+		$containers = $xpath->query(
+			// Equivalent of CSS attribute `~=` to support multiple classes
+			'body/div[contains(concat(" ",normalize-space(@class)," ")," mw-parser-output ")][1]'
+		);
 
 		// Return if no parser output is found
 		if ( !$containers->length || $containers->item( 0 ) === null ) {

--- a/includes/Partials/BodyContent.php
+++ b/includes/Partials/BodyContent.php
@@ -134,7 +134,7 @@ final class BodyContent extends Partial {
 		$xpath = new DOMXpath( $doc );
 		$containers = $xpath->query(
 			// Equivalent of CSS attribute `~=` to support multiple classes
-			'body/div[contains(concat(" ",normalize-space(@class)," ")," mw-parser-output ")][1]'
+			'//div[contains(concat(" ",normalize-space(@class)," ")," mw-parser-output ")][1]'
 		);
 
 		// Return if no parser output is found


### PR DESCRIPTION
As-of https://gerrit.wikimedia.org/r/c/mediawiki/core/+/939783 in mediawiki-core, this class attribute is going to contain multiple classes. This would break the section-creation. This change to the query is backwards-compatible, so this should just inoculate the skin against future updates.