### PR TITLE
fix: duplicated specialpages link in sidebar

### DIFF
--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -273,6 +273,25 @@ class SkinCitizen extends SkinMustache {
 	}
 
 	/**
+	 * Build the sidebar but remove specialpages that is duplicated in the toolbox
+	 * 
+	 * It's a pretty dirty workaround soo
+	 * maybe throw it in the TODO with the buildNavUrls function
+	 */
+	public function buildSidebar(): array {
+		$sidebar = parent::buildSidebar();
+
+		if ( isset( $sidebar['navigation'] ) && is_array( $sidebar['navigation'] ) ) {
+			$sidebar['navigation'] = array_filter(
+				$sidebar['navigation'],
+				fn( $item ) => isset($item['id']) && $item['id'] !== 'n-specialpages'
+			);
+		}
+
+		return $sidebar;
+	}
+
+	/**
 	 * Add client preferences features
 	 * Did not add the citizen-feature- prefix because there might be features from core MW or extensions
 	 *


### PR DESCRIPTION
from #1116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the duplicate “Special Pages” entry from the sidebar. The link remains accessible via the Toolbox, reducing redundancy and visual clutter while keeping navigation consistent.
  * Improved clarity of sidebar navigation. Users will see a cleaner menu with fewer repeated links; no other navigation items are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->