### PR TITLE
Fix sticky header display on root user pages

### DIFF
--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -170,8 +170,8 @@ class SkinCitizen extends SkinMustache {
 		}
 
 		// HACK: So that we only get the tagline once
-		$patterns = ['/<a href=/', '/<\/a>/'];
-		$replacements = ['<span data-href=', '</span>'];
+		$patterns = [ '/<a href=/', '/<\/a>/' ];
+		$replacements = [ '<span data-href=', '</span>' ];
 		$parentData['data-sticky-header']['html-tagline'] = preg_replace( $patterns, $replacements, $parentData['data-page-heading']['html-tagline'] );
 
 		// HACK: So that we can use Icon.mustache in Header__logo.mustache

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -170,7 +170,9 @@ class SkinCitizen extends SkinMustache {
 		}
 
 		// HACK: So that we only get the tagline once
-		$parentData['data-sticky-header']['html-tagline'] = $parentData['data-page-heading']['html-tagline'];
+		$patterns = ['/<a href=/', '/<\/a>/'];
+		$replacements = ['<span data-href=', '</span>'];
+		$parentData['data-sticky-header']['html-tagline'] = preg_replace( $patterns, $replacements, $parentData['data-page-heading']['html-tagline'] );
 
 		// HACK: So that we can use Icon.mustache in Header__logo.mustache
 		$parentData['data-logos']['icon-home'] = 'home';


### PR DESCRIPTION
Please see issue #1080 for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the display of taglines in sticky headers by converting links into non-clickable spans, preserving link targets for styling or other purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->