### PR TITLE
feat(search): ✨ add the citizen-search-trigger class to trigger searc…

### DIFF
--- a/resources/skins.citizen.commandPalette/init.js
+++ b/resources/skins.citizen.commandPalette/init.js
@@ -25,7 +25,6 @@ function initApp() {
 	const commandPalette = app.mount( overlay );
 
 	registerButton( commandPalette );
-	bindKeyboardShortcuts( commandPalette );
 }
 
 /**
@@ -44,58 +43,6 @@ function registerButton( commandPalette ) {
 	details.addEventListener( 'click', () => {
 		commandPalette.open();
 	} );
-}
-
-/**
- * Manually toggle the details state when the keyboard button is SLASH is pressed.
- *
- * @param {Vue} commandPalette
- * @return {void}
- */
-function bindKeyboardShortcuts( commandPalette ) {
-	const onExpandOnSlash = ( event ) => {
-		const isKeyPressed = () => {
-			// "/"
-			if ( event.key === '/' ) {
-				return true;
-			// "Ctrl" + "K" (or "Command" + "K" on Mac)
-			} else if ( ( event.ctrlKey || event.metaKey ) && event.key.toLowerCase() === 'k' ) {
-				return true;
-			// "Alt" + "Shift" + "F" is the MW standard key
-			// Shift key might makes F key goes capital, so we need to make it lowercase
-			} else if ( event.altKey && event.shiftKey && event.key.toLowerCase() === 'f' ) {
-				return true;
-			} else {
-				return false;
-			}
-		};
-		if ( isKeyPressed() && !isFormField( event.target ) ) {
-			// Since Firefox quickfind interfere with this
-			event.preventDefault();
-			commandPalette.open();
-		}
-	};
-
-	document.addEventListener( 'keydown', onExpandOnSlash, true );
-}
-
-/**
- * Check if the element is a HTML form element or content editable
- * This is to prevent trigger search box when user is typing on a textfield, input, etc.
- *
- * @param {HTMLElement} element
- * @return {boolean}
- */
-function isFormField( element ) {
-	if ( !( element instanceof HTMLElement ) ) {
-		return false;
-	}
-	const name = element.nodeName.toLowerCase();
-	const type = ( element.getAttribute( 'type' ) || '' ).toLowerCase();
-	return ( name === 'select' ||
-        name === 'textarea' ||
-        ( name === 'input' && type !== 'submit' && type !== 'reset' && type !== 'checkbox' && type !== 'radio' ) ||
-        element.isContentEditable );
 }
 
 initApp();


### PR DESCRIPTION
…h UI

The `.citizen-search-trigger` class can now be used to trigger the search UI. Also simplified the keyboard shortcut binding in CommandPalette and Search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for opening the search interface using keyboard shortcuts: Ctrl/Command + K and Alt + Shift + F.
  - Enabled opening the search interface by clicking on elements with the search trigger class.

- **Refactor**
  - Unified and streamlined the logic for opening the search interface for a more consistent user experience.

- **Removed**
  - Removed previous keyboard shortcut bindings for opening the command palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->