### PR TITLE
fix: 🐛 use --color-visited--active

### DIFF
--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -222,6 +222,10 @@
 	&:visited:hover {
 		color: var( --color-visited--hover );
 	}
+
+	&:visited:active {
+		color: var( --color-visited--active );
+	}
 }
 
 // Based on Codex 2.0 typography tokens from T363845


### PR DESCRIPTION
This fixes an issue where visited links don't change color when activated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced link visuals by adding an active state for visited links. Previously visited links now display a distinct color when actively clicked, aligning with existing hover behavior.
  * Improves visual feedback and consistency across the interface while respecting theme colors.
  * No functional changes; purely a UI polish affecting link states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->