### PR TITLE
feat(CommandPalette): ✨ use `<a>` or `<button>` respectively

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -196,13 +196,11 @@ module.exports = exports = defineComponent( {
 			switch ( selectionAction.action ) {
 				case 'navigate':
 					if ( selectionAction.payload ) {
-						window.location.href = selectionAction.payload;
+						// <a> tags are handled by the browser on mouse click, so we don't need to navigate.
+						if ( !result.isMouseClick ) {
+							window.location.href = selectionAction.payload;
+						}
 						close();
-					}
-					break;
-				case 'navigate-new-tab':
-					if ( selectionAction.payload ) {
-						window.open( selectionAction.payload, '_blank' );
 					}
 					break;
 				case 'updateQuery':

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
@@ -13,7 +13,6 @@ Partially based on the MenuItem component from Codex.
 		:class="rootClasses"
 		:data-type="type"
 		@mousedown.prevent="onMouseDown"
-		@click.prevent="onClick"
 	>
 		<command-palette-list-item-content
 			:label="label"
@@ -26,6 +25,7 @@ Partially based on the MenuItem component from Codex.
 			:search-query="searchQuery"
 			:url="url"
 			:highlight-query="highlightQuery"
+			@click="onClick"
 		></command-palette-list-item-content>
 		<command-palette-list-item-actions
 			ref="actionsRef"
@@ -45,6 +45,7 @@ const { defineComponent, computed, ref } = require( 'vue' );
 // Import the new sub-components
 const CommandPaletteListItemContent = require( './CommandPaletteListItemContent.vue' );
 const CommandPaletteListItemActions = require( './CommandPaletteListItemActions.vue' );
+const { CommandPaletteItem } = require( '../types.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
@@ -138,27 +139,23 @@ module.exports = exports = defineComponent( {
 			}
 		};
 
-		const onClick = ( event ) => {
-			emit( 'select', {
-				id: props.id,
-				label: props.label,
-				url: props.url,
-				type: props.type,
-				value: props.value,
-				thumbnail: props.thumbnail,
-				thumbnailIcon: props.thumbnailIcon,
-				description: props.description,
-				metadata: props.metadata,
-				actions: props.actions,
-				source: props.source,
-				eventDetails: {
-					button: event.button,
-					ctrlKey: event.ctrlKey,
-					metaKey: event.metaKey,
-					shiftKey: event.shiftKey,
-					altKey: event.altKey
-				}
-			} );
+		const onClick = () => {
+			emit( 'select',
+				/** @type {CommandPaletteItem} */ ( {
+					id: props.id,
+					label: props.label,
+					url: props.url,
+					type: props.type,
+					value: props.value,
+					thumbnail: props.thumbnail,
+					thumbnailIcon: props.thumbnailIcon,
+					description: props.description,
+					metadata: props.metadata,
+					actions: props.actions,
+					source: props.source,
+					isMouseClick: true
+				} )
+			);
 		};
 
 		// --- Action Handling ---

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
@@ -1,5 +1,8 @@
 <template>
-	<div
+	<component
+		:is="url ? 'a' : 'button'"
+		:href="url || undefined"
+		:type="url ? undefined : 'button'"
 		class="citizen-command-palette-list-item__content"
 	>
 		<cdx-thumbnail
@@ -62,7 +65,7 @@
 				{{ typeLabel }}
 			</div>
 		</div>
-	</div>
+	</component>
 </template>
 
 <script>
@@ -78,6 +81,10 @@ module.exports = exports = defineComponent( {
 		CdxThumbnail
 	},
 	props: {
+		url: {
+			type: String,
+			default: ''
+		},
 		label: {
 			type: String,
 			required: true
@@ -128,6 +135,17 @@ module.exports = exports = defineComponent( {
 		align-items: center;
 		padding: var( --space-sm ) var( --citizen-command-palette-side-padding );
 		text-decoration: none;
+
+		// Reset button styles
+		button& {
+			cursor: pointer;
+			background: none;
+			border: none;
+			font: inherit;
+			color: inherit;
+			text-align: inherit;
+			width: 100%;
+		}
 
 		&:hover {
 			text-decoration: none;

--- a/resources/skins.citizen.commandPalette/stores/searchStore.js
+++ b/resources/skins.citizen.commandPalette/stores/searchStore.js
@@ -342,7 +342,7 @@ exports.useSearchStore = defineStore( 'search', {
 			}
 
 			// Save item on navigation, unless it's a command
-			if ( ( actionResult.action === 'navigate' || actionResult.action === 'navigate-new-tab' ) && result.type !== 'command' ) {
+			if ( actionResult.action === 'navigate' && result.type !== 'command' ) {
 				recentItemsService.saveRecentItem( result );
 			}
 

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -4,15 +4,6 @@
  */
 
 /**
- * @typedef {Object} CommandPaletteEventDetails
- * @property {number} button Mouse button pressed (e.g., 0 for left, 1 for middle, 2 for right).
- * @property {boolean} ctrlKey Whether Ctrl key was pressed.
- * @property {boolean} metaKey Whether Meta key (Cmd on macOS, Windows key on Windows) was pressed.
- * @property {boolean} shiftKey Whether Shift key was pressed.
- * @property {boolean} altKey Whether Alt key was pressed.
- */
-
-/**
  * @typedef {Object} CommandPaletteItemAction
  * @property {string} id Action identifier (e.g., 'edit').
  * @property {string} label Localized action label.
@@ -51,7 +42,7 @@
  * @property {string} [value] Optional value associated with the item, used for specific types like commands (e.g. the command trigger string '/ns').
  * @property {boolean} [highlightQuery] Whether to highlight the query in the label.
  * @property {string} [source] Identifier of the provider that generated this item (e.g., 'recent', 'command', 'search').
- * @property {CommandPaletteEventDetails} [eventDetails] Details about the event that triggered the selection.
+ * @property {boolean} [isMouseClick] True if the selection was triggered by a mouse click.
  */
 
 /**
@@ -76,14 +67,6 @@
  */
 
 /**
- * Action to navigate to a URL in a new tab.
- *
- * @typedef {Object} CommandPaletteNavigateNewTabAction
- * @property {'navigate-new-tab'} action
- * @property {string} payload - The URL to navigate to.
- */
-
-/**
  * Action to update the command palette's query string.
  *
  * @typedef {Object} CommandPaletteUpdateQueryAction
@@ -103,7 +86,7 @@
  * Describes the action the UI should take after an item selection is handled.
  * This is a discriminated union based on the 'action' property.
  *
- * @typedef {CommandPaletteNavigateAction | CommandPaletteNavigateNewTabAction | CommandPaletteUpdateQueryAction | CommandPaletteNoneAction} CommandPaletteActionResult
+ * @typedef {CommandPaletteNavigateAction | CommandPaletteUpdateQueryAction | CommandPaletteNoneAction} CommandPaletteActionResult
  */
 
 /**

--- a/resources/skins.citizen.commandPalette/utils/providerActions.js
+++ b/resources/skins.citizen.commandPalette/utils/providerActions.js
@@ -1,36 +1,20 @@
-const { CommandPaletteItem, CommandPaletteEventDetails, CommandPaletteNavigateAction, CommandPaletteNavigateNewTabAction, CommandPaletteNoneAction } = require( '../types.js' );
+const { CommandPaletteItem, CommandPaletteNavigateAction, CommandPaletteNoneAction } = require( '../types.js' );
 
 /**
- * Returns a navigation action result based on the item's URL and its embedded event details.
+ * Returns a navigation action result based on the item's URL.
  *
- * @param {CommandPaletteItem} item The selected item, which should include eventDetails if applicable.
- * @return {CommandPaletteNavigateAction | CommandPaletteNavigateNewTabAction | CommandPaletteNoneAction} Action result for the UI.
+ * This is primarily used for keyboard-driven selections (e.g., Enter key),
+ * as clicks on items with URLs are handled by standard browser behavior on `<a>` tags.
+ *
+ * @param {CommandPaletteItem} item The selected item.
+ * @return {CommandPaletteNavigateAction | CommandPaletteNoneAction} Action result for the UI.
  */
 function getNavigationAction( item ) {
 	if ( !item?.url ) {
 		return { action: 'none' };
 	}
 
-	if ( isNewTabActivation( item.eventDetails ) ) {
-		return { action: 'navigate-new-tab', payload: item.url };
-	} else {
-		return { action: 'navigate', payload: item.url };
-	}
-}
-
-/**
- * Checks if the event details indicate an intention to open in a new tab.
- *
- * @param {CommandPaletteEventDetails} eventDetails
- * @return {boolean}
- */
-function isNewTabActivation( eventDetails ) {
-	if ( !eventDetails ) {
-		return false;
-	}
-	const isMiddleClick = eventDetails.button === 1;
-	const isCtrlOrCmdClick = eventDetails.button === 0 && ( eventDetails.ctrlKey || eventDetails.metaKey );
-	return isMiddleClick || isCtrlOrCmdClick;
+	return { action: 'navigate', payload: item.url };
 }
 
 module.exports = {


### PR DESCRIPTION
Instead of using a `<div>` element and handling the events ourselves, we now use a `<a>` or `<button>` element, depending on the item's type.

It is more semantically correct and allows us to use the browser's default navigation behavior for `<a>` tags.

Fixes: #1089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions in the command palette now render as either links or buttons, improving accessibility and interaction consistency.
  * List items in the command palette can be rendered as links or buttons, matching their intended functionality.

* **Bug Fixes**
  * Improved handling of navigation actions to avoid duplicate navigation when clicking on links.
  * Fixed styling issues for icons in action buttons and links.

* **Refactor**
  * Simplified event handling and type definitions for command palette actions.
  * Removed support for opening navigation actions in a new tab from the command palette.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->