### PR TITLE
fix(CodeMirror): 🐛 fix the misaligned CodeMirror v6 overlay on VE

### DIFF
--- a/skinStyles/extensions/CodeMirror/ext.CodeMirror.v6.visualEditor.less
+++ b/skinStyles/extensions/CodeMirror/ext.CodeMirror.v6.visualEditor.less
@@ -25,3 +25,15 @@
 		min-width: 0;
 	}
 }
+
+.skin-citizen {
+	.ve-init-mw-desktopArticleTarget {
+		.cm-editor {
+			// @since MW 1.44
+			// T357482
+			// Ensure that CodeMirror overlay is on top of VE so the highlight works properly
+			z-index: 0;
+			padding: 0;
+		}
+	}
+}


### PR DESCRIPTION
There was a similar rule for old versions of CodeMirror but the class name is changed in v6.

Before:
<img width="491" height="69" alt="image" src="https://github.com/user-attachments/assets/4bd33930-b826-43c0-83e7-16bc9ac503e2" />

After:
<img width="396" height="66" alt="image" src="https://github.com/user-attachments/assets/8949ff25-f52f-49ee-9b3c-b830a03c136b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved layering issues in the visual editor for the Citizen skin so CodeMirror overlays display correctly above highlights.
  * Eliminated unintended padding in the editor area for a cleaner, more consistent layout.

* **Style**
  * Adjusted stacking context and spacing for the CodeMirror editor within the Citizen skin to improve visual consistency without affecting other skins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->