### PR TITLE
fix(header): 🐛 disable wrapping to fix indicator wrapping

### DIFF
--- a/resources/skins.citizen.styles/components/PageHeader.less
+++ b/resources/skins.citizen.styles/components/PageHeader.less
@@ -27,7 +27,7 @@
 
 .firstHeading-container {
 	display: flex;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 	align-items: center;
 }
 

--- a/resources/skins.citizen.styles/layout.less
+++ b/resources/skins.citizen.styles/layout.less
@@ -64,8 +64,7 @@
 		transition-property: max-width;
 	}
 
-	.citizen-page-header-inner,
-	.firstHeading-container {
+	.citizen-page-header-inner {
 		flex-wrap: nowrap;
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated page header layout to prevent elements from wrapping onto multiple lines, ensuring a single-line display for header content on desktop screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->