### PR TITLE
Fix double escaping in legacy search box

### DIFF
--- a/resources/skins.citizen.search/typeahead.js
+++ b/resources/skins.citizen.search/typeahead.js
@@ -364,7 +364,7 @@ async function getSuggestions() {
 			// Update placeholder with no result content
 			listEl.innerHTML = '';
 			groupEl.hidden = true;
-			placeholderEl.innerHTML = searchResults.getPlaceholderHTML( searchQuery.valueHtml, compiledTemplates );
+			placeholderEl.innerHTML = searchResults.getPlaceholderHTML( searchQuery.value, compiledTemplates );
 			placeholderEl.hidden = false;
 		}
 


### PR DESCRIPTION
Pass the unescaped value to getPlaceholderHTML instead of the escaped one since the mustache template already escapes it.