### PR TITLE
fix(AccountInfo): 🐛 resetting incorrectly styled elements

### DIFF
--- a/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
+++ b/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
@@ -3,13 +3,27 @@
  *
  * SkinStyles for Extension:AccountInfo
  * Module: ext.AccountInfo.special
- * Version: REL1_39 (3145de8)
+ * Version: REL1_39 (2e529e7)
  *
- * Date: 2024-07-13
+ * Date: 2024-07-24
 */
 
-.mw-special-AccountInfo table,
-.mw-special-AccountInfo #mw-content-text > p {
+.mw-special-AccountInfo h1 {
+	font-size: var( --font-size-xxx-large );
+	font-weight: var( --font-weight-semibold );
+	border-bottom: none;
+	margin-bottom: 0.25em;
+}
+
+.mw-special-AccountInfo p {
+	padding: 0;
+	background: none;
+	border-radius: 0;
+	margin-bottom: none;
+	width: 100%;
+}
+
+.mw-special-AccountInfo table {
 	width: 100%;
 }
 

--- a/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
+++ b/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
@@ -9,18 +9,18 @@
 */
 
 .mw-special-AccountInfo h1 {
+	margin-bottom: 0.25em;
 	font-size: var( --font-size-xxx-large );
 	font-weight: var( --font-weight-semibold );
 	border-bottom: none;
-	margin-bottom: 0.25em;
 }
 
 .mw-special-AccountInfo p {
+	width: 100%;
 	padding: 0;
+	margin-bottom: none;
 	background: none;
 	border-radius: 0;
-	margin-bottom: none;
-	width: 100%;
 }
 
 .mw-special-AccountInfo table {


### PR DESCRIPTION
Fixing some incorrectly styled elements as a result of AccountInfo's terrible CSS selector choices, this change resets the paragraph (p) and table (table) selectors to their default values within Citizen and limits their effects to the Special:AccountInfo page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual presentation of the Account Info extension with refined styles for headings and paragraphs.
- **Bug Fixes**
	- Removed outdated styles for tables and paragraphs to improve layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->