### PR TITLE
feat(commandPalette): ✨ add action command

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -98,9 +98,14 @@
 	"citizen-command-palette-type-fulltext-search": "Fulltext search",
 	"citizen-command-palette-type-namespace": "Namespace",
 	"citizen-command-palette-type-command": "Command",
+	"citizen-command-palette-type-special-page": "Special page",
+	"citizen-command-palette-type-menu-item": "Menu item",
 
 	"citizen-command-palette-type-fulltext-search-description": "Search the full text of all pages",
 
-	"citizen-command-palette-type-command-namespace-label": "Search by Namespace",
-	"citizen-command-palette-type-command-namespace-description": "Type /ns: followed by a namespace name or ID"
+	"citizen-command-palette-type-command-namespace-label": "Namespace",
+	"citizen-command-palette-type-command-namespace-description": "Search for a page in a specific namespace",
+
+	"citizen-command-palette-type-command-action-label": "Action",
+	"citizen-command-palette-type-command-action-description": "Perform a specific action"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -79,6 +79,7 @@
 	"citizen-user-info-text-anon": "Description in the user menu when user is not logged in.",
 	"citizen-user-info-text-temp": "Description in the user menu when user is using a temporary account.",
 	"citizen-command-palette-heading-recent": "Label for the recently searched results in the command palette",
+	"citizen-command-palette-heading-related": "Label for the related results in the command palette",
 	"citizen-command-palette-keyhint-actions": "Keyboard hint for the key to select an action in an item in the command palette",
 	"citizen-command-palette-keyhint-return": "Keyboard hint for the key to return to search in the command palette",
 	"citizen-command-palette-keyhint-enter-select": "Keyboard hint for the key to select an item in the command palette",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -91,6 +91,10 @@
 	"citizen-command-palette-type-command": "Label for the command type of the result in the command palette",
 	"citizen-command-palette-type-fulltext-search": "Label for the fulltext search type of the result in the command palette",
 	"citizen-command-palette-type-fulltext-search-description": "Description for the fulltext search in the command palette",
-	"citizen-command-palette-type-command-namespace-label": "Label for the command namespace type of the result in the command palette",
-	"citizen-command-palette-type-command-namespace-description": "Description for the command namespace type of the result in the command palette"
+	"citizen-command-palette-type-command-namespace-label": "Label for the namespace command in the command palette",
+	"citizen-command-palette-type-command-namespace-description": "Description for the namespace command in the command palette",
+	"citizen-command-palette-type-special-page": "Label for the special page type of the result in the command palette",
+	"citizen-command-palette-type-command-action-label": "Label for the action command in the command palette",
+	"citizen-command-palette-type-command-action-description": "Description for the action command in the command palette",
+	"citizen-command-palette-type-menu-item": "Label for the menu item type of the result in the command palette"
 }

--- a/resources/skins.citizen.commandPalette/commands/action.js
+++ b/resources/skins.citizen.commandPalette/commands/action.js
@@ -1,0 +1,203 @@
+/**
+ * Placeholder command handler for actions.
+ */
+const { CommandPaletteItem, CommandHandler } = require( '../types.js' );
+const { cdxIconSpecialPages, cdxIconPlay } = require( '../icons.json' );
+
+/**
+ * Cache for special page results to avoid repeated API calls.
+ *
+ * @type {null|Promise<Array<CommandPaletteItem>>}
+ */
+let specialPageCache = null;
+
+/**
+ * Cache for menu item results to avoid repeated DOM queries.
+ *
+ * @type {null|Array<CommandPaletteItem>}
+ */
+let menuItemCache = null;
+
+/**
+ * Fetches and formats special pages from the MediaWiki API.
+ *
+ * @return {Promise<Array<CommandPaletteItem>>} A promise that resolves with an array of special page items.
+ */
+function fetchSpecialPages() {
+	if ( specialPageCache ) {
+		return specialPageCache;
+	}
+
+	specialPageCache = new mw.Api().get( {
+		action: 'query',
+		meta: 'siteinfo',
+		siprop: 'specialpagealiases'
+	} ).then( ( data ) => {
+		const specialPages = data.query.specialpagealiases;
+		/** @type {Array<CommandPaletteItem>} */
+		const items = [];
+
+		specialPages.forEach( ( page ) => {
+			// Use the first alias as the primary label
+			const label = page.aliases[ 0 ].replace( /_/g, ' ' );
+			const realName = page.realname;
+			const url = mw.util.getUrl( 'Special:' + realName );
+
+			items.push( {
+				id: 'special-' + realName.toLowerCase(),
+				type: 'special-page',
+				label: label,
+				url: url,
+				// description: Could potentially fetch descriptions via another API call or use mw.message
+				// icon: Needs a way to map special pages to icons
+				thumbnailIcon: cdxIconSpecialPages,
+				value: '/action:' + realName,
+				highlightQuery: true
+			} );
+		} );
+
+		// Sort alphabetically by label
+		items.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+
+		return items;
+	} ).catch( ( error ) => {
+		mw.log.error( 'Error fetching special pages:', error );
+		specialPageCache = null; // Clear cache on error
+		return []; // Return empty list on error
+	} );
+
+	return specialPageCache;
+}
+
+/**
+ * Fetches and formats menu items from the specified portlet's navigation.
+ *
+ * @return {Array<CommandPaletteItem>} An array of menu items.
+ */
+function fetchMenuItems() {
+	if ( menuItemCache !== null ) {
+		// Return cached results if available
+		return menuItemCache;
+	}
+
+	/**
+	 * The IDs of the portlets to fetch menu items from.
+	 * Defined here because ResourceLoader may have trouble with this in the top-level scope.
+	 */
+	const TARGET_PORTLET_IDS = [ 'p-views', 'p-associated-pages', 'p-cactions', 'p-tb', 'p-personal' ];
+
+	/** @type {Array<CommandPaletteItem>} */
+	const allItems = [];
+	const seenUrls = new Set();
+
+	TARGET_PORTLET_IDS.forEach( ( portletId ) => {
+		const portletElement = document.getElementById( portletId );
+
+		if ( !portletElement ) {
+			// console.debug( `Portlet element not found: ${ portletId }` ); // TODO: Consider mw.log.warn or similar if needed
+			return; // Skip this portlet if not found
+		}
+
+		const menuLabel = portletElement.querySelector( '.citizen-menu__heading' )?.textContent.trim();
+		const links = portletElement.querySelectorAll( '.citizen-menu__content-list li a' );
+
+		links.forEach( ( link ) => {
+			const listItem = link.closest( 'li' );
+			const id = listItem ? listItem.id : ''; // e.g., 't-whatlinkshere'
+			const url = link.getAttribute( 'href' ) || '#';
+			const labelElement = link.querySelector( 'span:not([class*="icon"])' ); // Get the text span, excluding icon spans
+
+			// Skip if label element not found or URL already seen
+			if ( !labelElement || seenUrls.has( url ) ) {
+				return;
+			}
+
+			const label = labelElement.textContent.trim();
+			// Remove trailing access key hint like "[alt-shift-j]"
+			const description = link.getAttribute( 'title' )?.replace( /\s*\[.*?\]\s*$/, '' );
+
+			allItems.push( {
+				id: id || 'menuitem-' + label.toLowerCase().replace( /\s+/g, '-' ), // Generate an ID if none exists
+				type: 'menu-item',
+				label: label,
+				description: description,
+				url: url,
+				thumbnailIcon: cdxIconPlay, // TODO: Somehow get the icon from the link
+				value: `/action:${ label }`,
+				highlightQuery: true,
+				metadata: [
+					{
+						label: menuLabel
+					}
+				]
+			} );
+			seenUrls.add( url ); // Add URL to set to track duplicates
+		} );
+	} );
+
+	// Sort alphabetically by label after combining and de-duplicating
+	allItems.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+
+	// Cache the combined and sorted results
+	menuItemCache = allItems;
+
+	return allItems;
+}
+
+/**
+ * Checks if a CommandPaletteItem matches the given query.
+ *
+ * @param {CommandPaletteItem} item The item to check.
+ * @param {string} lowerCaseQuery The query string (already lowercased).
+ * @return {boolean} True if the item matches, false otherwise.
+ */
+function itemMatchesQuery( item, lowerCaseQuery ) {
+	if ( item.label.toLowerCase().includes( lowerCaseQuery ) ) {
+		return true;
+	}
+
+	// Check ID based on type
+	if ( item.type === 'special-page' && item.id.slice( 'special-'.length ).includes( lowerCaseQuery ) ) {
+		return true;
+	} else if ( item.type === 'menu-item' && item.id.toLowerCase().includes( lowerCaseQuery ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Gets action results (special pages and menu items) based on the sub-query.
+ *
+ * @param {string} subQuery The part of the query after "/action:".
+ * @return {Promise<Array<CommandPaletteItem>>} A promise resolving to an array of action items.
+ */
+async function getActionResults( subQuery ) {
+	// Fetch both special pages and menu items
+	// Use Promise.all to fetch concurrently, though fetchMenuItems is currently synchronous
+	const [ specialPages, menuItems ] = await Promise.all( [
+		fetchSpecialPages(),
+		Promise.resolve( fetchMenuItems() ) // Fetch items from all target portlets
+	] );
+
+	// Combine the results, filtering out any potential null/undefined items from promises
+	// Ensure menu items come first, then special pages.
+	// Both lists are already sorted alphabetically.
+	const allItems = [ ...menuItems, ...specialPages ].filter( ( item ) => item );
+
+	if ( !subQuery ) {
+		return allItems; // Return all combined and sorted items if no subQuery
+	}
+
+	const lowerSubQuery = subQuery.toLowerCase();
+	// Filter using the helper function
+	return allItems.filter( ( item ) => itemMatchesQuery( item, lowerSubQuery ) );
+}
+
+/** @type {CommandHandler} */
+module.exports = {
+	triggers: [ '/action:', '>' ],
+	label: mw.message( 'citizen-command-palette-type-command-action-label' ).text(),
+	description: mw.message( 'citizen-command-palette-type-command-action-description' ).text(),
+	getResults: getActionResults
+};

--- a/resources/skins.citizen.commandPalette/commands/namespace.js
+++ b/resources/skins.citizen.commandPalette/commands/namespace.js
@@ -21,7 +21,8 @@ function adaptNamespaceResult( nsResult ) {
 			{
 				label: nsResult.value
 			}
-		]
+		],
+		highlightQuery: true
 	};
 }
 
@@ -39,13 +40,12 @@ function getNamespaceResults( subQuery ) {
 		value: id
 	} ) ).filter( ( ns ) => ns.value !== MAIN_NAMESPACE_ID ); // Use the constant here
 
-	const trimmedQuery = subQuery.trim();
-	const lowerQuery = trimmedQuery.toLowerCase();
+	const lowerQuery = subQuery.toLowerCase();
 
 	// Combine results using a Map to handle duplicates based on namespace ID (value)
 	const combinedResults = new Map();
 
-	if ( !trimmedQuery ) {
+	if ( !subQuery ) {
 		// If the query is empty, return all namespaces
 		allNamespaces.forEach( ( ns ) => combinedResults.set( ns.value, ns ) );
 	} else {
@@ -56,7 +56,7 @@ function getNamespaceResults( subQuery ) {
 				combinedResults.set( ns.value, ns );
 			}
 			// Check ID prefix (case-sensitive)
-			if ( ns.value.startsWith( trimmedQuery ) ) {
+			if ( ns.value.startsWith( subQuery ) ) {
 				combinedResults.set( ns.value, ns );
 			}
 		} );
@@ -67,6 +67,7 @@ function getNamespaceResults( subQuery ) {
 
 /** @type {CommandHandler} */
 module.exports = {
+	triggers: [ '/ns:', ':' ],
 	label: mw.msg( 'citizen-command-palette-type-command-namespace-label' ),
 	description: mw.msg( 'citizen-command-palette-type-command-namespace-description' ),
 	getResults: getNamespaceResults

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
@@ -70,11 +70,16 @@ module.exports = exports = defineComponent( {
 		const activeItemId = ref( null );
 
 		function getListItemBindings( listItem, index ) {
+			// Determine the query to use for highlighting
+			// Use the specific highlightTerm if provided by the provider (for sub-queries),
+			// otherwise fall back to the main search query.
+			const highlightQuery = listItem.highlightTerm ?? props.searchQuery;
+
 			return {
 				...listItem,
 				active: listItem.id === activeItemId.value,
 				highlighted: index === props.highlightedItemIndex,
-				searchQuery: props.searchQuery,
+				searchQuery: highlightQuery, // Use the determined query for highlighting
 				id: String( listItem.id )
 			};
 		}

--- a/resources/skins.citizen.commandPalette/providers/CommandProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/CommandProvider.js
@@ -4,7 +4,8 @@ const { cdxIconCode } = require( '../icons.json' );
 // Registry for slash command handlers
 // TODO: Allow extensions to register their own commands
 const commandRegistry = {
-	ns: require( '../commands/namespace.js' )
+	ns: require( '../commands/namespace.js' ),
+	action: require( '../commands/action.js' )
 };
 
 /**
@@ -17,23 +18,46 @@ function getCommandListItems( filterPrefix ) {
 	let entries = Object.entries( commandRegistry );
 
 	if ( filterPrefix ) {
-		entries = entries.filter( ( [ cmdName ] ) => cmdName.toLowerCase().startsWith( filterPrefix.toLowerCase() ) );
+		// Filter entries based on handler triggers
+		entries = entries.filter( ( [ /* cmdName */, handler ] ) => {
+			const lowerFilterPrefix = filterPrefix.toLowerCase();
+			const match = handler.triggers && handler.triggers.some( ( trigger ) => {
+				const lowerTrigger = trigger.toLowerCase();
+				const starts = lowerTrigger.startsWith( lowerFilterPrefix );
+				return starts;
+			} );
+			return match;
+		} );
 	}
 
-	return entries.map( ( [ cmdName, handler ] ) => ( {
-		id: `citizen-command-palette-item-command-${ cmdName }`,
-		type: 'command',
-		label: handler.label ?? cmdName,
-		description: handler.description,
-		thumbnailIcon: cdxIconCode,
-		value: `/${ cmdName }:`,
-		metadata: [
-			{
+	const mappedResults = entries.map( ( [ cmdName, handler ] ) => {
+		let metadata = [];
+		if ( handler.triggers && handler.triggers.length > 0 ) {
+			metadata = handler.triggers.map( ( trigger, index ) => ( {
+				label: trigger,
+				highlightQuery: index === 0 // Highlight only the first trigger
+			} ) );
+		} else {
+			// Fallback if no triggers are defined
+			metadata.push( {
 				label: `/${ cmdName }`,
 				highlightQuery: true
-			}
-		]
-	} ) );
+			} );
+		}
+
+		return {
+			id: `citizen-command-palette-item-command-${ cmdName }`,
+			type: 'command',
+			label: handler.label ?? cmdName,
+			description: handler.description,
+			thumbnailIcon: cdxIconCode,
+			// Use the first trigger as the primary value
+			value: handler.triggers ? handler.triggers[ 0 ] : `/${ cmdName }`,
+			metadata: metadata // Use the generated metadata array
+		};
+	} );
+
+	return mappedResults;
 }
 
 /** @type {CommandPaletteProvider} */
@@ -41,7 +65,7 @@ module.exports = {
 	/** Whether this provider returns results asynchronously */
 	isAsync: true, // Although some commands might be sync, the handler resolution can be async
 	/** Debounce time in milliseconds for async providers */
-	debounceMs: 0, // No debounce for commands for responsiveness
+	debounceMs: 0, // Reverted: No debounce for commands for responsiveness
 
 	/**
 	 * Determines if this provider should handle the current query.
@@ -50,7 +74,15 @@ module.exports = {
 	 * @return {boolean}
 	 */
 	canProvide( query ) {
-		return query.startsWith( '/' ) || query.startsWith( ':' );
+		// Handle if the query starts with '/' (for root query and prefix search)
+		const startsWithSlash = query.startsWith( '/' );
+
+		// Handle if the query starts with any registered trigger
+		const startsWithTrigger = Object.values( commandRegistry ).some( ( handler ) => (
+			handler.triggers && handler.triggers.some( ( trigger ) => query.startsWith( trigger ) )
+		) );
+
+		return startsWithSlash || startsWithTrigger;
 	},
 
 	/**
@@ -60,44 +92,74 @@ module.exports = {
 	 * @return {Promise<Array<CommandPaletteItem>>}
 	 */
 	async getResults( query ) {
-		// Handle ':' as a shortcut for '/ns:'
-		if ( query.startsWith( ':' ) ) {
-			query = '/ns' + query;
+		let matchedHandler = null;
+		let matchedTrigger = null;
+		let commandName = null; // Keep track of the command name for filtering later
+
+		// Find the handler and trigger that match the query start
+		for ( const [ cmd, handler ] of Object.entries( commandRegistry ) ) {
+			if ( handler.triggers ) {
+				for ( const trigger of handler.triggers ) {
+					if ( query.startsWith( trigger ) ) {
+						// Prioritize longer matches (e.g., "/ns" over "/")
+						if ( !matchedTrigger || trigger.length > matchedTrigger.length ) {
+							matchedHandler = handler;
+							matchedTrigger = trigger;
+							commandName = cmd; // Store the command name associated with the handler
+						}
+					}
+				}
+			}
 		}
 
-		// Case 1: Root query "/" - Show available commands
+		// --- Query Handling Logic ---
+
+		// Case 1: Root query "/" - Show all available commands
 		if ( query === '/' ) {
-			return getCommandListItems();
+			return getCommandListItems().slice( 0, 10 );
 		}
 
-		// Case 2: Specific command query (e.g., "/ns:Talk")
-		// Remove leading '/' and find the first colon, if any
-		const commandString = query.slice( 1 ).trim();
-		const colonIndex = commandString.indexOf( ':' );
-		const hasSubquery = colonIndex !== -1;
+		// Case 2: A specific command trigger is fully matched (e.g., query starts with "/ns" or ":")
+		if ( matchedHandler && matchedTrigger ) {
+			// Extract the sub-query after the trigger
+			const subQuery = query.slice( matchedTrigger.length ).trim();
 
-		const commandName = ( hasSubquery ? commandString.slice( 0, colonIndex ) : commandString ).toLowerCase();
-		const subQuery = hasSubquery ? commandString.slice( colonIndex + 1 ).trim() : '';
+			// Handle cases where the trigger might end with ':' (like /ns:) vs just /ns
+			let actualSubQuery = subQuery;
+			if ( matchedTrigger.endsWith( ':' ) && subQuery.startsWith( ':' ) ) {
+				actualSubQuery = subQuery.slice( 1 ).trim();
+			} else if ( subQuery.startsWith( ':' ) && !matchedTrigger.endsWith( ':' ) ) {
+				actualSubQuery = subQuery.slice( 1 ).trim();
+			}
 
-		if ( commandName && commandRegistry[ commandName ] ) {
-			const commandHandler = commandRegistry[ commandName ];
-
-			if ( typeof commandHandler.getResults !== 'function' ) {
-				mw.log.error( `[CommandProvider] Command handler for "${ commandName }" is missing required getResults function.` );
+			if ( typeof matchedHandler.getResults !== 'function' ) {
+				mw.log.error( `[CommandProvider] Command handler for "${ commandName }" (triggered by "${ matchedTrigger }") is missing required getResults function.` );
 				return [];
 			}
 
 			try {
-				const results = await commandHandler.getResults( subQuery );
-				return Array.isArray( results ) ? results : [];
+				// Pass the actual sub-query (part after trigger and potentially colon) to the handler
+				const results = await matchedHandler.getResults( actualSubQuery );
+				const processedResults = ( Array.isArray( results ) ? results : [] ).map( ( item ) => {
+					if ( item.highlightQuery ) {
+						return { ...item, highlightTerm: actualSubQuery };
+					}
+					return item;
+				} );
+				return processedResults.slice( 0, 10 );
 			} catch ( err ) {
-				mw.log.error( `[CommandProvider] "${ commandName }" failed:`, err );
+				mw.log.error( `[CommandProvider] Handler for "${ commandName }" (triggered by "${ matchedTrigger }") failed:`, err );
 				return [];
 			}
-		} else {
-			// If the command name doesn't match any registered command, show the list again,
-			// filtered by the typed prefix.
-			return getCommandListItems( commandName );
 		}
+
+		// Case 3: No specific trigger matched, but query starts with '/' (e.g., "/n" or "/unknown")
+		// Perform prefix search on command triggers.
+		if ( !matchedTrigger && query.startsWith( '/' ) ) {
+			return getCommandListItems( query ).slice( 0, 10 ); // Filter commands by query prefix
+		}
+
+		// Case 4: Query doesn't match any command pattern - return empty array
+		return [];
 	}
 };

--- a/resources/skins.citizen.commandPalette/stores/searchStore.js
+++ b/resources/skins.citizen.commandPalette/stores/searchStore.js
@@ -85,16 +85,13 @@ exports.useSearchStore = defineStore( 'search', {
 		 * @param {boolean} [clearItems=true] - Whether to clear the displayedItems array.
 		 * @private
 		 */
-		resetOperationState( clearItems = true ) {
+		resetOperationState( /* clearItems = true */ ) {
 			clearTimeout( this.debounceTimeout );
 			this.debounceTimeout = null;
 			clearTimeout( this.pendingDelayTimeout );
 			this.pendingDelayTimeout = null;
 			this.isPending = false;
 			this.showPending = false;
-			if ( clearItems ) {
-				this.displayedItems = [];
-			}
 		},
 
 		/**
@@ -146,7 +143,7 @@ exports.useSearchStore = defineStore( 'search', {
 			// Add fulltext search item if applicable
 			if (
 				this.searchQuery &&
-				!this.searchQuery.startsWith( '/' )
+				!CommandProvider.canProvide( this.searchQuery )
 			) {
 				const fulltextSearchItem = this.createFulltextSearchItem( this.searchQuery );
 				// Ensure fulltext item is always at the end
@@ -168,9 +165,8 @@ exports.useSearchStore = defineStore( 'search', {
 			try {
 				const results = typeof provider.getResults === 'function' ? provider.getResults( query ) : [];
 				if ( this.searchQuery === query ) {
-					// Pass a source hint based on provider type or query
-					const sourceHint = query.startsWith( '/' ) ? 'command' : 'search';
-					this.setProviderResults( results, sourceHint );
+					// Pass a source hint based on whether it's a command
+					this.setProviderResults( results, provider === CommandProvider ? 'command' : 'search' );
 				}
 			} catch ( error ) {
 				mw.log.error( `[skins.citizen.commandPalette] Sync Provider failed for query "${ query }":`, error );
@@ -210,9 +206,7 @@ exports.useSearchStore = defineStore( 'search', {
 				try {
 					const results = typeof provider.getResults === 'function' ? await provider.getResults( query ) : [];
 					if ( this.searchQuery === query ) {
-						// Pass a source hint
-						const sourceHint = query.startsWith( '/' ) ? 'command' : 'search';
-						this.setProviderResults( results, sourceHint );
+						this.setProviderResults( results, provider === CommandProvider ? 'command' : 'search' );
 					}
 				} catch ( error ) {
 					mw.log.error( `[skins.citizen.commandPalette] Async Provider failed for query "${ query }":`, error );
@@ -242,18 +236,28 @@ exports.useSearchStore = defineStore( 'search', {
 				return;
 			}
 
-			// Reset debounce/pending state and clear previous items for non-empty query
-			this.resetOperationState();
+			// Reset debounce/pending state, but keep existing items temporarily
+			this.resetOperationState( false ); // Pass false to keep items
 
-			// --- Handle non-empty query ---
+			// Immediately update or add the fulltext search item if applicable
+			// Use CommandProvider.canProvide to check if it's NOT a command query
+			if ( query && !CommandProvider.canProvide( query ) ) {
+				const newFulltextItem = this.createFulltextSearchItem( query );
+				const existingFulltextIndex = this.displayedItems.findIndex( ( item ) => item.type === 'fulltext-search' );
 
-			// Immediately display just the fulltext search item if applicable
-			if ( query && !query.startsWith( '/' ) ) {
-				const fulltextSearchItem = this.createFulltextSearchItem( query );
-				this.displayedItems = [ fulltextSearchItem ];
+				if ( existingFulltextIndex !== -1 ) {
+					// Replace existing fulltext item
+					this.displayedItems.splice( existingFulltextIndex, 1, newFulltextItem );
+				} else {
+					// Add fulltext item if it wasn't there (e.g., coming from presults)
+					this.displayedItems.push( newFulltextItem );
+				}
 			} else {
-				// Command query, start with empty list
-				this.displayedItems = [];
+				// If it's a command query or became one, remove any existing fulltext item immediately
+				const existingFulltextIndex = this.displayedItems.findIndex( ( item ) => item.type === 'fulltext-search' );
+				if ( existingFulltextIndex !== -1 ) {
+					this.displayedItems.splice( existingFulltextIndex, 1 );
+				}
 			}
 
 			const provider = providers.find( ( p ) => p.canProvide( query ) );

--- a/resources/skins.citizen.commandPalette/stores/searchStore.js
+++ b/resources/skins.citizen.commandPalette/stores/searchStore.js
@@ -82,10 +82,9 @@ exports.useSearchStore = defineStore( 'search', {
 		/**
 		 * Resets state related to ongoing or previous search/presults operations.
 		 *
-		 * @param {boolean} [clearItems=true] - Whether to clear the displayedItems array.
 		 * @private
 		 */
-		resetOperationState( /* clearItems = true */ ) {
+		resetOperationState() {
 			clearTimeout( this.debounceTimeout );
 			this.debounceTimeout = null;
 			clearTimeout( this.pendingDelayTimeout );
@@ -236,8 +235,7 @@ exports.useSearchStore = defineStore( 'search', {
 				return;
 			}
 
-			// Reset debounce/pending state, but keep existing items temporarily
-			this.resetOperationState( false ); // Pass false to keep items
+			this.resetOperationState();
 
 			// Immediately update or add the fulltext search item if applicable
 			// Use CommandProvider.canProvide to check if it's NOT a command query
@@ -246,17 +244,17 @@ exports.useSearchStore = defineStore( 'search', {
 				const existingFulltextIndex = this.displayedItems.findIndex( ( item ) => item.type === 'fulltext-search' );
 
 				if ( existingFulltextIndex !== -1 ) {
-					// Replace existing fulltext item
-					this.displayedItems.splice( existingFulltextIndex, 1, newFulltextItem );
+					const newItems = [ ...this.displayedItems ];
+					newItems.splice( existingFulltextIndex, 1, newFulltextItem );
+					this.displayedItems = newItems;
 				} else {
-					// Add fulltext item if it wasn't there (e.g., coming from presults)
-					this.displayedItems.push( newFulltextItem );
+					this.displayedItems = [ ...this.displayedItems, newFulltextItem ];
 				}
 			} else {
 				// If it's a command query or became one, remove any existing fulltext item immediately
 				const existingFulltextIndex = this.displayedItems.findIndex( ( item ) => item.type === 'fulltext-search' );
 				if ( existingFulltextIndex !== -1 ) {
-					this.displayedItems.splice( existingFulltextIndex, 1 );
+					this.displayedItems = this.displayedItems.filter( ( _, index ) => index !== existingFulltextIndex );
 				}
 			}
 
@@ -320,8 +318,7 @@ exports.useSearchStore = defineStore( 'search', {
 		 */
 		async clearSearch() {
 			this.searchQuery = '';
-			// Reset state, but keep existing items displayed while fetching new ones
-			this.resetOperationState( false );
+			this.resetOperationState();
 
 			// Fetch recent items synchronously and display them immediately
 			const fetchedRecentItems = this.fetchRecentItems();

--- a/skin.json
+++ b/skin.json
@@ -321,6 +321,7 @@
 				"resources/skins.citizen.commandPalette/providers/SearchProvider.js",
 				"resources/skins.citizen.commandPalette/providers/CommandProvider.js",
 				"resources/skins.citizen.commandPalette/commands/namespace.js",
+				"resources/skins.citizen.commandPalette/commands/action.js",
 				"resources/skins.citizen.commandPalette/components/App.vue",
 				"resources/skins.citizen.commandPalette/components/CommandPaletteEmptyState.vue",
 				"resources/skins.citizen.commandPalette/components/CommandPaletteFooter.vue",
@@ -344,7 +345,9 @@
 						"cdxIconCode",
 						"cdxIconEdit",
 						"cdxIconSearch",
-						"cdxIconTrash"
+						"cdxIconTrash",
+						"cdxIconSpecialPages",
+						"cdxIconPlay"
 					]
 				},
 				{
@@ -374,7 +377,11 @@
 				"citizen-command-palette-type-command",
 				"citizen-command-palette-type-fulltext-search-description",
 				"citizen-command-palette-type-command-namespace-label",
-				"citizen-command-palette-type-command-namespace-description"
+				"citizen-command-palette-type-command-namespace-description",
+				"citizen-command-palette-type-special-page",
+				"citizen-command-palette-type-command-action-label",
+				"citizen-command-palette-type-command-action-description",
+				"citizen-command-palette-type-menu-item"
 			]
 		},
 		"skins.citizen.commandPalette.codex": {


### PR DESCRIPTION
Action command can be triggered with `>` or `/action`.
Currently it queries all special pages and all menus on the page (excluding main menu/navigation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new "Action", "Special page", and "Menu item" categories to the command palette, enabling users to quickly perform actions, access special pages, and navigate menu items.
  - Enhanced command palette to support multiple triggers per command for more flexible command entry.
- **Enhancements**
  - Refined command palette labels and descriptions for improved clarity.
  - Improved search result highlighting with per-item highlight terms.
  - Enhanced command recognition logic to better handle queries and sub-queries.
  - Updated search behavior to selectively update fulltext search results without clearing other displayed items.
- **Bug Fixes**
  - Fixed issues with command detection and result filtering for a smoother search experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->