### PR TITLE
fix: 🐛 add background for line numbers

### DIFF
--- a/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
+++ b/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
@@ -304,6 +304,8 @@
 		}
 
 		.linenos {
+			background-color: var(--color-surface-2);
+			border-left: var(--border-width-base) solid var(--border-color-base);
 			color: var( --color-subtle );
 		}
 

--- a/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
+++ b/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
@@ -304,9 +304,9 @@
 		}
 
 		.linenos {
-			background-color: var(--color-surface-2);
-			border-left: var(--border-width-base) solid var(--border-color-base);
 			color: var( --color-subtle );
+			background-color: var( --color-surface-2 );
+			border-left: var( --border-width-base ) solid var( --border-color-base );
 		}
 
 		a:hover .linenos,

--- a/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
+++ b/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
@@ -304,9 +304,9 @@
 		}
 
 		.linenos {
-			background-color: var( --color-surface-2 );
-			color: var( --color-subtle );
 			margin-left: var( --border-width-base );
+			color: var( --color-subtle );
+			background-color: var( --color-surface-2 );
 		}
 
 		a:hover .linenos,

--- a/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
+++ b/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
@@ -304,9 +304,9 @@
 		}
 
 		.linenos {
-			color: var( --color-subtle );
 			background-color: var( --color-surface-2 );
-			border-left: var( --border-width-base ) solid var( --border-color-base );
+			color: var( --color-subtle );
+			margin-left: var( --border-width-base );
 		}
 
 		a:hover .linenos,


### PR DESCRIPTION
For SyntaxHighlight_GeSHi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the appearance of line numbers in code highlights by adding a background color and a left border.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->