### PR TITLE
fix(toc): 🐛 fix scrolling when sticky header is disabled

### DIFF
--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -119,7 +119,7 @@
 		}
 
 		.citizen-scroll--down {
-			--height-sticky-header: 0px !important;
+			--height-sticky-header: 0 !important;
 
 			.citizen-header,
 			.citizen-page-header,

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -119,7 +119,7 @@
 		}
 
 		.citizen-scroll--down {
-			--height-sticky-header: ~"0px" !important;
+			--height-sticky-header: ~'0px' !important;
 
 			.citizen-header,
 			.citizen-page-header,

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -119,7 +119,7 @@
 		}
 
 		.citizen-scroll--down {
-			--height-sticky-header: 0 !important;
+			--height-sticky-header: ~"0px" !important;
 
 			.citizen-header,
 			.citizen-page-header,

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -119,7 +119,7 @@
 		}
 
 		.citizen-scroll--down {
-			--height-sticky-header: 0 !important;
+			--height-sticky-header: 0px !important;
 
 			.citizen-header,
 			.citizen-page-header,

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -39,7 +39,7 @@
 	--toolbar-size: 2.5rem;
 	// Used to offset sticky elements with sticky header
 	// This is overriden by inline styles in the html element when sticky header is active
-	--height-sticky-header: ~"0px";
+	--height-sticky-header: ~'0px';
 	// Width or height of citizen-header, depending on the orientation
 	--header-size: @header-size;
 	// Max-height allowed for header card, 20vh is left for closing affordnance

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -39,7 +39,7 @@
 	--toolbar-size: 2.5rem;
 	// Used to offset sticky elements with sticky header
 	// This is overriden by inline styles in the html element when sticky header is active
-	--height-sticky-header: 0;
+	--height-sticky-header: 0px;
 	// Width or height of citizen-header, depending on the orientation
 	--header-size: @header-size;
 	// Max-height allowed for header card, 20vh is left for closing affordnance

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -39,7 +39,7 @@
 	--toolbar-size: 2.5rem;
 	// Used to offset sticky elements with sticky header
 	// This is overriden by inline styles in the html element when sticky header is active
-	--height-sticky-header: 0px;
+	--height-sticky-header: 0;
 	// Width or height of citizen-header, depending on the orientation
 	--header-size: @header-size;
 	// Max-height allowed for header card, 20vh is left for closing affordnance

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -39,7 +39,7 @@
 	--toolbar-size: 2.5rem;
 	// Used to offset sticky elements with sticky header
 	// This is overriden by inline styles in the html element when sticky header is active
-	--height-sticky-header: 0;
+	--height-sticky-header: ~"0px";
 	// Width or height of citizen-header, depending on the orientation
 	--header-size: @header-size;
 	// Max-height allowed for header card, 20vh is left for closing affordnance


### PR DESCRIPTION
Currently, when the sticky header is disabled, scrolling in the table of contents does not work. This is because `0` is used in `calc()`, which breaks the `max-height`.

This PR fixes the issue by specifying a unit, which is required by `calc()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the sticky header height styling to explicitly use "0px" instead of "0", ensuring consistent rendering across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->