### PR TITLE
fix: add missing import to CookieWarning styles

### DIFF
--- a/skinStyles/extensions/CookieWarning/ext.CookieWarning.styles.less
+++ b/skinStyles/extensions/CookieWarning/ext.CookieWarning.styles.less
@@ -8,6 +8,7 @@
  * Date: 2023-07-30
 */
 
+@import '../../../resources/mixins.less';
 @import '../../../resources/variables.less';
 
 .mw-cookiewarning-container {


### PR DESCRIPTION
This fixes a compilation error:
```
/*
Less_Exception_Compiler: .mixin-citizen-font-styles is undefined in /srv/mediawiki/1.43/skins/Citizen/skinStyles/extensions/CookieWarning/ext.CookieWarning.styles.less
Backtrace:
from /srv/mediawiki/1.43/vendor/wikimedia/less.php/lib/Less/Tree/Mixin/Call.php(159)
#0 /srv/mediawiki/1.43/vendor/wikimedia/less.php/lib/Less/Tree/Ruleset.php(150): Less_Tree_Mixin_Call->compile(Less_Environment)
#1 /srv/mediawiki/1.43/vendor/wikimedia/less.php/lib/Less/Tree/Ruleset.php(92): Less_Tree_Ruleset->EvalMixinCalls(Less_Tree_Ruleset, Less_Environment, int)
#2 /srv/mediawiki/1.43/vendor/wikimedia/less.php/lib/Less/Tree/Ruleset.php(97): Less_Tree_Ruleset->compile(Less_Environment)
#3 /srv/mediawiki/1.43/vendor/wikimedia/less.php/lib/Less/Parser.php(225): Less_Tree_Ruleset->compile(Less_Environment)
#4 /srv/mediawiki/1.43/includes/ResourceLoader/FileModule.php(1128): Less_Parser->getCss()
#5 /srv/mediawiki/1.43/includes/ResourceLoader/FileModule.php(1015): MediaWiki\ResourceLoader\FileModule->compileLessString(string, string, MediaWiki\ResourceLoader\Context)
#6 /srv/mediawiki/1.43/includes/ResourceLoader/FileModule.php(991): MediaWiki\ResourceLoader\FileModule->processStyle(string, string, MediaWiki\ResourceLoader\FilePath, MediaWiki\ResourceLoader\Context)
#7 /srv/mediawiki/1.43/includes/ResourceLoader/FileModule.php(969): MediaWiki\ResourceLoader\FileModule->readStyleFile(MediaWiki\ResourceLoader\FilePath, MediaWiki\ResourceLoader\Context)
#8 /srv/mediawiki/1.43/includes/ResourceLoader/FileModule.php(409): MediaWiki\ResourceLoader\FileModule->readStyleFiles(array, MediaWiki\ResourceLoader\Context)
#9 /srv/mediawiki/1.43/includes/ResourceLoader/Module.php(853): MediaWiki\ResourceLoader\FileModule->getStyles(MediaWiki\ResourceLoader\Context)
#10 /srv/mediawiki/1.43/includes/ResourceLoader/Module.php(812): MediaWiki\ResourceLoader\Module->buildContent(MediaWiki\ResourceLoader\Context)
#11 /srv/mediawiki/1.43/includes/ResourceLoader/ResourceLoader.php(1268): MediaWiki\ResourceLoader\Module->getModuleContent(MediaWiki\ResourceLoader\Context)
#12 /srv/mediawiki/1.43/includes/ResourceLoader/ResourceLoader.php(1177): MediaWiki\ResourceLoader\ResourceLoader->addOneModuleResponse(MediaWiki\ResourceLoader\Context, Wikimedia\Minify\IdentityMinifierState, string, MediaWiki\ResourceLoader\FileModule, array)
#13 /srv/mediawiki/1.43/includes/ResourceLoader/ResourceLoader.php(1110): MediaWiki\ResourceLoader\ResourceLoader->getOneModuleResponse(MediaWiki\ResourceLoader\Context, string, MediaWiki\ResourceLoader\FileModule)
#14 /srv/mediawiki/1.43/includes/ResourceLoader/ResourceLoader.php(825): MediaWiki\ResourceLoader\ResourceLoader->makeModuleResponse(MediaWiki\ResourceLoader\Context, array, array)
#15 /srv/mediawiki/1.43/includes/ResourceLoader/ResourceLoaderEntryPoint.php(54): MediaWiki\ResourceLoader\ResourceLoader->respond(MediaWiki\ResourceLoader\Context)
#16 /srv/mediawiki/1.43/includes/MediaWikiEntryPoint.php(200): MediaWiki\ResourceLoader\ResourceLoaderEntryPoint->execute()
#17 /srv/mediawiki/1.43/load.php(42): MediaWiki\MediaWikiEntryPoint->run()
#18 /srv/mediawiki/config/initialise/entrypoints/load.php(3): require(string)
#19 {main}

Problematic modules: {"ext.CookieWarning.styles":"error"}
*/
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved stylesheet structure for the Cookie Warning extension. No visual changes for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->