### PR TITLE
UserProfileV2: 🐛 fix deprecations and add fixes for mobile

### DIFF
--- a/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
+++ b/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
@@ -35,7 +35,7 @@
 	filter: var( --filter-invert );
 }
 
-@media screen and (max-width: 532px) {
+@media screen and (max-width: 512px) {
 	.profile-identitybox { flex-direction: column; }
 	ul.profile-header-statistics > li:first-child:after {
 		content: "\2003";

--- a/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
+++ b/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
@@ -3,9 +3,9 @@
  *
  * SkinStyles for UserProfileV2
  * Module: ext.userProfileV2
- * Version: main e8390662
+ * Version: main c3f308b1
  *
- * Date: 2024-07-24
+ * Date: 2025-03-27
 */
 
 /* ext.userProfileV2.less */
@@ -16,7 +16,7 @@
 }
 
 .profile-user-group {
-	color: var( --color-base--emphasized );
+	color: var( --color-emphasized );
 	/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 	text-transform: capitalize;
 	border-radius: var( --border-radius-base );
@@ -27,10 +27,18 @@
 }
 
 .external-link.tooltip:hover::after {
-	color: var( --color-base--emphasized );
-	border-radius: var( --border-radius--small );
+	color: var( --color-emphasized );
+	border-radius: var( --border-radius-base );
 }
 
 .profile-externalLinks svg {
 	filter: var( --filter-invert );
+}
+
+@media screen and (max-width 532px) {
+	.profile-identitybox { flex-direction: column; }
+	ul.profile-header-statistics > li:not(:first-child):before {
+		content: unset;
+		margin: unset;
+	}
 }

--- a/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
+++ b/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
@@ -35,10 +35,13 @@
 	filter: var( --filter-invert );
 }
 
-@media screen and (max-width 532px) {
+@media screen and (max-width: 532px) {
 	.profile-identitybox { flex-direction: column; }
+	ul.profile-header-statistics > li:first-child:after {
+		content: "\2003";
+	}
 	ul.profile-header-statistics > li:not(:first-child):before {
 		content: unset;
-		margin: unset;
+		margin-left: unset;
 	}
 }


### PR DESCRIPTION
When the profile masthead gets smaller than a certain screen dimension (512 px), the fix will warp the masthead element downward so that it will look like the image
![image](https://github.com/user-attachments/assets/08b4deea-b553-457c-b54f-5a057272bb09)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the color scheme and border styling in the user profile view for improved visual consistency.
	- Enhanced responsiveness for smaller screens by adjusting layout direction and spacing in user profile sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->