### PR TITLE
feat(commandPalette): ✨ initial implementation of Command Palette

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: mediawiki/skins/Citizen
+          fetch-depth: 0
 
       - name: Install dependencies with Composer
         run: composer update --no-ansi --no-interaction --no-progress

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Name | Description | Values | Default
 `$wgCitizenEnableManifest` | Enable or disable [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) | `true` - enable; `false` - disable | `true`
 `$wgCitizenManifestOptions` | Options of the web app manifest | - | See below
 
+### Development
+Name | Description | Values | Default
+:--- | :--- | :--- | :---
+`$wgEnableCommandPalette` | [EXPERIMENTAL] Enables or disable the command palette. Command palette is in active development and may not work as expected. | `true` - enable; `false` - disable | `false`
+
 ```php
 $wgCitizenManifestOptions = [
 	'background_color' => '#0d0e12',

--- a/includes/Hooks/ResourceLoaderHooks.php
+++ b/includes/Hooks/ResourceLoaderHooks.php
@@ -50,6 +50,7 @@ class ResourceLoaderHooks {
 			'wgCitizenOverflowInheritedClasses' => $config->get( 'CitizenOverflowInheritedClasses' ),
 			'wgCitizenOverflowNowrapClasses' => $config->get( 'CitizenOverflowNowrapClasses' ),
 			'wgCitizenSearchModule' => $config->get( 'CitizenSearchModule' ),
+			'wgCitizenEnableCommandPalette' => $config->get( 'CitizenEnableCommandPalette' ),
 		];
 	}
 
@@ -84,10 +85,21 @@ class ResourceLoaderHooks {
 			'wgCitizenSearchGateway' => $config->get( 'CitizenSearchGateway' ),
 			'wgCitizenSearchDescriptionSource' => $config->get( 'CitizenSearchDescriptionSource' ),
 			'wgCitizenMaxSearchResults' => $config->get( 'CitizenMaxSearchResults' ),
-			'wgArticlePath' => $config->get( MainConfigNames::ArticlePath ),
-			'wgScript' => $config->get( MainConfigNames::Script ),
 			'wgScriptPath' => $config->get( MainConfigNames::ScriptPath ),
 			'wgSearchSuggestCacheExpiry' => $config->get( MainConfigNames::SearchSuggestCacheExpiry )
 		];
+	}
+
+	/**
+	 * Passes config variables to skins.citizen.commandPalette ResourceLoader module.
+	 * @param RL\Context $context
+	 * @param Config $config
+	 * @return array
+	 */
+	public static function getCitizenCommandPaletteResourceLoaderConfig(
+		RL\Context $context,
+		Config $config
+	) {
+		return [];
 	}
 }

--- a/resources/skins.citizen.commandPalette/.eslintrc.json
+++ b/resources/skins.citizen.commandPalette/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+	"extends": [
+		"../.eslintrc.json"
+	],
+	"rules": {
+		"max-len": "off",
+		"es-x/no-object-values": "off",
+		"es-x/no-optional-chaining": "off",
+		"es-x/no-nullish-coalescing-operators": "off",
+		"es-x/no-symbol-prototype-description": "off",
+		"es-x/no-rest-spread-properties": "off"
+	}
+}

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -1,0 +1,318 @@
+<template>
+	<div v-if="isOpen" class="citizen-command-palette">
+		<div class="citizen-command-palette__overlay" @click="close"></div>
+		<div class="citizen-command-palette__container">
+			<div class="citizen-command-palette__search">
+				<cdx-text-input
+					ref="searchInput"
+					v-model="searchQuery"
+					class="citizen-command-palette__input"
+					input-type="search"
+					:start-icon="cdxIconSearch"
+					:clearable="true"
+					:placeholder="placeholder"
+					@keydown.down.prevent="highlightNext"
+					@keydown.up.prevent="highlightPrevious"
+					@keydown.home.prevent="highlightFirst"
+					@keydown.end.prevent="highlightLast"
+					@keydown.enter.prevent="executeCommand"
+					@keydown.esc="close"
+				></cdx-text-input>
+			</div>
+			<div
+				ref="resultsContainer"
+				class="citizen-command-palette__results"
+			>
+				<template v-for="( resultGroup, key ) in searchResults" :key="key">
+					<command-palette-list
+						v-if="resultGroup.items.length > 0"
+						:items="resultGroup.items"
+						:highlighted-item-index="highlightedItemIndex"
+						:show-thumbnail="resultGroup.showThumbnail"
+						:search-query="searchQuery"
+						:heading="resultGroup.heading"
+						@update:highlighted-item-index="updatehighlightedItemIndex"
+						@select="selectResult"
+					></command-palette-list>
+				</template>
+			</div>
+			<div class="citizen-command-palette__footer">
+				🧪 Citizen Command Palette is in beta.
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+const { defineComponent, ref, watch, nextTick, computed } = require( 'vue' );
+const fetchJson = require( '../fetch.js' );
+const urlGenerator = require( '../urlGenerator.js' )();
+const CommandPaletteList = require( './CommandPaletteList.vue' );
+const { CdxTextInput } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { cdxIconSearch } = require( '../icons.json' );
+
+// @vue/component
+module.exports = exports = defineComponent( {
+	name: 'App',
+	compilerOptions: {
+		whitespace: 'condense'
+	},
+	components: {
+		CdxTextInput,
+		CommandPaletteList
+	},
+	props: {},
+	setup() {
+		// State
+		const isOpen = ref( false );
+		const searchQuery = ref( '' );
+		const searchResults = ref( {
+			pages: {
+				heading: 'Pages',
+				items: [],
+				showThumbnail: true
+			}
+		} );
+		const highlightedItemIndex = ref( -1 );
+		const placeholder = ref( mw.message( 'citizen-command-palette-placeholder' ).text() );
+		const debounceTimeout = ref( null );
+		const searchInput = ref( null );
+		const resultsContainer = ref( null );
+
+		// Computed
+		const itemsLength = computed( () => Object.values( searchResults.value ).reduce( ( acc, group ) => acc + group.items.length, 0 ) );
+
+		// Navigation methods
+		const highlightNext = () => {
+			if ( itemsLength.value === 0 ) {
+				return;
+			}
+			highlightedItemIndex.value = ( highlightedItemIndex.value + 1 ) % itemsLength.value;
+		};
+
+		const highlightPrevious = () => {
+			if ( itemsLength.value === 0 ) {
+				return;
+			}
+			highlightedItemIndex.value = ( highlightedItemIndex.value - 1 + itemsLength.value ) % itemsLength.value;
+		};
+
+		const highlightFirst = () => {
+			if ( itemsLength.value > 0 ) {
+				highlightedItemIndex.value = 0;
+			} else {
+				highlightedItemIndex.value = -1;
+			}
+		};
+
+		const highlightLast = () => {
+			if ( itemsLength.value > 0 ) {
+				highlightedItemIndex.value = itemsLength.value - 1;
+			}
+		};
+
+		// Scroll handling
+		const maybeScrollIntoView = () => {
+			if ( !resultsContainer.value ) {
+				return;
+			}
+
+			const isResultsScrollable =
+				resultsContainer.value.scrollHeight > resultsContainer.value.clientHeight;
+
+			if ( !isResultsScrollable ) {
+				return;
+			}
+
+			const highlightedElement = resultsContainer.value.querySelector( '.citizen-command-palette-list-item--highlighted' );
+			highlightedElement?.scrollIntoView( {
+				block: 'nearest',
+				behavior: 'smooth'
+			} );
+		};
+
+		// Selection handling
+		const updatehighlightedItemIndex = ( index ) => {
+			highlightedItemIndex.value = index;
+		};
+
+		const selectResult = ( result ) => {
+			window.location.href = result.url;
+			isOpen.value = false;
+		};
+
+		const executeCommand = () => {
+			const allItems = Object.values( searchResults.value ).reduce( ( acc, group ) => acc.concat( group.items ), [] );
+			if ( allItems.length > 0 ) {
+				selectResult( allItems[ highlightedItemIndex.value ] );
+			} else {
+				window.location.href = urlGenerator.generateUrl();
+				isOpen.value = false;
+			}
+		};
+
+		// Search method
+		// TODO: Make this generic so that it can be used for other search types
+		// eslint-disable-next-line es-x/no-async-functions
+		const search = async ( query ) => {
+			highlightedItemIndex.value = -1;
+
+			if ( !query ) {
+				searchResults.value.pages.items = [];
+				return;
+			}
+
+			try {
+				// TODO: Do not hardcode rest.php path, we need to build the URL based on config
+				// TODO: Do not hardcode limit, we need to use the config
+				const { fetch } = fetchJson( `/w/rest.php/v1/search/title?q=${ encodeURIComponent( query ) }&limit=10`, {
+					headers: {
+						accept: 'application/json'
+					}
+				} );
+				const data = await fetch;
+				const items = data.pages.map( ( result ) => ( {
+					id: `citizen-command-palette-result-page-${ result.id }`,
+					label: result.title,
+					description: result.description,
+					thumbnail: result.thumbnail,
+					url: urlGenerator.generateUrl( result.title )
+				} ) );
+				searchResults.value = {
+					pages: {
+						heading: 'Pages',
+						items,
+						showThumbnail: true
+					}
+				};
+			} catch ( error ) {
+				mw.log.error( 'Error searching:', error );
+				searchResults.value.pages.items = [];
+			}
+		};
+
+		// Watchers
+		watch( searchQuery, ( newQuery ) => {
+			if ( debounceTimeout.value ) {
+				clearTimeout( debounceTimeout.value );
+			}
+			debounceTimeout.value = setTimeout( () => {
+				search( newQuery );
+			}, 300 );
+		} );
+
+		watch( highlightedItemIndex, () => {
+			nextTick( () => {
+				maybeScrollIntoView();
+			} );
+		} );
+
+		watch( searchResults, () => {
+			nextTick( () => {
+				maybeScrollIntoView();
+			} );
+		}, { deep: true } );
+
+		return {
+			// State
+			isOpen,
+			searchQuery,
+			searchResults,
+			highlightedItemIndex,
+			placeholder,
+			searchInput,
+			resultsContainer,
+
+			cdxIconSearch,
+
+			// Methods
+			highlightNext,
+			highlightPrevious,
+			highlightFirst,
+			highlightLast,
+			updatehighlightedItemIndex,
+			selectResult,
+			executeCommand
+		};
+	},
+	methods: {
+		/**
+		 * @public
+		 */
+		open() {
+			this.isOpen = true;
+			this.$nextTick( () => {
+				this.$refs.searchInput?.focus();
+			} );
+		},
+		close() {
+			this.isOpen = false;
+			this.searchQuery = '';
+			this.searchResults = {};
+			this.highlightedItemIndex = 0;
+		}
+	}
+} );
+</script>
+
+<style lang="less">
+@import 'mediawiki.skin.variables.less';
+
+.citizen-command-palette {
+	--citizen-command-palette-side-padding: var( --space-md );
+
+	position: fixed;
+	inset: 0;
+
+	&__overlay {
+		position: absolute;
+		inset: 0;
+		background-color: var( --background-color-backdrop-light );
+	}
+
+	&__container {
+		position: absolute;
+		top: 3.5rem;
+		left: 0;
+		right: 0;
+		margin-inline: auto;
+		min-width: 16rem;
+		max-width: 80vw;
+		font-size: var( --font-size-base );
+		background-color: var( --color-surface-1 );
+		border: var( --border-base );
+		border-radius: var( --border-radius-medium );
+		box-shadow: var( --box-shadow-drop-xx-large );
+		line-height: var( --line-height-xx-small );
+		overflow: hidden;
+	}
+
+	&__input {
+		/* 8px from CdxTextInput */
+		margin: var( --space-sm ) calc( var( --citizen-command-palette-side-padding ) - 8px );
+
+		.cdx-text-input__input {
+			padding-left: calc( 8px + 1.25rem + var( --space-sm ) );
+			padding-block: 0;
+			/* Let the container handles the states */
+			box-shadow: none !important;
+			background-color: transparent !important;
+			border: 0 !important;
+			outline: none !important;
+		}
+	}
+
+	&__results {
+		border-top: var( --border-subtle );
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+
+	&__footer {
+		border-top: var( --border-subtle );
+		padding: var( --space-sm ) var( --citizen-command-palette-side-padding );
+		font-size: var( --font-size-x-small );
+		color: var( --color-subtle );
+	}
+}
+</style>

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -29,7 +29,11 @@
 					</div>
 				</template>
 
-				<template v-else v-for="( resultGroup, key ) in searchResults" :key="key">
+				<template
+					v-for="( resultGroup, key ) in searchResults"
+					v-else
+					:key="key"
+				>
 					<command-palette-list
 						v-if="resultGroup.items.length > 0"
 						:items="resultGroup.items"

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
@@ -1,0 +1,119 @@
+<!-- eslint-disable max-len -->
+<template>
+	<section class="citizen-command-palette-list">
+		<div
+			v-if="heading"
+			class="citizen-command-palette-list__heading"
+			role="presentation"
+		>
+			{{ heading }}
+		</div>
+		<ul
+			ref="listRef"
+			class="citizen-command-palette-list__listbox"
+			role="listbox"
+			tabindex="-1"
+		>
+			<command-palette-list-item
+				v-for="( item, index ) in items"
+				:key="item.id"
+				v-bind="getListItemBindings( item )"
+				@change="( property, value ) => onItemChange( item.id, property, value, index )"
+			></command-palette-list-item>
+		</ul>
+	</section>
+</template>
+
+<script>
+const { defineComponent, ref, watch } = require( 'vue' );
+const CommandPaletteListItem = require( './CommandPaletteListItem.vue' );
+
+// @vue/component
+module.exports = exports = defineComponent( {
+	name: 'CommandPaletteList',
+	components: {
+		CommandPaletteListItem
+	},
+	props: {
+		items: {
+			type: Array,
+			required: true
+		},
+		highlightedItemIndex: {
+			type: Number,
+			default: 0
+		},
+		showThumbnail: {
+			type: Boolean,
+			default: false
+		},
+		searchQuery: {
+			type: String,
+			default: ''
+		},
+		heading: {
+			type: String,
+			default: ''
+		}
+	},
+	emits: [ 'update:highlightedItemIndex' ],
+	setup( props, { emit } ) {
+		const listRef = ref( null );
+		const highlightedItemId = ref( null );
+		const activeItemId = ref( null );
+
+		// Watch for changes in highlightedItemIndex and update highlightedItemId accordingly
+		watch( () => props.highlightedItemIndex, ( newIndex ) => {
+			if ( props.items[ newIndex ] ) {
+				highlightedItemId.value = props.items[ newIndex ].id;
+			}
+		} );
+
+		function getListItemBindings( listItem ) {
+			return {
+				active: listItem.id === activeItemId.value,
+				highlighted: listItem.id === highlightedItemId.value,
+				showThumbnail: props.showThumbnail,
+				searchQuery: props.searchQuery,
+				...listItem
+			};
+		}
+
+		function onItemChange( itemId, property, value, index ) {
+			if ( property === 'highlighted' ) {
+				highlightedItemId.value = value ? itemId : null;
+				if ( value ) {
+					emit( 'update:highlightedItemIndex', index );
+				}
+			} else if ( property === 'active' ) {
+				activeItemId.value = value ? itemId : null;
+			}
+		}
+
+		return {
+			listRef,
+			getListItemBindings,
+			onItemChange
+		};
+	}
+} );
+</script>
+
+<style lang="less">
+.citizen-command-palette-list {
+	padding-block: var( --space-xs );
+
+	&__heading {
+		padding: var( --space-xs ) var( --citizen-command-palette-side-padding );
+		font-size: var( --font-size-x-small );
+		font-weight: var( --font-weight-medium );
+		color: var( --color-subtle );
+	}
+
+	&__listbox {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+}
+</style>

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
@@ -1,0 +1,200 @@
+<!--
+Partially based on the MenuItem component from Codex.
+@see https://github.com/wikimedia/design-codex/blob/main/packages/codex/src/components/menu-item/MenuItem.vue
+-->
+<!-- eslint-disable max-len -->
+<template>
+	<li
+		:id="id"
+		role="option"
+		class="citizen-command-palette-list-item"
+		:class="rootClasses"
+		@mousemove="onMouseMove"
+		@mouseleave="onMouseLeave"
+		@mousedown.prevent="onMouseDown"
+	>
+		<slot>
+			<a
+				:href="url"
+				class="citizen-command-palette-list-item__content"
+			>
+				<cdx-thumbnail
+					v-if="showThumbnail"
+					:thumbnail="thumbnail"
+					class="citizen-command-palette-list-item__thumbnail"
+				></cdx-thumbnail>
+
+				<cdx-icon
+					v-else-if="icon"
+					:icon="icon"
+					class="citizen-command-palette-list-item__icon"
+				></cdx-icon>
+
+				<div class="citizen-command-palette-list-item__text">
+					<div class="citizen-command-palette-list-item__text__label">
+						<!-- Techinally you are not supposed to use CdxSearchResultTitle... -->
+						<cdx-search-result-title
+							:title="label"
+							:search-query="searchQuery"
+						></cdx-search-result-title>
+					</div>
+					<div
+						v-if="description"
+						class="citizen-command-palette-list-item__text__description"
+					>
+						<bdi>{{ description }}</bdi>
+					</div>
+				</div>
+			</a>
+		</slot>
+	</li>
+</template>
+
+<script>
+const { defineComponent, computed } = require( 'vue' );
+const { CdxIcon, CdxSearchResultTitle, CdxThumbnail } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+
+// @vue/component
+module.exports = exports = defineComponent( {
+	name: 'CommandPaletteListItem',
+	components: {
+		CdxIcon,
+		CdxSearchResultTitle,
+		CdxThumbnail
+	},
+	props: {
+		id: {
+			type: String,
+			required: true
+		},
+		active: {
+			type: Boolean,
+			default: false
+		},
+		highlighted: {
+			type: Boolean,
+			default: false
+		},
+		label: {
+			type: String,
+			required: true
+		},
+		url: {
+			type: String,
+			default: ''
+		},
+		icon: {
+			type: [ String, Object ],
+			default: ''
+		},
+		showThumbnail: {
+			type: Boolean,
+			default: false
+		},
+		thumbnail: {
+			type: [ Object, null ],
+			default: null
+		},
+		description: {
+			type: [ String, null ],
+			default: ''
+		},
+		searchQuery: {
+			type: String,
+			default: ''
+		}
+	},
+	emits: [
+		'change'
+	],
+	setup( props, { emit } ) {
+		const onMouseMove = () => {
+			if ( !props.highlighted ) {
+				emit( 'change', 'highlighted', true );
+			}
+		};
+
+		const onMouseLeave = () => {
+			emit( 'change', 'highlighted', false );
+		};
+
+		const onMouseDown = ( e ) => {
+			if ( e.button === 0 ) {
+				emit( 'change', 'active', true );
+			}
+		};
+
+		const rootClasses = computed( () => ( {
+			'citizen-command-palette-list-item--active': props.active && props.highlighted,
+			'citizen-command-palette-list-item--highlighted': props.highlighted
+		} ) );
+
+		return {
+			onMouseMove,
+			onMouseLeave,
+			onMouseDown,
+			rootClasses
+		};
+	}
+} );
+</script>
+
+<style lang="less">
+.citizen-command-palette-list-item {
+	list-style: none;
+	position: relative;
+
+	&__content {
+		padding: var( --space-xs ) var( --citizen-command-palette-side-padding );
+		display: flex;
+		align-items: center;
+		text-decoration: none;
+		column-gap: var(--space-sm);
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	&__text {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+
+		&__label,
+		&__description {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		&__label {
+			color: var( --color-emphasized );
+			font-weight: var( --font-weight-semi-bold );
+
+			.cdx-search-result-title {
+				/* So that text-overflow works */
+				display: inline;
+
+				&__match {
+					color: var( --color-subtle );
+				}
+			}
+		}
+
+		&__description {
+			color: var( --color-subtle );
+			font-size: var( --font-size-small );
+		}
+	}
+
+	&--highlighted {
+		background-color: var( --background-color-interactive-subtle--hover );
+		cursor: pointer;
+	}
+
+	&--active {
+		background-color: var( --background-color-interactive-subtle--active );
+	}
+}
+</style>

--- a/resources/skins.citizen.commandPalette/fetch.js
+++ b/resources/skins.citizen.commandPalette/fetch.js
@@ -1,3 +1,4 @@
+/* eslint-disable compat/compat */
 /*
  * Adapted from Vector
  * All credits go to the developers behind Vector

--- a/resources/skins.citizen.commandPalette/fetch.js
+++ b/resources/skins.citizen.commandPalette/fetch.js
@@ -1,0 +1,57 @@
+/*
+ * Adapted from Vector
+ * All credits go to the developers behind Vector
+ * @see https://github.com/wikimedia/mediawiki-skins-Vector/blob/master/resources/skins.vector.search/fetch.js
+*/
+
+/**
+ * @typedef {Object} AbortableFetch
+ * @property {Promise<any>} fetch
+ * @property {Function} abort
+ */
+
+/**
+ * @typedef {Object} NullableAbortController
+ * @property {AbortSignal | undefined} signal
+ * @property {Function} abort
+ */
+const nullAbortController = {
+	signal: undefined,
+	abort: () => {} // Do nothing (no-op)
+};
+
+/**
+ * A wrapper which combines native fetch() in browsers and the following json() call.
+ *
+ * @param {string} resource
+ * @param {RequestInit} [init]
+ * @return {AbortableFetch}
+ */
+function fetchJson( resource, init ) {
+	// As of 2020, browser support for AbortController is limited:
+	// https://caniuse.com/abortcontroller
+	// so replacing it with no-op if it doesn't exist.
+	const controller = window.AbortController ?
+		new AbortController() :
+		nullAbortController;
+
+	const getJson = fetch( resource, Object.assign( {}, init, {
+		signal: controller.signal
+	} ) ).then( ( response ) => {
+		if ( !response.ok ) {
+			return Promise.reject(
+				'Network request failed with HTTP code ' + response.status
+			);
+		}
+		return response.json();
+	} );
+
+	return {
+		fetch: getJson,
+		abort: () => {
+			controller.abort();
+		}
+	};
+}
+
+module.exports = fetchJson;

--- a/resources/skins.citizen.commandPalette/fetch.js
+++ b/resources/skins.citizen.commandPalette/fetch.js
@@ -39,9 +39,7 @@ function fetchJson( resource, init ) {
 		signal: controller.signal
 	} ) ).then( ( response ) => {
 		if ( !response.ok ) {
-			return Promise.reject(
-				'Network request failed with HTTP code ' + response.status
-			);
+			throw new Error( 'Network request failed with HTTP code ' + response.status );
 		}
 		return response.json();
 	} );

--- a/resources/skins.citizen.commandPalette/init.js
+++ b/resources/skins.citizen.commandPalette/init.js
@@ -1,0 +1,23 @@
+const
+	Vue = require( 'vue' ),
+	App = require( './components/App.vue' );
+
+function initApp() {
+	const teleportTarget = require( 'mediawiki.page.ready' ).teleportTarget;
+
+	const app = Vue.createMwApp( App );
+	const commandPalette = app.mount( teleportTarget );
+
+	console.log( '[skins.citizen.commandPalette] Command palette initialized' );
+
+	// Add keyboard shortcut (Cmd/Ctrl + K)
+	// TODO: Placeholder entry point, this should replace the slash search shortcut
+	document.addEventListener( 'keydown', ( event ) => {
+		if ( ( event.metaKey || event.ctrlKey ) && event.key === 'k' ) {
+			event.preventDefault();
+			commandPalette.open();
+		}
+	} );
+}
+
+initApp();

--- a/resources/skins.citizen.commandPalette/init.js
+++ b/resources/skins.citizen.commandPalette/init.js
@@ -1,23 +1,88 @@
 const
 	Vue = require( 'vue' ),
-	App = require( './components/App.vue' );
+	App = require( './components/App.vue' ),
+	config = require( './config.json' );
 
+/**
+ * Initialize the command palette
+ *
+ * @return {void}
+ */
 function initApp() {
 	const teleportTarget = require( 'mediawiki.page.ready' ).teleportTarget;
 
-	const app = Vue.createMwApp( App );
+	const app = Vue.createMwApp( App, {}, config );
 	const commandPalette = app.mount( teleportTarget );
 
-	console.log( '[skins.citizen.commandPalette] Command palette initialized' );
+	registerButton( commandPalette );
+	bindOpenOnSlash( commandPalette );
+}
 
-	// Add keyboard shortcut (Cmd/Ctrl + K)
-	// TODO: Placeholder entry point, this should replace the slash search shortcut
-	document.addEventListener( 'keydown', ( event ) => {
-		if ( ( event.metaKey || event.ctrlKey ) && event.key === 'k' ) {
+/**
+ * Setup the button to open the command palette
+ * This is very hacky, but it works for now.
+ *
+ * @param {Vue} commandPalette
+ * @return {void}
+ */
+function registerButton( commandPalette ) {
+	const details = document.getElementById( 'citizen-search-details' );
+	// Remove the search card from the DOM so it won't be triggered by the button
+	document.getElementById( 'citizen-search__card' )?.remove();
+
+	details.open = false;
+	details.addEventListener( 'click', () => {
+		commandPalette.open();
+	} );
+}
+
+/**
+ * Manually toggle the details state when the keyboard button is SLASH is pressed.
+ *
+ * @param {Vue} commandPalette
+ * @return {void}
+ */
+function bindOpenOnSlash( commandPalette ) {
+	const onExpandOnSlash = ( event ) => {
+		const isKeyPressed = () => {
+			// "/" key is standard on many sites
+			if ( event.key === '/' ) {
+				return true;
+			// "Alt" + "Shift" + "F" is the MW standard key
+			// Shift key might makes F key goes capital, so we need to make it lowercase
+			} else if ( event.altKey && event.shiftKey && event.key.toLowerCase() === 'f' ) {
+				return true;
+			} else {
+				return false;
+			}
+		};
+		if ( isKeyPressed() && !isFormField( event.target ) ) {
+			// Since Firefox quickfind interfere with this
 			event.preventDefault();
 			commandPalette.open();
 		}
-	} );
+	};
+
+	document.addEventListener( 'keydown', onExpandOnSlash, true );
+}
+
+/**
+ * Check if the element is a HTML form element or content editable
+ * This is to prevent trigger search box when user is typing on a textfield, input, etc.
+ *
+ * @param {HTMLElement} element
+ * @return {boolean}
+ */
+function isFormField( element ) {
+	if ( !( element instanceof HTMLElement ) ) {
+		return false;
+	}
+	const name = element.nodeName.toLowerCase();
+	const type = ( element.getAttribute( 'type' ) || '' ).toLowerCase();
+	return ( name === 'select' ||
+        name === 'textarea' ||
+        ( name === 'input' && type !== 'submit' && type !== 'reset' && type !== 'checkbox' && type !== 'radio' ) ||
+        element.isContentEditable );
 }
 
 initApp();

--- a/resources/skins.citizen.commandPalette/searchClients/ISearchClient.js
+++ b/resources/skins.citizen.commandPalette/searchClients/ISearchClient.js
@@ -7,7 +7,7 @@
 /**
  * Search for pages by title
  *
- * @function ISearchClient#fetchByQuery
+ * @method ISearchClient#fetchByQuery
  * @param {string} query The search term
  * @param {number} [limit] Maximum number of results
  * @param {boolean} [showDescription] Whether to show descriptions
@@ -17,7 +17,7 @@
 /**
  * Load more search results
  *
- * @function ISearchClient#loadMore
+ * @method ISearchClient#loadMore
  * @param {string} query The search term
  * @param {number} offset The number of search results that were already loaded
  * @param {number} [limit] How many further search results to load

--- a/resources/skins.citizen.commandPalette/searchClients/ISearchClient.js
+++ b/resources/skins.citizen.commandPalette/searchClients/ISearchClient.js
@@ -1,0 +1,25 @@
+/**
+ * Interface for search clients
+ *
+ * @interface ISearchClient
+ */
+
+/**
+ * Search for pages by title
+ *
+ * @function ISearchClient#fetchByQuery
+ * @param {string} query The search term
+ * @param {number} [limit] Maximum number of results
+ * @param {boolean} [showDescription] Whether to show descriptions
+ * @return {AbortableSearchFetch}
+ */
+
+/**
+ * Load more search results
+ *
+ * @function ISearchClient#loadMore
+ * @param {string} query The search term
+ * @param {number} offset The number of search results that were already loaded
+ * @param {number} [limit] How many further search results to load
+ * @return {AbortableSearchFetch}
+ */

--- a/resources/skins.citizen.commandPalette/searchClients/MwRestSearchClient.js
+++ b/resources/skins.citizen.commandPalette/searchClients/MwRestSearchClient.js
@@ -1,0 +1,129 @@
+/**
+ * REST API search client implementation
+ *
+ * @module MwRestSearchClient
+ */
+
+const fetchJson = require( '../fetch.js' );
+const urlGenerator = require( '../urlGenerator.js' );
+
+/**
+ * @typedef {Object} RestResponse
+ * @property {RestResult[]} pages
+ */
+
+/**
+ * @typedef {Object} RestResult
+ * @property {number} id
+ * @property {string} key
+ * @property {string} title
+ * @property {string | null } matched_title
+ * @property {string} [description]
+ * @property {RestThumbnail | null} [thumbnail]
+ */
+
+/**
+ * @typedef {Object} RestThumbnail
+ * @property {string} url
+ * @property {number | null} [width]
+ * @property {number | null} [height]
+ */
+
+/**
+ * @class
+ * @implements {ISearchClient}
+ */
+class MwRestSearchClient {
+	/**
+	 * @param {MwMap} config
+	 */
+	constructor( config ) {
+		this.config = config;
+		this.urlGenerator = urlGenerator( config );
+	}
+
+	/**
+	 * Adapts the REST API response to the SearchResponse format
+	 *
+	 * @private
+	 * @param {string} query
+	 * @param {RestResponse} response
+	 * @param {boolean} showDescription
+	 * @return {SearchResponse}
+	 */
+	adaptApiResponse( query, response, showDescription ) {
+		return {
+			query,
+			results: response.pages.map( ( page ) => {
+				const thumbnail = page.thumbnail;
+				return {
+					id: page.id,
+					label: page.matched_title || page.title,
+					key: page.key,
+					title: page.title,
+					description: showDescription ? page.description : undefined,
+					url: this.urlGenerator.generateUrl( page ),
+					thumbnail: thumbnail ? {
+						url: thumbnail.url,
+						width: thumbnail.width ?? undefined,
+						height: thumbnail.height ?? undefined
+					} : undefined
+				};
+			} )
+		};
+	}
+
+	/**
+	 * @override
+	 * @param {string} query The search term
+	 * @param {number} [limit=10] Maximum number of results
+	 * @param {boolean} [showDescription=true] Whether to show descriptions
+	 * @return {AbortableSearchFetch}
+	 */
+	fetchByQuery( query, limit = 10, showDescription = true ) {
+		const searchApiUrl = this.config.get( 'wgScriptPath' ) + '/rest.php';
+		const params = { q: query, limit: limit.toString() };
+		const search = new URLSearchParams( params );
+		const url = `${ searchApiUrl }/v1/search/title?${ search.toString() }`;
+		const result = fetchJson( url, {
+			headers: {
+				accept: 'application/json'
+			}
+		} );
+
+		const searchResponsePromise = result.fetch.then( ( /** @type {RestResponse} */ res ) => this.adaptApiResponse( query, res, showDescription ) );
+
+		return {
+			abort: result.abort,
+			fetch: searchResponsePromise
+		};
+	}
+
+	/**
+	 * @override
+	 * @param {string} query The search term
+	 * @param {number} offset The number of search results that were already loaded
+	 * @param {number} [limit=10] How many further search results to load
+	 * @return {AbortableSearchFetch}
+	 */
+	loadMore( query, offset, limit = 10 ) {
+		const searchApiUrl = this.config.get( 'wgScriptPath' ) + '/rest.php';
+		const params = { q: query, limit: limit.toString(), offset: offset.toString() };
+		const search = new URLSearchParams( params );
+		const url = `${ searchApiUrl }/v1/search/title?${ search.toString() }`;
+		const result = fetchJson( url, {
+			headers: {
+				accept: 'application/json'
+			}
+		} );
+
+		const searchResponsePromise = result.fetch.then( ( /** @type {RestResponse} */ res ) => this.adaptApiResponse( query, res, true ) );
+
+		return {
+			abort: result.abort,
+			fetch: searchResponsePromise
+		};
+	}
+}
+
+module.exports = MwRestSearchClient;

--- a/resources/skins.citizen.commandPalette/searchClients/SearchClientFactory.js
+++ b/resources/skins.citizen.commandPalette/searchClients/SearchClientFactory.js
@@ -1,0 +1,28 @@
+/**
+ * Factory for creating search clients
+ *
+ * @module SearchClientFactory
+ */
+
+const MwRestSearchClient = require( './MwRestSearchClient.js' );
+
+/**
+ * Factory function to create search clients
+ *
+ * @param {string} type Type of search client to create
+ * @param {MwMap} config
+ * @return {ISearchClient}
+ */
+function createSearchClient( type, config ) {
+	switch ( type ) {
+		case 'rest':
+			return new MwRestSearchClient( config );
+		// Add more search client types here
+		default:
+			throw new Error( `Unknown search client type: ${ type }` );
+	}
+}
+
+module.exports = {
+	createSearchClient
+};

--- a/resources/skins.citizen.commandPalette/searchService.js
+++ b/resources/skins.citizen.commandPalette/searchService.js
@@ -1,0 +1,45 @@
+/**
+ * Search service that manages search clients
+ *
+ * @module searchService
+ */
+
+const SearchClientFactory = require( './searchClients/SearchClientFactory.js' );
+
+/**
+ * Create a search service instance
+ *
+ * @param {MwMap} config MediaWiki configuration
+ * @return {Object} Search service instance
+ */
+function createSearchService( config ) {
+	const searchClient = SearchClientFactory.createSearchClient( 'rest', config );
+
+	/**
+	 * Search for pages by title
+	 *
+	 * @param {string} query Search query
+	 * @param {number} [limit=10] Maximum number of results
+	 * @return {Promise<SearchResponse>} Search results
+	 */
+	// eslint-disable-next-line es-x/no-async-functions
+	async function search( query, limit = 10 ) {
+		const { fetch } = searchClient.fetchByQuery( query, limit );
+		try {
+			const response = await fetch;
+			return response.results;
+		} catch ( error ) {
+			if ( error.name === 'AbortError' ) {
+				// Search was aborted, ignore
+				return [];
+			}
+			throw error;
+		}
+	}
+
+	return {
+		search
+	};
+}
+
+module.exports = createSearchService;

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -1,0 +1,70 @@
+/**
+ * @typedef {Object} SearchResult
+ * @property {number} id
+ * @property {string} label
+ * @property {string} [description]
+ * @property {SearchThumbnail} [thumbnail]
+ * @property {string} url
+ * @property {string} [title]
+ * @property {string} [fragment]
+ */
+
+/**
+ * @typedef {Object} SearchThumbnail
+ * @property {string} url
+ * @property {number} [width]
+ * @property {number} [height]
+ */
+
+/**
+ * @typedef {Object} SearchResponse
+ * @property {string} query
+ * @property {SearchResult[]} results
+ */
+
+/**
+ * @typedef {Object} SearchResultsGroup
+ * @property {string} heading
+ * @property {SearchResult[]} items
+ * @property {boolean} showThumbnail
+ */
+
+/**
+ * @typedef {Object} SearchResults
+ * @property {Object.<string, SearchResultsGroup>} [pages]
+ */
+
+/**
+ * @typedef {Object} UrlParams
+ * @property {string} [search]
+ * @property {string} [title]
+ * @property {string} [fulltext]
+ */
+
+/**
+ * @typedef {Object} AbortableFetch
+ * @property {Promise<any>} fetch
+ * @property {Function} abort
+ */
+
+/**
+ * @typedef {Object} SearchClient
+ * @property {Function} fetchByQuery
+ * @property {Function} [loadMore]
+ */
+
+/**
+ * @typedef {Object} SearchService
+ * @property {Function} search
+ */
+
+/**
+ * @typedef {Object} UrlGenerator
+ * @property {Function} generateUrl
+ */
+
+/**
+ * @typedef {Object} AbortableSearchFetch
+ * @property {Promise<SearchResponse>} fetch
+ * @property {Function} abort
+ */

--- a/resources/skins.citizen.commandPalette/urlGenerator.js
+++ b/resources/skins.citizen.commandPalette/urlGenerator.js
@@ -1,0 +1,59 @@
+/*
+ * Adapted from Vector
+ * All credits go to the developers behind Vector
+ * @see https://github.com/wikimedia/mediawiki-skins-Vector/blob/master/resources/skins.vector.search/urlGenerator.js
+*/
+
+/**
+ * @typedef {Record<string,string>} UrlParams
+ * @param {string} title
+ * @param {string} fulltext
+ */
+
+/**
+ * @callback generateUrl
+ * @param {SearchResult|string} page
+ * @param {UrlParams} [params]
+ * @return {string}
+ */
+
+/**
+ * @typedef {Object} UrlGenerator
+ * @property {generateUrl} generateUrl
+ */
+
+/**
+ * Generates URLs for suggestions.
+ *
+ * @return {UrlGenerator}
+ */
+function urlGenerator() {
+	return {
+		/**
+		 * @param {SearchResult|string} page
+		 * @param {UrlParams} params
+		 * @return {string}
+		 */
+		generateUrl(
+			page,
+			params = {}
+		) {
+			let title;
+			if ( !page ) {
+				title = 'Special:Search';
+			} else if ( typeof page !== 'string' ) {
+				const fragment = page.fragment;
+				title = page.title;
+				if ( fragment ) {
+					title += `#${ fragment }`;
+				}
+			} else {
+				title = page;
+			}
+			return mw.util.getUrl( title, params );
+		}
+	};
+}
+
+/** @module urlGenerator */
+module.exports = urlGenerator;

--- a/resources/skins.citizen.commandPalette/urlGenerator.js
+++ b/resources/skins.citizen.commandPalette/urlGenerator.js
@@ -31,7 +31,7 @@ function urlGenerator() {
 	return {
 		/**
 		 * @param {SearchResult|string} page
-		 * @param {UrlParams} params
+		 * @param {UrlParams} [params]
 		 * @return {string}
 		 */
 		generateUrl(

--- a/resources/skins.citizen.preferences/clientPreferences.js
+++ b/resources/skins.citizen.preferences/clientPreferences.js
@@ -71,7 +71,7 @@ function isFeatureExcluded( featureName ) {
 function getVisibleClientPreferences( config ) {
 	const active = getClientPreferences();
 	// Order should be based on key in config.json
-	return Object.keys( config ).filter( ( key ) => active.indexOf( key ) > -1 );
+	return Object.keys( config ).filter( ( key ) => active.includes( key ) );
 }
 
 /**

--- a/resources/skins.citizen.scripts/search.js
+++ b/resources/skins.citizen.scripts/search.js
@@ -194,9 +194,16 @@ function renderSearchClearButton( input ) {
  * @return {void}
  */
 function initSearch( window ) {
-	const
-		searchModule = require( './config.json' ).wgCitizenSearchModule,
-		searchBoxes = document.querySelectorAll( '.citizen-search-box' );
+	const config = require( './config.json' );
+
+	if ( config.wgCitizenEnableCommandPalette ) {
+		// Short-circuit the search module initialization,
+		// as it will be replaced by the command palette
+		mw.loader.load( 'skins.citizen.commandPalette' );
+		return;
+	}
+
+	const searchBoxes = document.querySelectorAll( '.citizen-search-box' );
 
 	if ( !searchBoxes.length ) {
 		return;
@@ -223,7 +230,7 @@ function initSearch( window ) {
 
 		renderSearchClearButton( input );
 		setLoadingIndicatorListeners( searchBox, true, renderSearchLoadingIndicator );
-		loadSearchModule( input, searchModule, () => {
+		loadSearchModule( input, config.wgCitizenSearchModule, () => {
 			setLoadingIndicatorListeners( searchBox, false, renderSearchLoadingIndicator );
 		} );
 	} );

--- a/resources/skins.citizen.scripts/skin.js
+++ b/resources/skins.citizen.scripts/skin.js
@@ -93,10 +93,6 @@ function main( window ) {
 		mw.loader.load( 'skins.citizen.preferences' );
 	}
 
-	// Enable command palette
-	// TODO: Replace the search module with the command palette
-	mw.loader.load( 'skins.citizen.commandPalette' );
-
 	// Defer non-essential tasks
 	mw.requestIdleCallback( deferredTasks, { timeout: 3000 } );
 }

--- a/resources/skins.citizen.scripts/skin.js
+++ b/resources/skins.citizen.scripts/skin.js
@@ -93,6 +93,10 @@ function main( window ) {
 		mw.loader.load( 'skins.citizen.preferences' );
 	}
 
+	// Enable command palette
+	// TODO: Replace the search module with the command palette
+	mw.loader.load( 'skins.citizen.commandPalette' );
+
 	// Defer non-essential tasks
 	mw.requestIdleCallback( deferredTasks, { timeout: 3000 } );
 }

--- a/resources/skins.citizen.scripts/tableOfContents.js
+++ b/resources/skins.citizen.scripts/tableOfContents.js
@@ -250,7 +250,7 @@ module.exports = function tableOfContents( props ) {
 		const topSection = /** @type {HTMLElement} */ ( tocSection.closest( `.${ TOP_SECTION_CLASS }` ) );
 		const toggle = topSection.querySelector( `.${ TOGGLE_CLASS }` );
 
-		if ( topSection && toggle && expandedSections.indexOf( topSection ) < 0 ) {
+		if ( topSection && toggle && !expandedSections.includes( topSection ) ) {
 			toggle.setAttribute( 'aria-expanded', 'true' );
 			topSection.classList.add( EXPANDED_SECTION_CLASS );
 			expandedSections.push( topSection );
@@ -300,7 +300,7 @@ module.exports = function tableOfContents( props ) {
 	function collapseSections( selectedIds ) {
 		const sectionIdsToCollapse = selectedIds || getExpandedSectionIds();
 		expandedSections = expandedSections.filter( ( section ) => {
-			const isSelected = sectionIdsToCollapse.indexOf( section.id ) > -1;
+			const isSelected = sectionIdsToCollapse.includes( section.id );
 			const toggle = isSelected ? section.getElementsByClassName( TOGGLE_CLASS ) : undefined;
 			if ( isSelected && toggle && toggle.length > 0 ) {
 				toggle[ 0 ].setAttribute( 'aria-expanded', 'false' );

--- a/resources/skins.citizen.search/fetch.js
+++ b/resources/skins.citizen.search/fetch.js
@@ -39,9 +39,7 @@ function fetchJson( resource, init ) {
 		signal: controller.signal
 	} ) ).then( ( response ) => {
 		if ( !response.ok ) {
-			return Promise.reject(
-				'Network request failed with HTTP code ' + response.status
-			);
+			throw new Error( 'Network request failed with HTTP code ' + response.status );
 		}
 		return response.json();
 	} );

--- a/resources/skins.citizen.styles/tokens-codex.less
+++ b/resources/skins.citizen.styles/tokens-codex.less
@@ -132,8 +132,8 @@
 	//--color-icon-notice: #72777d;
 	//--mix-blend-mode-base: normal;
 	//--mix-blend-mode-blend: multiply;
-	//--background-color-interactive--hover: #dadde3;
-	//--background-color-interactive--active: #c8ccd1;
+	--background-color-interactive--hover: var( --color-surface-2--hover );
+	--background-color-interactive--active: var( --color-surface-2--active );
 	//--background-color-progressive-subtle--hover: #dce3f9;
 	//--background-color-progressive-subtle--active: #cbd6f6;
 	//--background-color-destructive-subtle--hover: #ffdad3;
@@ -145,6 +145,9 @@
 	//--border-color-error--active: #612419;
 	--color-link-red--visited--hover: var( --color-destructive--visited--hover );
 	--color-link-red--visited--active: var( --color-destructive--visited--active );
+
+	--background-color-interactive-subtle--hover: var( --color-surface-1--hover );
+	--background-color-interactive-subtle--active: var( --color-surface-1--active );
 
 	/* Fallback for browsers that do not support OKLCH */
 	@supports not ( color: oklch( 100% 0 0 ) ) {

--- a/resources/skins.citizen.styles/tokens-theme-base.less
+++ b/resources/skins.citizen.styles/tokens-theme-base.less
@@ -31,6 +31,8 @@
 
 	--color-surface-0: ~'oklch( var( --color-surface-0-oklch__l ) var( --color-surface-0-oklch__c ) var( --color-progressive-oklch__h ) )';
 	--color-surface-1: ~'oklch( var( --color-surface-1-oklch__l ) var( --color-surface-1-oklch__c ) var( --color-progressive-oklch__h ) )';
+	--color-surface-1--hover: ~'oklch( calc( var( --color-surface-1-oklch__l ) + var( --delta-lightness-hover-state ) ) var( --color-surface-1-oklch__c ) var( --color-progressive-oklch__h ) )';
+	--color-surface-1--active: ~'oklch( calc( var( --color-surface-1-oklch__l ) + var( --delta-lightness-active-state ) ) var( --color-surface-1-oklch__c ) var( --color-progressive-oklch__h ) )';
 	--color-surface-2: ~'oklch( var( --color-surface-2-oklch__l ) var( --color-surface-2-oklch__c ) var( --color-progressive-oklch__h ) )';
 	--color-surface-2--hover: ~'oklch( calc( var( --color-surface-2-oklch__l ) + var( --delta-lightness-hover-state ) ) var( --color-surface-2-oklch__c ) var( --color-progressive-oklch__h ) )';
 	--color-surface-2--active: ~'oklch( calc( var( --color-surface-2-oklch__l ) + var( --delta-lightness-active-state ) ) var( --color-surface-2-oklch__c ) var( --color-progressive-oklch__h ) )';

--- a/resources/skins.citizen.styles/tokens-theme-base.less
+++ b/resources/skins.citizen.styles/tokens-theme-base.less
@@ -131,6 +131,8 @@
 	@supports not ( color: oklch( 100% 0 0 ) ) {
 		--color-surface-0: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-0-hsl__s ), var( --color-surface-0-hsl__l ) )';
 		--color-surface-1: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-1-hsl__s ), var( --color-surface-1-hsl__l ) )';
+		--color-surface-1--hover: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-1-hsl__s ), calc( var( --color-surface-1-hsl__l ) + var( --delta-lightness-hover-state ) ) )';
+		--color-surface-1--active: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-1-hsl__s ), calc( var( --color-surface-1-hsl__l ) + var( --delta-lightness-active-state ) ) )';
 		--color-surface-2: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-2-hsl__s ), var( --color-surface-2-hsl__l ) )';
 		--color-surface-2--hover: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-2-hsl__s ), calc( var( --color-surface-2-hsl__l ) + var( --delta-lightness-hover-state ) ) )';
 		--color-surface-2--active: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-2-hsl__s ), calc( var( --color-surface-2-hsl__l ) + var( --delta-lightness-active-state ) ) )';

--- a/skin.json
+++ b/skin.json
@@ -362,6 +362,38 @@
 				"watchlist",
 				"wikiText"
 			]
+		},
+		"skins.citizen.commandPalette": {
+			"class": "MediaWiki\\ResourceLoader\\CodexModule",
+			"dependencies": [
+				"vue",
+				"mediawiki.page.ready",
+				"skins.citizen.commandPalette.codex"
+			],
+			"packageFiles": [
+				"resources/skins.citizen.commandPalette/init.js",
+				"resources/skins.citizen.commandPalette/fetch.js",
+				"resources/skins.citizen.commandPalette/urlGenerator.js",
+				"resources/skins.citizen.commandPalette/components/App.vue",
+				"resources/skins.citizen.commandPalette/components/CommandPaletteList.vue",
+				"resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue",
+				{
+					"name": "resources/skins.citizen.commandPalette/icons.json",
+					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",
+					"callbackParam": [
+						"cdxIconSearch"
+					]
+				}
+			]
+		},
+		"skins.citizen.commandPalette.codex": {
+			"class": "MediaWiki\\ResourceLoader\\CodexModule",
+			"codexComponents": [
+				"CdxIcon",
+				"CdxSearchResultTitle",
+				"CdxTextInput",
+				"CdxThumbnail"
+			]
 		}
 	},
 	"ResourceFileModulePaths": {

--- a/skin.json
+++ b/skin.json
@@ -294,6 +294,49 @@
 				"resources/skins.citizen.serviceWorker/sw.js"
 			]
 		},
+		"skins.citizen.commandPalette": {
+			"class": "MediaWiki\\ResourceLoader\\CodexModule",
+			"dependencies": [
+				"vue",
+				"mediawiki.page.ready",
+				"skins.citizen.commandPalette.codex"
+			],
+			"packageFiles": [
+				"resources/skins.citizen.commandPalette/init.js",
+				"resources/skins.citizen.commandPalette/fetch.js",
+				"resources/skins.citizen.commandPalette/searchService.js",
+				"resources/skins.citizen.commandPalette/urlGenerator.js",
+				"resources/skins.citizen.commandPalette/searchClients/SearchClientFactory.js",
+				"resources/skins.citizen.commandPalette/searchClients/MwRestSearchClient.js",
+				"resources/skins.citizen.commandPalette/components/App.vue",
+				"resources/skins.citizen.commandPalette/components/CommandPaletteList.vue",
+				"resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue",
+				{
+					"name": "resources/skins.citizen.commandPalette/icons.json",
+					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",
+					"callbackParam": [
+						"cdxIconSearch"
+					]
+				},
+				{
+					"name": "resources/skins.citizen.commandPalette/config.json",
+					"callback": "MediaWiki\\Skins\\Citizen\\Hooks\\ResourceLoaderHooks::getCitizenCommandPaletteResourceLoaderConfig"
+				}
+			],
+			"messages": [
+				"searchsuggest-search",
+				"search-nonefound"
+			]
+		},
+		"skins.citizen.commandPalette.codex": {
+			"class": "MediaWiki\\ResourceLoader\\CodexModule",
+			"codexComponents": [
+				"CdxIcon",
+				"CdxSearchResultTitle",
+				"CdxTextInput",
+				"CdxThumbnail"
+			]
+		},
 		"skins.citizen.icons": {
 			"selectorWithoutVariant": ".mw-ui-icon-wikimedia-{name}:before",
 			"useDataURI": false,
@@ -361,38 +404,6 @@
 				"userTalk",
 				"watchlist",
 				"wikiText"
-			]
-		},
-		"skins.citizen.commandPalette": {
-			"class": "MediaWiki\\ResourceLoader\\CodexModule",
-			"dependencies": [
-				"vue",
-				"mediawiki.page.ready",
-				"skins.citizen.commandPalette.codex"
-			],
-			"packageFiles": [
-				"resources/skins.citizen.commandPalette/init.js",
-				"resources/skins.citizen.commandPalette/fetch.js",
-				"resources/skins.citizen.commandPalette/urlGenerator.js",
-				"resources/skins.citizen.commandPalette/components/App.vue",
-				"resources/skins.citizen.commandPalette/components/CommandPaletteList.vue",
-				"resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue",
-				{
-					"name": "resources/skins.citizen.commandPalette/icons.json",
-					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",
-					"callbackParam": [
-						"cdxIconSearch"
-					]
-				}
-			]
-		},
-		"skins.citizen.commandPalette.codex": {
-			"class": "MediaWiki\\ResourceLoader\\CodexModule",
-			"codexComponents": [
-				"CdxIcon",
-				"CdxSearchResultTitle",
-				"CdxTextInput",
-				"CdxThumbnail"
 			]
 		}
 	},
@@ -774,6 +785,12 @@
 		"TableOfContentsCollapseAtCount": {
 			"value": 28,
 			"description": "@var The minimum number of headings required to collapse all headings in the sticky table of contents by default."
+		},
+		"EnableCommandPalette": {
+			"value": false,
+			"description": "[EXPERIMENTAL] Enables or disable the command palette. Command palette is in active development and may not work as expected.",
+			"descriptionmsg": "citizen-config-enablecommandpalette",
+			"public": true
 		}
 	},
 	"manifest_version": 2

--- a/tests/phpunit/integration/Hooks/ResourceLoaderHooksTest.php
+++ b/tests/phpunit/integration/Hooks/ResourceLoaderHooksTest.php
@@ -7,6 +7,7 @@ namespace MediaWiki\Skins\Citizen\Tests\Integration\Hooks;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\Skins\Citizen\Hooks\ResourceLoaderHooks;
 use MediaWikiIntegrationTestCase;
+use MediaWiki\MainConfigNames;
 
 /**
  * @group Citizen
@@ -22,6 +23,7 @@ class ResourceLoaderHooksTest extends MediaWikiIntegrationTestCase {
 			'CitizenOverflowInheritedClasses' => false,
 			'CitizenOverflowNowrapClasses' => false,
 			'CitizenSearchModule' => false,
+			'CitizenEnableCommandPalette' => false,
 		] );
 
 		$rlCtxMock = $this->getMockBuilder( Context::class )->disableOriginalConstructor()->getMock();
@@ -36,33 +38,7 @@ class ResourceLoaderHooksTest extends MediaWikiIntegrationTestCase {
 			'wgCitizenSearchModule' => false,
 			'wgCitizenOverflowInheritedClasses' => false,
 			'wgCitizenOverflowNowrapClasses' => false,
-		], $config );
-	}
-
-	/**
-	 * @covers \MediaWiki\Skins\Citizen\Hooks\ResourceLoaderHooks
-	 * @return void
-	 */
-	public function testCitizenResourceLoaderConfigAllTrue() {
-		$this->overrideConfigValues( [
-			'CitizenEnablePreferences' => true,
-			'CitizenOverflowInheritedClasses' => true,
-			'CitizenOverflowNowrapClasses' => true,
-			'CitizenSearchModule' => true,
-		] );
-
-		$rlCtxMock = $this->getMockBuilder( Context::class )->disableOriginalConstructor()->getMock();
-
-		$config = ResourceLoaderHooks::getCitizenResourceLoaderConfig(
-			$rlCtxMock,
-			$this->getServiceContainer()->getMainConfig()
-		);
-
-		$this->assertArraySubmapSame( [
-			'wgCitizenEnablePreferences' => true,
-			'wgCitizenOverflowInheritedClasses' => true,
-			'wgCitizenOverflowNowrapClasses' => true,
-			'wgCitizenSearchModule' => true,
+			'wgCitizenEnableCommandPalette' => false,
 		], $config );
 	}
 
@@ -93,12 +69,11 @@ class ResourceLoaderHooksTest extends MediaWikiIntegrationTestCase {
 	 */
 	public function testCitizenSearchResourceLoaderConfig() {
 		$this->overrideConfigValues( [
-			'CitizenSearchGateway' => 'CitizenSearchGateway',
-			'CitizenSearchDescriptionSource' => 'CitizenSearchDescriptionSource',
-			'CitizenMaxSearchResults' => 'CitizenMaxSearchResults',
-			'Script' => 'Script',
-			'ScriptPath' => 'ScriptPath',
-			'SearchSuggestCacheExpiry' => 'SearchSuggestCacheExpiry',
+			'CitizenSearchGateway' => 'mwRestApi',
+			'CitizenSearchDescriptionSource' => 'textextracts',
+			'CitizenMaxSearchResults' => 10,
+			MainConfigNames::ScriptPath => 'ScriptPath',
+			MainConfigNames::SearchSuggestCacheExpiry => 'SearchSuggestCacheExpiry'
 		] );
 
 		$rlCtxMock = $this->getMockBuilder( Context::class )->disableOriginalConstructor()->getMock();
@@ -109,12 +84,13 @@ class ResourceLoaderHooksTest extends MediaWikiIntegrationTestCase {
 		);
 
 		$this->assertArraySubmapSame( [
-			'wgCitizenSearchGateway' => 'CitizenSearchGateway',
-			'wgCitizenSearchDescriptionSource' => 'CitizenSearchDescriptionSource',
-			'wgCitizenMaxSearchResults' => 'CitizenMaxSearchResults',
-			'wgScript' => 'Script',
-			'wgScriptPath' => 'ScriptPath',
+			'isAdvancedSearchExtensionEnabled' => false,
 			'isMediaSearchExtensionEnabled' => false,
+			'wgCitizenSearchGateway' => 'mwRestApi',
+			'wgCitizenSearchDescriptionSource' => 'textextracts',
+			'wgCitizenMaxSearchResults' => 10,
+			'wgScriptPath' => 'ScriptPath',
+			'wgSearchSuggestCacheExpiry' => 'SearchSuggestCacheExpiry'
 		], $config );
 	}
 }


### PR DESCRIPTION
Start implementing the Command Palette feature that will replace the search typeahead in the future.
This is barebone, experimental, and currently does not have feature parity with the current search.
To enable the feature, set `$wgCitizenEnableCommandPalette` to `true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an experimental command palette that offers keyboard navigation and real-time search results.
	- Added configuration options allowing users to enable or disable the command palette, enhancing the search experience.
- **Documentation**
	- Expanded the user guide with a new "Development" section describing the experimental command palette feature.
- **Refactor & Style**
	- Improved workflows to retrieve complete project history.
	- Streamlined code for clearer array checks and updated interactive color tokens for a more consistent visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->