### PR TITLE
refactor: use dependency injection instead of static MediaWikiServices calls

### DIFF
--- a/includes/Components/CitizenComponentPageHeading.php
+++ b/includes/Components/CitizenComponentPageHeading.php
@@ -4,14 +4,17 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Components;
 
+use MediaWiki\Cache\GenderCache;
 use MediaWiki\Html\Html;
 use MediaWiki\Language\Language;
-use MediaWiki\MediaWikiServices;
+use MediaWiki\Language\LanguageConverterFactory;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Skin\SkinComponentUtils;
 use MediaWiki\StubObject\StubUserLang;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
+use MediaWiki\User\UserFactory;
+use MediaWiki\User\UserIdentityLookup;
 use MediaWiki\Utils\MWTimestamp;
 use MessageLocalizer;
 use Wikimedia\IPUtils;
@@ -23,7 +26,11 @@ use Wikimedia\IPUtils;
 class CitizenComponentPageHeading implements CitizenComponent {
 
 	public function __construct(
-		private MediaWikiServices $services,
+		private UserFactory $userFactory,
+		private GenderCache $genderCache,
+		private UserIdentityLookup $userIdentityLookup,
+		private LanguageConverterFactory $languageConverterFactory,
+		private Language $contentLanguage,
 		private MessageLocalizer $localizer,
 		private OutputPage $out,
 		private Language|StubUserLang $pageLang,
@@ -42,12 +49,12 @@ class CitizenComponentPageHeading implements CitizenComponent {
 		$titleText = $this->title->getText();
 
 		if ( IPUtils::isIPAddress( $titleText ) ) {
-			return $this->services->getUserFactory()->newFromName( $titleText );
+			return $this->userFactory->newFromName( $titleText );
 		}
 
-		$userIdentity = $this->services->getUserIdentityLookup()->getUserIdentityByName( $titleText );
+		$userIdentity = $this->userIdentityLookup->getUserIdentityByName( $titleText );
 		if ( $userIdentity && $userIdentity->isRegistered() ) {
-			return $this->services->getUserFactory()->newFromId( $userIdentity->getId() );
+			return $this->userFactory->newFromId( $userIdentity->getId() );
 		}
 
 		return null;
@@ -86,7 +93,7 @@ class CitizenComponentPageHeading implements CitizenComponent {
 	 * @return string
 	 */
 	private function buildGenderTagline( User $user ): string {
-		$gender = $this->services->getGenderCache()->getGenderOf( $user, __METHOD__ );
+		$gender = $this->genderCache->getGenderOf( $user, __METHOD__ );
 		$msgGender = '';
 		if ( $gender === 'male' ) {
 			$msgGender = '♂';
@@ -255,9 +262,7 @@ class CitizenComponentPageHeading implements CitizenComponent {
 
 		if ( $tagline !== '' ) {
 			// Apply language variant conversion
-			$langConv = $this->services
-				->getLanguageConverterFactory()
-				->getLanguageConverter( $this->services->getContentLanguage() );
+			$langConv = $this->languageConverterFactory->getLanguageConverter( $this->contentLanguage );
 			$tagline = $langConv->convert( $tagline );
 		}
 

--- a/includes/Components/CitizenComponentPageHeading.php
+++ b/includes/Components/CitizenComponentPageHeading.php
@@ -7,7 +7,7 @@ namespace MediaWiki\Skins\Citizen\Components;
 use MediaWiki\Cache\GenderCache;
 use MediaWiki\Html\Html;
 use MediaWiki\Language\Language;
-use MediaWiki\Language\LanguageConverterFactory;
+use MediaWiki\Languages\LanguageConverterFactory;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Skin\SkinComponentUtils;
 use MediaWiki\StubObject\StubUserLang;

--- a/includes/Components/CitizenComponentUserInfo.php
+++ b/includes/Components/CitizenComponentUserInfo.php
@@ -6,10 +6,10 @@ namespace MediaWiki\Skins\Citizen\Components;
 
 use MediaWiki\Html\Html;
 use MediaWiki\Language\Language;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\MalformedTitleException;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
+use MediaWiki\User\UserGroupManager;
 use MessageLocalizer;
 
 /**
@@ -18,7 +18,7 @@ use MessageLocalizer;
 class CitizenComponentUserInfo implements CitizenComponent {
 
 	public function __construct(
-		private MediaWikiServices $services,
+		private UserGroupManager $userGroupManager,
 		private Language $lang,
 		private MessageLocalizer $localizer,
 		private Title $title,
@@ -74,7 +74,7 @@ class CitizenComponentUserInfo implements CitizenComponent {
 	 * Build the template data for the user groups
 	 */
 	private function getUserGroups(): ?array {
-		$groups = $this->services->getUserGroupManager()->getUserGroups( $this->user );
+		$groups = $this->userGroupManager->getUserGroups( $this->user );
 
 		if ( !$groups ) {
 			return null;

--- a/includes/Partials/Metadata.php
+++ b/includes/Partials/Metadata.php
@@ -27,9 +27,20 @@ namespace MediaWiki\Skins\Citizen\Partials;
 
 use Exception;
 use MediaWiki\MainConfigNames;
-use MediaWiki\MediaWikiServices;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWiki\Utils\UrlUtils;
 
 final class Metadata extends Partial {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct(
+		SkinCitizen $skin,
+		private UrlUtils $urlUtils
+	) {
+		parent::__construct( $skin );
+	}
 
 	/**
 	 * Adds metadata to the output page
@@ -57,8 +68,7 @@ final class Metadata extends Partial {
 		}
 
 		try {
-			$href = MediaWikiServices::getInstance()->getUrlUtils()
-				->expand( wfAppendQuery( wfScript( 'api' ),
+			$href = $this->urlUtils->expand( wfAppendQuery( wfScript( 'api' ),
 					[ 'action' => 'webapp-manifest' ] ), PROTO_RELATIVE );
 		} catch ( Exception $e ) {
 			$href = '';

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -23,7 +23,11 @@
 
 namespace MediaWiki\Skins\Citizen;
 
-use MediaWiki\MediaWikiServices;
+use MediaWiki\Cache\GenderCache;
+use MediaWiki\Language\Language;
+use MediaWiki\Languages\LanguageConverterFactory;
+use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentFooter;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentMainMenu;
@@ -38,9 +42,12 @@ use MediaWiki\Skins\Citizen\Components\CitizenComponentUserInfo;
 use MediaWiki\Skins\Citizen\Partials\Metadata;
 use MediaWiki\Skins\Citizen\Partials\Theme;
 use MediaWiki\Title\Title;
+use MediaWiki\User\UserFactory;
+use MediaWiki\User\UserGroupManager;
+use MediaWiki\User\UserIdentityLookup;
+use MobileContext;
 use SkinMustache;
 use SkinTemplate;
-use Wikimedia\Services\NoSuchServiceException;
 
 /**
  * Skin subclass for Citizen
@@ -56,7 +63,18 @@ class SkinCitizen extends SkinMustache {
 	 *
 	 * @inheritDoc
 	 */
-	public function __construct( $options = [] ) {
+	public function __construct(
+		private UserFactory $userFactory,
+		private GenderCache $genderCache,
+		private UserIdentityLookup $userIdentityLookup,
+		private LanguageConverterFactory $languageConverterFactory,
+		private Language $contentLanguage,
+		private PermissionManager $permissionManager,
+		private ExtensionRegistry $extensionRegistry,
+		private UserGroupManager $userGroupManager,
+		private ?MobileContext $mfContext,
+		array $options = []
+	) {
 		if ( !isset( $options['name'] ) ) {
 			$options['name'] = 'citizen';
 		}
@@ -102,7 +120,6 @@ class SkinCitizen extends SkinMustache {
 		$title = $this->getTitle();
 		$user = $this->getUser();
 		$pageLang = $title->getPageLanguage();
-		$services = MediaWikiServices::getInstance();
 
 		$components = [
 			'data-footer' => new CitizenComponentFooter(
@@ -115,7 +132,11 @@ class SkinCitizen extends SkinMustache {
 				$parentData['data-footer']['data-info']
 			),
 			'data-page-heading' => new CitizenComponentPageHeading(
-				$services,
+				$this->userFactory,
+				$this->genderCache,
+				$this->userIdentityLookup,
+				$this->languageConverterFactory,
+				$this->contentLanguage,
 				$localizer,
 				$out,
 				$pageLang,
@@ -132,7 +153,7 @@ class SkinCitizen extends SkinMustache {
 				$localizer,
 				$title,
 				$user,
-				$services->getPermissionManager(),
+				$this->permissionManager,
 				count( $this->getLanguagesCached() ),
 				$parentData['data-portlets-sidebar'],
 				// These portlets can be unindexed
@@ -141,7 +162,7 @@ class SkinCitizen extends SkinMustache {
 			),
 			'data-search-box' => new CitizenComponentSearchBox(
 				$localizer,
-				$services->getExtensionRegistry(),
+				$this->extensionRegistry,
 				$parentData['data-search-box']
 			),
 			'data-site-stats' => new CitizenComponentSiteStats(
@@ -150,7 +171,7 @@ class SkinCitizen extends SkinMustache {
 				$pageLang
 			),
 			'data-user-info' => new CitizenComponentUserInfo(
-				$services,
+				$this->userGroupManager,
 				$lang,
 				$localizer,
 				$title,
@@ -219,15 +240,8 @@ class SkinCitizen extends SkinMustache {
 			return false;
 		}
 
-		// Check if page is in mobile view and let MF do the formatting
-		try {
-			$mfCxt = MediaWikiServices::getInstance()->getService( 'MobileFrontend.Context' );
-			return !$mfCxt->shouldDisplayMobileView();
-		} catch ( NoSuchServiceException $ex ) {
-			// MobileFrontend not installed. Don't do anything
-		}
-
-		return true;
+		// If MF is installed, check if page is in mobile view and let MF do the formatting
+		return $this->mfContext === null || !$this->mfContext->shouldDisplayMobileView();
 	}
 
 	/**

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -45,6 +45,7 @@ use MediaWiki\Title\Title;
 use MediaWiki\User\UserFactory;
 use MediaWiki\User\UserGroupManager;
 use MediaWiki\User\UserIdentityLookup;
+use MediaWiki\Utils\UrlUtils;
 use MobileContext;
 use SkinMustache;
 use SkinTemplate;
@@ -72,6 +73,7 @@ class SkinCitizen extends SkinMustache {
 		private PermissionManager $permissionManager,
 		private ExtensionRegistry $extensionRegistry,
 		private UserGroupManager $userGroupManager,
+		private UrlUtils $urlUtils,
 		private ?MobileContext $mfContext,
 		array $options = []
 	) {
@@ -288,7 +290,7 @@ class SkinCitizen extends SkinMustache {
 		$config = $this->getConfig();
 		$title = $this->getOutput()->getTitle();
 
-		$metadata = new Metadata( $this );
+		$metadata = new Metadata( $this, $this->urlUtils );
 		$skinTheme = new Theme( $this );
 
 		// Add metadata

--- a/skin.json
+++ b/skin.json
@@ -29,6 +29,19 @@
 	"ValidSkinNames": {
 		"citizen": {
 			"class": "MediaWiki\\Skins\\Citizen\\SkinCitizen",
+			"services": [
+				"UserFactory",
+				"GenderCache",
+				"UserIdentityLookup",
+				"LanguageConverterFactory",
+				"ContentLanguage",
+				"PermissionManager",
+				"ExtensionRegistry",
+				"UserGroupManager"
+			],
+			"optional_services": [
+				"MobileFrontend.Context"
+			],
 			"args": [
 				{
 					"name": "citizen",

--- a/skin.json
+++ b/skin.json
@@ -37,7 +37,8 @@
 				"ContentLanguage",
 				"PermissionManager",
 				"ExtensionRegistry",
-				"UserGroupManager"
+				"UserGroupManager",
+				"UrlUtils"
 			],
 			"optional_services": [
 				"MobileFrontend.Context"

--- a/tests/phpunit/integration/SkinCitizenTest.php
+++ b/tests/phpunit/integration/SkinCitizenTest.php
@@ -15,14 +15,34 @@ use RequestContext;
  * @group Citizen
  */
 class SkinCitizenTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * @return SkinCitizen
+	 */
+	private function createSkinInstance() {
+		return new SkinCitizen(
+			$this->getServiceContainer()->getUserFactory(),
+			$this->getServiceContainer()->getGenderCache(),
+			$this->getServiceContainer()->getUserIdentityLookup(),
+			$this->getServiceContainer()->getLanguageConverterFactory(),
+			$this->getServiceContainer()->getContentLanguage(),
+			$this->getServiceContainer()->getPermissionManager(),
+			$this->getServiceContainer()->getExtensionRegistry(),
+			$this->getServiceContainer()->getUserGroupManager(),
+			$this->getServiceContainer()->getUrlUtils(),
+			null,
+			[
+				'name' => 'Citizen',
+			]
+		);
+	}
+
 	/**
 	 * @covers \MediaWiki\Skins\Citizen\SkinCitizen
 	 * @return void
 	 */
 	public function testConstructor() {
-		$skin = new SkinCitizen( [
-			'name' => 'Citizen',
-		] );
+		$skin = $this->createSkinInstance();
 
 		$this->assertInstanceOf( SkinCitizen::class, $skin );
 	}
@@ -42,9 +62,7 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 			'CitizenEnableManifest' => true,
 		] );
 
-		$skin = new SkinCitizen( [
-			'name' => 'Citizen',
-		] );
+		$skin = $this->createSkinInstance();
 		$title = Title::newFromText( 'TestTitle' );
 		$skin->setRelevantTitle( $title );
 
@@ -71,9 +89,7 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 			'CitizenEnableManifest' => false,
 		] );
 
-		$skin = new SkinCitizen( [
-			'name' => 'Citizen',
-		] );
+		$skin = $this->createSkinInstance();
 
 		$this->assertEmpty( $skin->getOutput()->getLinkTags() );
 	}
@@ -89,9 +105,7 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 			'CitizenEnableCJKFonts' => true,
 		] );
 
-		$skin = new SkinCitizen( [
-			'name' => 'Citizen',
-		] );
+		$skin = $this->createSkinInstance();
 
 		$this->assertArrayHasKey( 'styles', $skin->getOptions() );
 		$this->assertContains( 'skins.citizen.styles.fonts.cjk', $skin->getOptions()['styles'] );
@@ -112,9 +126,7 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 			'CitizenEnableCollapsibleSections' => true,
 		] );
 
-		$skin = new SkinCitizen( [
-			'name' => 'Citizen',
-		] );
+		$skin = $this->createSkinInstance();
 
 		$this->assertArrayHasKey( 'bodyClasses', $skin->getOptions() );
 		$this->assertContains( 'citizen-sections-enabled', $skin->getOptions()['bodyClasses'] );


### PR DESCRIPTION
This PR replaces all static usages of MediaWikiServices with dependency injection through the SkinCitizen class. The service container object should in general not be passed around. Instead, we should always only pass as few services as possible to other classes. This also simplifies writing unit tests for some of the classes, like CitizenComponentPageHeading, since instead of mocking the service container, only the relevant services need to be mocked.
The logic for retrieving MobileFrontend.Context is also simplified: Instead of using a try/catch with MediaWikiServices::getService, we use an optional service that is injected into the constructor of SkinCitizen and then check whether that object is null or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of service dependencies for the Citizen skin and its components, using more explicit and efficient dependency injection.
  * Simplified logic for mobile view detection and removed unused code.
* **Chores**
  * Updated configuration to explicitly declare required and optional services for the Citizen skin.
* **Tests**
  * Refactored test setup for the Citizen skin to use a centralized helper for consistent dependency injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->