### PR TITLE
Various cleanups to CommandPalette

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -252,7 +252,6 @@ module.exports = exports = defineComponent( {
 			cdxIconArticleNotFound,
 			hasHighlightedItemWithActions,
 			isActionButtonFocused,
-			firstActionButtonOfHighlightedItem,
 			focusItem,
 			focusInput
 		};

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
@@ -175,7 +175,6 @@ module.exports = exports = defineComponent( {
 			let handled = false;
 			switch ( e.key ) {
 				case 'Enter':
-				case ' ': // Allow space to select as well
 					onClick();
 					handled = true;
 					break;

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
@@ -45,8 +45,6 @@ const { defineComponent, computed, ref } = require( 'vue' );
 // Import the new sub-components
 const CommandPaletteListItemContent = require( './CommandPaletteListItemContent.vue' );
 const CommandPaletteListItemActions = require( './CommandPaletteListItemActions.vue' );
-// Note: Cdx components are now only needed in sub-components, so mw.loader.require is removed here.
-// Note: useActionNavigation is now only used in CommandPaletteListItemActions.
 
 // @vue/component
 module.exports = exports = defineComponent( {
@@ -114,12 +112,12 @@ module.exports = exports = defineComponent( {
 		'change',
 		'select',
 		'action',
-		'focus-input', // Still potentially needed from actions sub-component? Check useActionNavigation emits
-		'navigate-list' // Still potentially needed from actions sub-component? Check useActionNavigation emits
+		'focus-input',
+		'navigate-list'
 	],
 	setup( props, { emit, expose } ) {
 		const rootRef = ref( null );
-		const actionsRef = ref( null ); // Ref for the actions sub-component
+		const actionsRef = ref( null );
 
 		// --- Item Interaction Logic ---
 		const onMouseMove = () => {
@@ -139,7 +137,6 @@ module.exports = exports = defineComponent( {
 		};
 
 		const onClick = () => {
-			// Emit the full item data on select
 			emit( 'select', {
 				id: props.id,
 				label: props.label,
@@ -170,10 +167,6 @@ module.exports = exports = defineComponent( {
 
 		// --- Keydown Handling ---
 		const onKeydown = ( e ) => {
-			// Keydown logic is now simplified:
-			// - Action button navigation (Arrows, Home, End, Tab) is handled *within* CommandPaletteListItemActions
-			// - We only need to handle Enter/Space on the list item itself for selection.
-
 			// Only handle keys if the event target is the list item itself
 			if ( e.target !== rootRef.value ) {
 				return;
@@ -186,8 +179,6 @@ module.exports = exports = defineComponent( {
 					onClick();
 					handled = true;
 					break;
-				// Arrow keys (Up/Down) are handled by the parent list for list navigation.
-				// Arrow keys (Left/Right), Home, End, Tab are potentially handled by the actions component if it has focus.
 			}
 
 			if ( handled ) {
@@ -209,9 +200,7 @@ module.exports = exports = defineComponent( {
 
 		// --- Expose Methods ---
 		expose( {
-			// Expose method to focus the list item itself
 			focus: () => rootRef.value?.focus(),
-			// Expose methods to focus buttons within the actions sub-component
 			focusFirstButton: () => actionsRef.value?.focusFirstButton(),
 			focusLastButton: () => actionsRef.value?.focusLastButton()
 		} );
@@ -230,7 +219,7 @@ module.exports = exports = defineComponent( {
 			onKeydown,
 			// Computed
 			rootClasses,
-			typeLabel // Pass computed typeLabel to content sub-component
+			typeLabel
 		};
 	}
 } );

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
@@ -1,4 +1,3 @@
-<!-- Renders and manages interactions for action buttons within a list item -->
 <template>
 	<div
 		v-if="actions && actions.length > 0"
@@ -47,15 +46,13 @@ module.exports = exports = defineComponent( {
 			type: Boolean,
 			default: false
 		},
-		// Prop to receive the parent item's ID for context in emitted events
 		itemId: {
 			type: String,
 			required: true
 		}
 	},
-	emits: [ 'action', 'focus-input', 'navigate-list' ], // Inherit necessary emits from useActionNavigation
+	emits: [ 'action', 'focus-input', 'navigate-list' ],
 	setup( props, { emit, expose } ) {
-		// eslint-disable-next-line vue/no-unused-properties -- Used internally by useActionNavigation
 		const buttonRefs = ref( {} );
 
 		// Use the composable here

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
@@ -61,7 +61,9 @@ module.exports = exports = defineComponent( {
 
 		// Reset refs before update
 		onBeforeUpdate( () => {
-			buttonRefs.value = {};
+			for ( const key in buttonRefs.value ) {
+				delete buttonRefs.value[ key ];
+			}
 		} );
 
 		const setButtonRef = ( el, actionId ) => {

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
@@ -1,0 +1,129 @@
+<!-- Renders and manages interactions for action buttons within a list item -->
+<template>
+	<div
+		v-if="actions && actions.length > 0"
+		class="citizen-command-palette-list-item__actions"
+		:class="{ 'citizen-command-palette-list-item__actions--visible': highlighted }"
+	>
+		<cdx-button
+			v-for="action in actions"
+			:key="action.id"
+			:ref="( el ) => setButtonRef( el, action.id )"
+			class="citizen-command-palette-list-item__action"
+			:aria-label="action.label"
+			weight="quiet"
+			:tabindex="-1"
+			@click.stop.prevent="onActionClick( action )"
+			@focus="onButtonFocus( action.id )"
+			@keydown="handleActionButtonKeydown"
+		>
+			<cdx-icon
+				:icon="action.icon"
+				size="small"
+				class="citizen-command-palette-list-item__action__icon"
+			></cdx-icon>
+		</cdx-button>
+	</div>
+</template>
+
+<script>
+const { defineComponent, ref, computed, onBeforeUpdate } = require( 'vue' );
+const { CdxIcon, CdxButton } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const useActionNavigation = require( '../composables/useActionNavigation.js' );
+
+// @vue/component
+module.exports = exports = defineComponent( {
+	name: 'CommandPaletteListItemActions',
+	components: {
+		CdxIcon,
+		CdxButton
+	},
+	props: {
+		actions: {
+			type: Array,
+			default: () => []
+		},
+		highlighted: {
+			type: Boolean,
+			default: false
+		},
+		// Prop to receive the parent item's ID for context in emitted events
+		itemId: {
+			type: String,
+			required: true
+		}
+	},
+	emits: [ 'action', 'focus-input', 'navigate-list' ], // Inherit necessary emits from useActionNavigation
+	setup( props, { emit, expose } ) {
+		// eslint-disable-next-line vue/no-unused-properties -- Used internally by useActionNavigation
+		const buttonRefs = ref( {} );
+
+		// Use the composable here
+		const { handleActionButtonKeydown, onButtonFocus, focusFirstButton, focusLastButton } =
+			useActionNavigation( computed( () => props.actions ), buttonRefs, emit );
+
+		// Reset refs before update
+		onBeforeUpdate( () => {
+			buttonRefs.value = {};
+		} );
+
+		const setButtonRef = ( el, actionId ) => {
+			if ( el ) {
+				buttonRefs.value[ actionId ] = el;
+			}
+		};
+
+		// Handle clicks on action buttons
+		const onActionClick = ( action ) => {
+			emit( 'action', {
+				itemId: props.itemId, // Include parent item ID
+				actionId: action.id,
+				url: action.url
+			} );
+		};
+
+		// Expose focus methods for parent component
+		expose( {
+			focusFirstButton,
+			focusLastButton
+		} );
+
+		return {
+			// buttonRefs needed by setButtonRef
+			setButtonRef,
+			onActionClick,
+			// Pass composable methods to template
+			handleActionButtonKeydown,
+			onButtonFocus
+		};
+	}
+} );
+</script>
+
+<style lang="less">
+.citizen-command-palette-list-item {
+	&__actions {
+		position: absolute;
+		inset-inline-end: var( --citizen-command-palette-side-padding );
+		display: flex;
+		gap: var( --space-xxs );
+		align-items: center;
+		height: 100%;
+		top: 0;
+		padding-left: var( --space-xl );
+		background-image: linear-gradient( to right, transparent 0%, transparent 30%, var( --actions-fade-color, inherit ) 70% );
+		opacity: 0;
+		transition: opacity var( --transition-quick );
+		pointer-events: none;
+
+		&--visible {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+
+	&__action {
+		border-radius: var( --border-radius-base );
+	}
+}
+</style>

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
@@ -1,8 +1,6 @@
 <template>
-	<a
-		:href="url"
+	<div
 		class="citizen-command-palette-list-item__content"
-		:tabindex="-1"
 	>
 		<cdx-thumbnail
 			:thumbnail="thumbnail"
@@ -12,7 +10,7 @@
 
 		<div class="citizen-command-palette-list-item__text">
 			<div class="citizen-command-palette-list-item__text__label">
-				<!-- Techinally you are not supposed to use CdxSearchResultTitle... -->
+				<!-- Technically you are not supposed to use CdxSearchResultTitle... -->
 				<cdx-search-result-title
 					:title="label"
 					:search-query="searchQuery"
@@ -57,7 +55,7 @@
 				{{ typeLabel }}
 			</div>
 		</div>
-	</a>
+	</div>
 </template>
 
 <script>
@@ -102,10 +100,6 @@ module.exports = exports = defineComponent( {
 			required: true
 		},
 		searchQuery: {
-			type: String,
-			default: ''
-		},
-		url: {
 			type: String,
 			default: ''
 		}

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
@@ -1,4 +1,3 @@
-<!-- Responsible for rendering the main display area of a list item -->
 <template>
 	<a
 		:href="url"
@@ -98,7 +97,7 @@ module.exports = exports = defineComponent( {
 			type: String,
 			required: true
 		},
-		typeLabel: { // Receive computed label from parent
+		typeLabel: {
 			type: String,
 			required: true
 		},
@@ -111,7 +110,6 @@ module.exports = exports = defineComponent( {
 			default: ''
 		}
 	}
-	// No setup needed, purely presentational based on props
 } );
 </script>
 

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
@@ -1,0 +1,187 @@
+<!-- Responsible for rendering the main display area of a list item -->
+<template>
+	<a
+		:href="url"
+		class="citizen-command-palette-list-item__content"
+		:tabindex="-1"
+	>
+		<cdx-thumbnail
+			:thumbnail="thumbnail"
+			:placeholder-icon="thumbnailIcon || undefined"
+			class="citizen-command-palette-list-item__thumbnail"
+		></cdx-thumbnail>
+
+		<div class="citizen-command-palette-list-item__text">
+			<div class="citizen-command-palette-list-item__text__label">
+				<!-- Techinally you are not supposed to use CdxSearchResultTitle... -->
+				<cdx-search-result-title
+					:title="label"
+					:search-query="searchQuery"
+				></cdx-search-result-title>
+			</div>
+			<div
+				v-if="description"
+				class="citizen-command-palette-list-item__text__description"
+			>
+				<bdi>{{ description }}</bdi>
+			</div>
+		</div>
+		<div class="citizen-command-palette-list-item__metadata">
+			<div
+				v-for="item in metadata"
+				:key="item.label"
+				class="citizen-command-palette-list-item__metadata__item"
+			>
+				<cdx-icon
+					v-if="item.icon"
+					:icon="item.icon"
+					size="small"
+					class="citizen-command-palette-list-item__metadata__item__icon"
+				></cdx-icon>
+				<cdx-search-result-title
+					v-if="item.label && item.highlightQuery"
+					class="citizen-command-palette-list-item__metadata__item__label"
+					:title="item.label"
+					:search-query="searchQuery"
+				></cdx-search-result-title>
+				<span
+					v-else
+					class="citizen-command-palette-list-item__metadata__item__label"
+				>
+					{{ item.label }}
+				</span>
+			</div>
+			<div
+				v-if="type"
+				class="citizen-command-palette-list-item__metadata__item citizen-command-palette-list-item__metadata__item--type"
+			>
+				{{ typeLabel }}
+			</div>
+		</div>
+	</a>
+</template>
+
+<script>
+const { defineComponent } = require( 'vue' );
+const { CdxIcon, CdxSearchResultTitle, CdxThumbnail } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+
+// @vue/component
+module.exports = exports = defineComponent( {
+	name: 'CommandPaletteListItemContent',
+	components: {
+		CdxIcon,
+		CdxSearchResultTitle,
+		CdxThumbnail
+	},
+	props: {
+		label: {
+			type: String,
+			required: true
+		},
+		description: {
+			type: [ String, null ],
+			default: ''
+		},
+		thumbnail: {
+			type: [ Object, null ],
+			default: null
+		},
+		thumbnailIcon: {
+			type: [ String, Object ],
+			default: ''
+		},
+		metadata: {
+			type: Array,
+			default: () => []
+		},
+		type: {
+			type: String,
+			required: true
+		},
+		typeLabel: { // Receive computed label from parent
+			type: String,
+			required: true
+		},
+		searchQuery: {
+			type: String,
+			default: ''
+		},
+		url: {
+			type: String,
+			default: ''
+		}
+	}
+	// No setup needed, purely presentational based on props
+} );
+</script>
+
+<style lang="less">
+.citizen-command-palette-list-item {
+	&__content {
+		display: flex;
+		column-gap: var( --space-sm );
+		align-items: center;
+		padding: var( --space-sm ) var( --citizen-command-palette-side-padding );
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	&__text {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+
+		&__label,
+		&__description {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		&__label {
+			font-weight: var( --font-weight-semi-bold );
+			color: var( --color-emphasized );
+
+			.cdx-search-result-title {
+				/* So that text-overflow works */
+				display: inline;
+			}
+		}
+
+		&__description {
+			font-size: var( --font-size-x-small );
+			color: var( --color-subtle );
+		}
+
+		.cdx-search-result-title {
+			font-weight: var( --font-weight-semi-bold );
+			color: var( --color-emphasized );
+
+			&__match {
+				color: var( --color-subtle );
+			}
+		}
+	}
+
+	&__metadata {
+		display: flex;
+		gap: var( --space-xxs );
+		font-size: var( --font-size-x-small );
+		color: var( --color-subtle );
+
+		&__item {
+			display: flex;
+			column-gap: var( --space-xxs );
+			align-items: center;
+			padding: var( --space-xxs ) var( --space-xs );
+			line-height: var( --line-height-xxx-small );
+			background: var( --color-surface-3 );
+			border: var( --border-subtle );
+			border-radius: var( --border-radius-base );
+		}
+	}
+}
+</style>

--- a/resources/skins.citizen.commandPalette/components/CommandPalettePresults.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPalettePresults.vue
@@ -25,7 +25,7 @@ const { defineComponent, computed } = require( 'vue' );
 const CommandPaletteList = require( './CommandPaletteList.vue' );
 const CommandPaletteEmptyState = require( './CommandPaletteEmptyState.vue' );
 const { cdxIconArticlesSearch, cdxIconTrash } = require( '../icons.json' );
-const createSearchHistory = require( '../services/searchHistory.js' );
+const createRecentItems = require( '../services/recentItems.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
@@ -54,7 +54,7 @@ module.exports = exports = defineComponent( {
 	},
 	emits: [ 'update:highlighted-item-index', 'select', 'update:recent-items', 'focus-input', 'navigate-list' ],
 	setup( props, { emit } ) {
-		const searchHistory = createSearchHistory();
+		const recentItemsService = createRecentItems();
 
 		// Add dismiss action to recent items
 		const itemsWithActions = computed( () => props.recentItems.map( ( item ) => ( {
@@ -72,7 +72,7 @@ module.exports = exports = defineComponent( {
 			if ( action.actionId === 'dismiss' ) {
 				const itemToRemove = props.recentItems.find( ( item ) => String( item.id ) === action.itemId );
 				if ( itemToRemove ) {
-					searchHistory.removeRecentItem( itemToRemove );
+					recentItemsService.removeRecentItem( itemToRemove );
 					emit( 'update:recent-items' );
 				}
 			}

--- a/resources/skins.citizen.commandPalette/providers/RecentItemsProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/RecentItemsProvider.js
@@ -1,8 +1,9 @@
-const { CommandPaletteItem } = require( '../types.js' );
+const { CommandPaletteItem, CommandPaletteProvider } = require( '../types.js' );
 const createRecentItems = require( '../services/recentItems.js' );
 
 const recentItemsService = createRecentItems();
 
+/** @type {CommandPaletteProvider} */
 module.exports = {
 	/** Whether the first result from this provider should be automatically selected */
 	shouldAutoSelectFirst: false,

--- a/resources/skins.citizen.commandPalette/providers/RecentItemsProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/RecentItemsProvider.js
@@ -1,9 +1,12 @@
 const { CommandPaletteItem } = require( '../types.js' );
-const createSearchHistory = require( '../services/searchHistory.js' );
+const createRecentItems = require( '../services/recentItems.js' );
 
-const searchHistoryService = createSearchHistory();
+const recentItemsService = createRecentItems();
 
 module.exports = {
+	/** Whether the first result from this provider should be automatically selected */
+	shouldAutoSelectFirst: false,
+
 	/**
 	 * Determines if this provider should handle the current query.
 	 *
@@ -23,6 +26,6 @@ module.exports = {
 	 * @return {Array<CommandPaletteItem>} An array of recent items.
 	 */
 	getResults() {
-		return searchHistoryService.getRecentItems();
+		return recentItemsService.getRecentItems();
 	}
 };

--- a/resources/skins.citizen.commandPalette/providers/SearchProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/SearchProvider.js
@@ -1,6 +1,7 @@
-const { CommandPaletteItem } = require( '../types.js' );
+const { CommandPaletteItem, CommandPaletteProvider } = require( '../types.js' );
 const SearchClientFactory = require( '../searchClients/SearchClientFactory.js' );
 
+/** @type {CommandPaletteProvider} */
 module.exports = {
 	/** Whether the first result from this provider should be automatically selected */
 	shouldAutoSelectFirst: false,

--- a/resources/skins.citizen.commandPalette/providers/SearchProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/SearchProvider.js
@@ -2,6 +2,9 @@ const { CommandPaletteItem } = require( '../types.js' );
 const SearchClientFactory = require( '../searchClients/SearchClientFactory.js' );
 
 module.exports = {
+	/** Whether the first result from this provider should be automatically selected */
+	shouldAutoSelectFirst: false,
+
 	/**
 	 * Determines if this provider should handle the current query.
 	 *

--- a/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
@@ -34,7 +34,13 @@ module.exports = {
 				label: handler.label ?? cmdName,
 				description: handler.description,
 				thumbnailIcon: cdxIconCode,
-				value: '/' + cmdName + ':'
+				value: `/${ cmdName }:`,
+				metadata: [
+					{
+						label: `/${ cmdName }`,
+						highlightQuery: true
+					}
+				]
 			} ) );
 		}
 

--- a/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
@@ -1,4 +1,4 @@
-const { CommandPaletteItem } = require( '../types.js' );
+const { CommandPaletteItem, CommandPaletteProvider } = require( '../types.js' );
 const { cdxIconCode } = require( '../icons.json' );
 
 // Registry for slash command handlers
@@ -36,6 +36,7 @@ function getCommandListItems( filterPrefix ) {
 	} ) );
 }
 
+/** @type {CommandPaletteProvider} */
 module.exports = {
 	/** Whether the first result from this provider should be automatically selected */
 	shouldAutoSelectFirst: true,

--- a/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
@@ -37,6 +37,9 @@ function getCommandListItems( filterPrefix ) {
 }
 
 module.exports = {
+	/** Whether the first result from this provider should be automatically selected */
+	shouldAutoSelectFirst: true,
+
 	/**
 	 * Determines if this provider should handle the current query.
 	 *

--- a/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/SlashCommandProvider.js
@@ -17,7 +17,7 @@ function getCommandListItems( filterPrefix ) {
 	let entries = Object.entries( commandRegistry );
 
 	if ( filterPrefix ) {
-		entries = entries.filter( ( [ cmdName ] ) => cmdName.startsWith( filterPrefix ) );
+		entries = entries.filter( ( [ cmdName ] ) => cmdName.toLowerCase().startsWith( filterPrefix.toLowerCase() ) );
 	}
 
 	return entries.map( ( [ cmdName, handler ] ) => ( {
@@ -77,8 +77,13 @@ module.exports = {
 				return [];
 			}
 
-			const results = await commandHandler.getResults( subQuery );
-			return Array.isArray( results ) ? results : [];
+			try {
+				const results = await commandHandler.getResults( subQuery );
+				return Array.isArray( results ) ? results : [];
+			} catch ( err ) {
+				mw.log.error( `[SlashCommandProvider] "${ commandName }" failed:`, err );
+				return [];
+			}
 		} else {
 			// If the command name doesn't match any registered command, show the list again,
 			// filtered by the typed prefix.

--- a/resources/skins.citizen.commandPalette/services/recentItems.js
+++ b/resources/skins.citizen.commandPalette/services/recentItems.js
@@ -11,7 +11,7 @@ const MAX_RECENT_ITEMS = 5;
  *
  * @return {Object} Search history service
  */
-function createSearchHistory() {
+function createRecentItems() {
 	/**
 	 * Saves an item to recent history
 	 *
@@ -88,4 +88,4 @@ function createSearchHistory() {
 	};
 }
 
-module.exports = createSearchHistory;
+module.exports = createRecentItems;

--- a/resources/skins.citizen.commandPalette/services/recentItems.js
+++ b/resources/skins.citizen.commandPalette/services/recentItems.js
@@ -1,15 +1,10 @@
-/**
- * Service for managing search history in the command palette
- */
 const { CommandPaletteItem } = require( '../types.js' );
 const { cdxIconHistory } = require( '../icons.json' );
 const RECENT_ITEMS_KEY = 'skin-citizen-command-palette-recent-items';
 const MAX_RECENT_ITEMS = 5;
 
 /**
- * Creates a search history service
- *
- * @return {Object} Search history service
+ * @return {Object} Recent items service
  */
 function createRecentItems() {
 	/**

--- a/resources/skins.citizen.commandPalette/stores/searchStore.js
+++ b/resources/skins.citizen.commandPalette/stores/searchStore.js
@@ -1,4 +1,4 @@
-const { CommandPaletteItem, CommandPaletteActionResult } = require( '../types.js' );
+const { CommandPaletteItem, CommandPaletteActionResult, CommandPaletteProvider } = require( '../types.js' );
 const { defineStore } = require( 'pinia' );
 const createRecentItems = require( '../services/recentItems.js' );
 const urlGenerator = require( '../utils/urlGenerator.js' )();
@@ -10,6 +10,7 @@ const SearchProvider = require( '../providers/SearchProvider.js' );
 const recentItemsService = createRecentItems();
 
 // List of providers in order of priority
+/** @type {Array<CommandPaletteProvider>} */
 const providers = [
 	RecentItemsProvider,
 	SlashCommandProvider,
@@ -80,6 +81,7 @@ exports.useSearchStore = defineStore( 'search', {
 			clearTimeout( this.pendingDelayTimeout );
 			// Don't reset showPending here, let _setResults handle it or the pendingDelayTimeout
 
+			/** @type {CommandPaletteProvider|undefined} */
 			const provider = providers.find( ( p ) => p.canProvide( query ) );
 
 			if ( !provider ) {

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -79,4 +79,13 @@
  * @property {number} value The namespace ID.
  */
 
+/**
+ * Defines the interface for a provider of search results for the Command Palette.
+ *
+ * @typedef {Object} CommandPaletteProvider
+ * @property {boolean} shouldAutoSelectFirst Whether the first result from this provider should be automatically selected in the list.
+ * @property {function(string): boolean} canProvide Determines if this provider should handle the given query.
+ * @property {function(string): (Array<CommandPaletteItem>|Promise<Array<CommandPaletteItem>>)} getResults Gets the results for the given query. Can be synchronous or asynchronous.
+ */
+
 module.exports = {/* Types are only used for JSDoc */};

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -49,8 +49,7 @@
  * @typedef {Object} CommandHandler
  * @property {string} label The user-facing label for the command (used in root '/' suggestions).
  * @property {string} description The user-facing description for the command (used in root '/' suggestions).
- * @property {function(string): Promise<Array<Object>>} getResults Asynchronously fetches raw suggestion data based on the sub-query.
- * @property {function(Object): CommandPaletteItem} adaptResult Synchronously transforms a single raw result object into a CommandPaletteItem.
+ * @property {function(string): Promise<Array<CommandPaletteItem>>} getResults Asynchronously fetches and adapts suggestion data based on the sub-query, returning CommandPaletteItems.
  */
 
 /**

--- a/skin.json
+++ b/skin.json
@@ -313,7 +313,7 @@
 				"resources/skins.citizen.commandPalette/utils/fetch.js",
 				"resources/skins.citizen.commandPalette/utils/urlGenerator.js",
 				"resources/skins.citizen.commandPalette/stores/searchStore.js",
-				"resources/skins.citizen.commandPalette/services/searchHistory.js",
+				"resources/skins.citizen.commandPalette/services/recentItems.js",
 				"resources/skins.citizen.commandPalette/searchClients/SearchClientFactory.js",
 				"resources/skins.citizen.commandPalette/searchClients/MwRestSearchClient.js",
 				"resources/skins.citizen.commandPalette/providers/RecentItemsProvider.js",

--- a/skin.json
+++ b/skin.json
@@ -327,6 +327,8 @@
 				"resources/skins.citizen.commandPalette/components/CommandPaletteKeyboardHints.vue",
 				"resources/skins.citizen.commandPalette/components/CommandPaletteList.vue",
 				"resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue",
+				"resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue",
+				"resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue",
 				"resources/skins.citizen.commandPalette/components/CommandPalettePresults.vue",
 				{
 					"name": "resources/skins.citizen.commandPalette/icons.json",


### PR DESCRIPTION
See commit for details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced two new components for command palette list items: one for displaying content and another for handling action buttons, improving modularity and maintainability.
  - Added a new action button container with enhanced keyboard navigation and focus management for command palette items.

- **Refactor**
  - Simplified and reorganized the command palette list item component by delegating content and actions to dedicated sub-components.
  - Centralized command list item generation in the command provider, improving handling of unknown commands by showing filtered suggestions.
  - Removed deprecated icon prop and streamlined event and focus handling in command palette list items.
  - Updated service usage from search history to recent items across relevant modules.
  - Added `shouldAutoSelectFirst` flags to providers to control automatic selection behavior.
  - Renamed internal functions and variables for clarity and consistency.

- **Bug Fixes**
  - Improved user experience by ensuring filtered command suggestions are shown when an unknown command is entered, instead of displaying no results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->