### PR TITLE
Fix section collapsing not functioning on Firefox

### DIFF
--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -28,7 +28,7 @@ function init( bodyContent ) {
 			const section = heading.nextElementSibling;
 
 			if ( section ) {
-				section.hidden = section.hidden === 'until-found' ? false : 'until-found';
+				section.hidden = section.hidden ? false : 'until-found';
 			}
 		}
 	};

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -34,7 +34,7 @@
 			}
 		}
 
-		&:has( + .citizen-section[ hidden='until-found' ] ) {
+		&:has( + .citizen-section[ hidden ] ) {
 			.citizen-section-indicator {
 				transform: rotate3d( 1, 0, 0, 180deg );
 			}


### PR DESCRIPTION
Fixes #964.

Changes the strict equality check to a boolean conversion in order to accept both `'until-found'` and `true`. Also replaces the equality check in the CSS with a generic 'attribute is present' check.

Tested on Firefox 131.0.3 and Chromium 130.0.