### PR TITLE
Correct Elasticsearch spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. See [standa
 * **core:** ✨ enable heading HTML change for 1.43 ([c64b2ff](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/c64b2ff5e6a15ad57798b2943468e58b2db4addb))
 * **menu:** ✨ add accesskey hint to menu items ([10a28ac](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/10a28ac476ac168ef3fa93b3e61867d1c040a370))
 * **search:** ✨ change search text label to advanced search if AdvancedSearch is enabled ([dea1628](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/dea1628ce37b502e73adaa3d39546911e08cac97))
-* **search:** ✨ show ElasticSearch at search footer if it is enabled ([3e63a3f](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/3e63a3f6cce49b1b2d21b827162ecbcb642babdf))
+* **search:** ✨ show Elasticsearch at search footer if it is enabled ([3e63a3f](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/3e63a3f6cce49b1b2d21b827162ecbcb642babdf))
 
 
 ### Bug Fixes

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -13,7 +13,7 @@
 	"citizen-drawer-toggle": "Toggle menu",
 	"citizen-usermenu-toggle": "Toggle personal menu",
 	"citizen-search-poweredby": "Powered by $1",
-	"citizen-search-poweredby-cirrussearch": "ElasticSearch",
+	"citizen-search-poweredby-cirrussearch": "Elasticsearch",
 	"citizen-search-poweredby-mediawiki": "MediaWiki",
 	"citizen-search-toggle": "Toggle search",
 	"citizen-search-keyhint-exit": "Exit search",

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -12,7 +12,7 @@
 	"citizen-drawer-toggle": "Дај/скриј мени",
 	"citizen-usermenu-toggle": "Дај/скриј лично мени",
 	"citizen-search-poweredby": "Овозможено од $1",
-	"citizen-search-poweredby-cirrussearch": "ElasticSearch",
+	"citizen-search-poweredby-cirrussearch": "Elasticsearch",
 	"citizen-search-poweredby-mediawiki": "МедијаВики",
 	"citizen-search-toggle": "Дај/скриј пребарување",
 	"citizen-search-keyhint-exit": "Излези од пребарувањето",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -18,7 +18,7 @@
 	"citizen-drawer-toggle": "Tooltip of drawer menu toggle",
 	"citizen-usermenu-toggle": "Tooltip of personal menu toggle",
 	"citizen-search-poweredby": "Label for the current search backend powering the search suggestion",
-	"citizen-search-poweredby-cirrussearch": "Label for ElasticSearch",
+	"citizen-search-poweredby-cirrussearch": "Label for Elasticsearch",
 	"citizen-search-poweredby-mediawiki": "Label for MediaWiki",
 	"citizen-search-toggle": "Tooltip of search box toggle",
 	"citizen-search-keyhint-exit": "Keyboard hint for the key to exit search",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -14,7 +14,7 @@
 	"citizen-drawer-toggle": "Bật tắt bảng chọn",
 	"citizen-usermenu-toggle": "Bật tắt bảng chọn cá nhân",
 	"citizen-search-poweredby": "Được hỗ trợ bởi $1",
-	"citizen-search-poweredby-cirrussearch": "ElasticSearch",
+	"citizen-search-poweredby-cirrussearch": "Elasticsearch",
 	"citizen-search-poweredby-mediawiki": "MediaWiki",
 	"citizen-search-toggle": "Tìm kiếm",
 	"citizen-search-keyhint-exit": "Thoát tìm kiếm",


### PR DESCRIPTION
It is always written with a small S, not capital.