### PR TITLE
OOUI: fix tab option selected border-bottom

### DIFF
--- a/skinStyles/ooui/oojs-ui-widgets.less
+++ b/skinStyles/ooui/oojs-ui-widgets.less
@@ -43,6 +43,10 @@
 	background-color: var( --background-color-button-quiet--active );
 }
 
+.oo-ui-tabSelectWidget-framed .oo-ui-tabOptionWidget.oo-ui-optionWidget-selected .oo-ui-labelElement-label {
+	background-color: var( --border-color-progressive--active );
+}
+
 .oo-ui-tabSelectWidget-frameless.oo-ui-widget-enabled:focus .oo-ui-tabOptionWidget.oo-ui-optionWidget-selected {
 	border-radius: var( --border-radius-base );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the visual appearance of selected tab options in framed tab widgets by applying a distinctive background color for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->