### PR TITLE
Make header position configurable

### DIFF
--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -337,5 +337,14 @@ class SkinCitizen extends SkinMustache {
 		if ( $config->get( 'CitizenEnableARFonts' ) === true ) {
 			$options['styles'][] = 'skins.citizen.styles.fonts.ar';
 		}
+
+		// Header position
+		$headerPosition = $config->get( 'CitizenHeaderPosition' );
+		
+		if ( !in_array( $headerPosition, [ 'left', 'right', 'top', 'bottom' ] ) ) {
+			$headerPosition = 'left';
+		}
+		
+		$this->getOutput()->addHtmlClasses( 'citizen-header-position-' . $headerPosition );
 	}
 }

--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -55,7 +55,15 @@
 }
 
 .mixin-citizen-sticky-header-element() {
-	top: var( --height-sticky-header ) !important;
+	--header-offset: var( --height-sticky-header );
+
+	@media ( min-width: @min-width-breakpoint-desktop ) {
+		.citizen-header-position-top & {
+			--header-offset: calc( var( --header-size ) + var( --height-sticky-header ) );
+		}
+	}
+
+	top: var( --header-offset ) !important;
 	transition-timing-function: var( --transition-timing-function-ease );
 	transition-duration: var( --transition-duration-medium );
 	transition-property: top;

--- a/resources/skins.citizen.styles/components/Drawer.less
+++ b/resources/skins.citizen.styles/components/Drawer.less
@@ -4,7 +4,33 @@
 		transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
-			transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-start );
+			.citizen-header-position-left & {
+				right: unset;
+				left: 100%;
+				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-start );
+			}
+
+			.citizen-header-position-right & {
+				right: 100%;
+				left: unset;
+				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-start );
+			}
+
+			.citizen-header-position-top & {
+				top: 100%;
+				right: unset;
+				left: 0;
+				bottom: unset;
+				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-start );
+			}
+
+			.citizen-header-position-bottom & {
+				top: unset;
+				right: unset;
+				left: 0;
+				bottom: 100%;
+				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
+			}
 		}
 	}
 

--- a/resources/skins.citizen.styles/components/Dropdown.less
+++ b/resources/skins.citizen.styles/components/Dropdown.less
@@ -85,8 +85,34 @@
 		.mixin-citizen-header-card( end );
 		transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-end );
 
-		@media ( min-width: @min-width-breakpoint-desktop ) {
-			transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
+		@media ( min-width: @min-width-breakpoint-desktop ) {			
+			.citizen-header-position-left & {
+				right: unset;
+				left: 100%;
+				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
+			}
+
+			.citizen-header-position-right & {
+				right: 100%;
+				left: unset;
+				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-end );
+			}
+
+			.citizen-header-position-top & {
+				top: 100%;
+				right: 0;
+				left: unset;
+				bottom: unset;
+				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-start );
+			}
+
+			.citizen-header-position-bottom & {
+				top: unset;
+				right: 0;
+				left: unset;
+				bottom: 100%;
+				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-end );
+			}
 		}
 	}
 

--- a/resources/skins.citizen.styles/components/Footer.less
+++ b/resources/skins.citizen.styles/components/Footer.less
@@ -9,9 +9,11 @@
 	direction: ltr;
 	.mixin-citizen-font-styles( 'small' );
 
-	.citizen-feature-autohide-navigation-clientpref-0 & {
-		// Reserve space for header, add only if autohide is off to avoid empty space
-		margin-bottom: var( --header-size );
+	@media ( max-width: @min-width-breakpoint-desktop ) {
+		.citizen-feature-autohide-navigation-clientpref-0 & {
+			// Reserve space for header, add only if autohide is off to avoid empty space
+			margin-bottom: var( --header-size );
+		}
 	}
 
 	&__container {

--- a/resources/skins.citizen.styles/components/Footer.less
+++ b/resources/skins.citizen.styles/components/Footer.less
@@ -3,13 +3,16 @@
 	clear: both;
 	padding: var( --space-xxl ) var( --padding-page );
 	margin-top: 8rem;
-	// Reserve space for header
-	margin-bottom: var( --header-size );
 	contain: content;
 	color: var( --color-subtle );
 	background-color: var( --color-surface-1 );
 	direction: ltr;
 	.mixin-citizen-font-styles( 'small' );
+
+	.citizen-feature-autohide-navigation-clientpref-0 & {
+		// Reserve space for header, add only if autohide is off to avoid empty space
+		margin-bottom: var( --header-size );
+	}
 
 	&__container {
 		max-width: var( --width-page );

--- a/resources/skins.citizen.styles/components/Header.less
+++ b/resources/skins.citizen.styles/components/Header.less
@@ -12,7 +12,8 @@
 	gap: var( --space-xxs );
 	padding: ~'var( --space-xs ) max( env( safe-area-inset-right ), var( --space-xs ) ) max( env( safe-area-inset-bottom ), var( --space-xs ) ) max( env( safe-area-inset-left ), var( --space-xs ) )';
 	background-color: var( --color-surface-0 );
-	border-top: var( --border-base );
+	border: 0 solid var( --border-color-base );
+	border-top-width: var( --border-width-base );
 
 	&__item {
 		display: flex;
@@ -69,7 +70,8 @@
 	&__logo {
 		padding: 0 var( --space-xs ) 0 0;
 		margin: 0 var( --space-xxs );
-		border-right: var( --border-subtle );
+		border: 0 solid var( --border-color-subtle );
+		border-right-width: var( --border-width-base );
 
 		img {
 			margin: auto;
@@ -160,28 +162,27 @@
 		top: 0;
 		right: unset;
 		left: 0;
-		border-top: 0;
 		
 		.citizen-header-position-left &__logo,
 		.citizen-header-position-right &__logo {
 			padding: 0 0 var( --space-xs ) 0;
 			margin: var( --space-xxs ) 0;
 			border-right: 0;
-			border-bottom: var( --border-width-base ) solid var( --border-color-base );
+			border-bottom-width: var( --border-width-base );
 		}
 
 		.citizen-header-position-left & {
 			--header-direction: column;
 			right: unset;
 			left: 0;
-			border-right: var( --border-width-base ) solid var( --border-color-base );
+			border-right-width: var( --border-width-base );
 		}
 
 		.citizen-header-position-right & {
 			--header-direction: column;
 			right: 0;
 			left: unset;
-			border-left: var( --border-width-base ) solid var( --border-color-base );
+			border-left-width: var( --border-width-base );
 		}
 
 		.citizen-header-position-top & {
@@ -189,7 +190,7 @@
 			right: 0;
 			bottom: unset;
 			left: 0;
-			border-bottom: var( --border-width-base ) solid var( --border-color-base );
+			border-bottom-width: var( --border-width-base );
 		}
 
 		.citizen-header-position-bottom & {
@@ -197,7 +198,7 @@
 			right: 0;
 			bottom: 0;
 			left: 0;
-			border-top: var( --border-width-base ) solid var( --border-color-base );
+			border-top-width: var( --border-width-base );
 		}
 	}
 }

--- a/resources/skins.citizen.styles/components/Header.less
+++ b/resources/skins.citizen.styles/components/Header.less
@@ -157,18 +157,47 @@
 
 @media ( min-width: @min-width-breakpoint-desktop ) {
 	.citizen-header {
-		--header-direction: column;
 		top: 0;
 		right: unset;
 		left: 0;
 		border-top: 0;
-		border-right: var( --border-base );
-
-		&__logo {
+		
+		.citizen-header-position-left &__logo,
+		.citizen-header-position-right &__logo {
 			padding: 0 0 var( --space-xs ) 0;
 			margin: var( --space-xxs ) 0;
 			border-right: 0;
-			border-bottom: var( --border-subtle );
+			border-bottom: var( --border-width-base ) solid var( --border-color-base );
+		}
+
+		.citizen-header-position-left & {
+			--header-direction: column;
+			right: unset;
+			left: 0;
+			border-right: var( --border-width-base ) solid var( --border-color-base );
+		}
+
+		.citizen-header-position-right & {
+			--header-direction: column;
+			right: 0;
+			left: unset;
+			border-left: var( --border-width-base ) solid var( --border-color-base );
+		}
+
+		.citizen-header-position-top & {
+			top: 0;
+			right: 0;
+			bottom: unset;
+			left: 0;
+			border-bottom: var( --border-width-base ) solid var( --border-color-base );
+		}
+
+		.citizen-header-position-bottom & {
+			top: unset;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			border-top: var( --border-width-base ) solid var( --border-color-base );
 		}
 	}
 }

--- a/resources/skins.citizen.styles/components/StickyHeader.less
+++ b/resources/skins.citizen.styles/components/StickyHeader.less
@@ -39,7 +39,17 @@
 		transition-property: transform, visibility;
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
-			margin-left: var( --header-size );
+			.citizen-header-position-left & {
+				margin-left: var( --header-size );
+			}
+
+			.citizen-header-position-right & {
+				margin-right: var( --header-size );
+			}
+			
+			.citizen-header-position-top & {
+				transform: translateY( calc( var( --header-size ) - 100% ) );
+			}
 		}
 	}
 
@@ -168,6 +178,12 @@
 		&-container {
 			visibility: visible;
 			transform: none;
+
+			@media ( min-width: @min-width-breakpoint-desktop ) {
+				.citizen-header-position-top & {
+					transform: translateY( calc( var( --header-size ) + 1px ) );
+				}
+			}
 		}
 	}
 }

--- a/resources/skins.citizen.styles/components/StickyHeader.less
+++ b/resources/skins.citizen.styles/components/StickyHeader.less
@@ -181,7 +181,7 @@
 
 			@media ( min-width: @min-width-breakpoint-desktop ) {
 				.citizen-header-position-top & {
-					transform: translateY( calc( var( --header-size ) + 1px ) );
+					transform: translateY( calc( var( --header-size ) + var( --border-width-base ) ) );
 				}
 			}
 		}

--- a/resources/skins.citizen.styles/components/TableOfContents.less
+++ b/resources/skins.citizen.styles/components/TableOfContents.less
@@ -210,10 +210,18 @@
 
 @media ( min-width: @min-width-breakpoint-desktop ) {
 	.citizen-toc {
+		--header-offset: var( --height-sticky-header );
+
+		@media ( min-width: @min-width-breakpoint-desktop ) {
+			.citizen-header-position-top & {
+				--header-offset: calc( var( --header-size ) + var( --height-sticky-header ) );
+			}
+		}
+
 		position: -webkit-sticky;
 		position: sticky;
-		top: var( --height-sticky-header );
-		max-height: ~'calc( 100vh - var( --height-sticky-header ) )';
+		top: var( --header-offset );
+		max-height: ~'calc( 100vh - var( --header-offset ) )';
 		padding: var( --space-xs ) 0;
 		overflow-y: auto;
 		overscroll-behavior: contain;

--- a/resources/skins.citizen.styles/components/TableOfContents.less
+++ b/resources/skins.citizen.styles/components/TableOfContents.less
@@ -212,10 +212,16 @@
 	.citizen-toc {
 		--header-offset: var( --height-sticky-header );
 
-		@media ( min-width: @min-width-breakpoint-desktop ) {
-			.citizen-header-position-top & {
-				--header-offset: calc( var( --header-size ) + var( --height-sticky-header ) );
-			}
+		.citizen-header-position-top & {
+			--header-offset: calc( var( --header-size ) + var( --height-sticky-header ) );
+		}
+
+		.ve-active & {
+			--header-offset: 48px;
+		}
+
+		.citizen-header-position-top.ve-active & {
+			--header-offset: calc( var( --header-size ) + 48px );
 		}
 
 		position: -webkit-sticky;

--- a/resources/skins.citizen.styles/layout.less
+++ b/resources/skins.citizen.styles/layout.less
@@ -39,7 +39,21 @@
 @media ( min-width: @min-width-breakpoint-desktop ) {
 	.citizen-page-container {
 		// Reserve space for header
-		margin-left: var( --header-size );
+		.citizen-header-position-left & {
+			margin-left: var( --header-size );
+		}
+
+		.citizen-header-position-right & {
+			margin-right: var( --header-size );
+		}
+
+		.citizen-header-position-top & {
+			margin-top: var( --header-size );
+		}
+
+		.citizen-header-position-bottom & {
+			margin-bottom: var( --header-size );
+		}
 	}
 
 	.citizen-toc-enabled {

--- a/skin.json
+++ b/skin.json
@@ -893,6 +893,12 @@
 			"description": "Enables or disable the command palette. Disable to use the old search module.",
 			"descriptionmsg": "citizen-config-enablecommandpalette",
 			"public": true
+		},
+		"HeaderPosition": {
+			"value": "left",
+			"description": "Position of the header on the desktop layout. Possible values: 'left', 'right', 'top' and 'bottom'",
+			"descriptionmsg": "citizen-config-headerposition",
+			"public": true
 		}
 	},
 	"manifest_version": 2

--- a/skinStyles/extensions/CookieWarning/ext.CookieWarning.styles.less
+++ b/skinStyles/extensions/CookieWarning/ext.CookieWarning.styles.less
@@ -28,7 +28,15 @@
 
 	@media only screen and ( min-width: @min-width-breakpoint-desktop ) {
 		right: unset;
-		left: var( --header-size );
+		left: 0;
+
+		.citizen-header-position-left & {
+			left: var( --header-size );
+		}
+	}
+
+	.citizen-header-position-bottom & {
+		bottom: var( --header-size );
 	}
 
 	.mw-cookiewarning-text {

--- a/skinStyles/extensions/Echo/ext.echo.ui.less
+++ b/skinStyles/extensions/Echo/ext.echo.ui.less
@@ -23,6 +23,33 @@
 		box-shadow: var( --box-shadow-large );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
+			.citizen-header-position-left & {
+        		right: unset !important;
+				left: var( --header-size ) !important;
+				bottom: 0 !important;
+			}
+
+			.citizen-header-position-right & {
+				right: var( --header-size ) !important;
+				left: unset !important;
+				bottom: 0 !important;
+			}
+
+			.citizen-header-position-top & {
+				right: 0 !important;
+				left: unset !important;
+				top: var( --header-size ) !important;
+				bottom: unset !important;
+			}
+
+			.citizen-header-position-bottom & {
+				right: 0 !important;
+				left: unset !important;
+				bottom: var( --header-size ) !important;
+			}
+		}
+
+		@media ( min-width: @min-width-breakpoint-desktop ) {
 			bottom: 0 !important;
 			left: var( --header-size ) !important;
 		}
@@ -83,6 +110,13 @@
 	top: unset;
 	bottom: 0;
 	z-index: @z-index-overlay; // Higher than header
+
+	@media ( min-width: @min-width-breakpoint-desktop ) {
+		.citizen-header-position-top & {
+			top: 0;
+			bottom: unset;
+		}
+	}
 
 	// Add dismiss affordnance backdrop
 	@media ( max-width: @max-width-breakpoint-tablet ) {

--- a/skinStyles/extensions/Echo/ext.echo.ui.less
+++ b/skinStyles/extensions/Echo/ext.echo.ui.less
@@ -49,11 +49,6 @@
 			}
 		}
 
-		@media ( min-width: @min-width-breakpoint-desktop ) {
-			bottom: 0 !important;
-			left: var( --header-size ) !important;
-		}
-
 		.oo-ui-popupWidget-body {
 			height: auto !important;
 			max-height: ~'calc( var( --header-card-maxheight ) - 2 * 3.1428571em )'; // 3.1428571em = height of .oo-ui-popupWidget-head & .oo-ui-popupWidget-footer

--- a/skinStyles/extensions/MediaSearch/mediasearch.styles.less
+++ b/skinStyles/extensions/MediaSearch/mediasearch.styles.less
@@ -780,6 +780,10 @@
 				border-bottom-right-radius: 0;
 				border-bottom-left-radius: 0;
 			}
+
+			.citizen-header-position-bottom & {
+				padding-bottom: var( --header-size );
+			}
 		}
 	}
 

--- a/skinStyles/extensions/VisualEditor/ext.visualEditor.core.less
+++ b/skinStyles/extensions/VisualEditor/ext.visualEditor.core.less
@@ -14,6 +14,12 @@
 	/* Fix weird gap between save button and toolbar bottom */
 	border-bottom: 0;
 	box-shadow: 0 1px 0 0 var( --border-color-base );
+
+	@media ( min-width: @min-width-breakpoint-desktop ) {
+		.citizen-header-position-top .ve-ui-toolbar-floating& {
+			top: var( --header-size );
+		}
+	}
 }
 
 /* ve.ce.BranchNode.css */

--- a/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
+++ b/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
@@ -49,6 +49,12 @@
 	&-bar {
 		border-bottom-color: var( --border-color-base );
 		box-shadow: none;
+
+		@media ( min-width: @min-width-breakpoint-desktop ) {
+			.citizen-header-position-top & {
+				top: var( --header-size );
+			}
+		}
 	}
 }
 

--- a/skinStyles/mediawiki/debug/mediawiki.debug.less
+++ b/skinStyles/mediawiki/debug/mediawiki.debug.less
@@ -147,7 +147,17 @@ a.mw-debug-panelabel:visited {
 
 	@media ( min-width: @min-width-breakpoint-desktop ) {
 		// So that it is not hidden by header
-		margin-left: var( --header-size );
+		.citizen-header-position-left & {
+			margin-left: var( --header-size );
+		}
+
+		.citizen-header-position-right & {
+			margin-right: var( --header-size );
+		}
+
+		.citizen-header-position-top & {
+			margin-top: var( --header-size );
+		}
 	}
 }
 

--- a/skinStyles/mediawiki/special/mediawiki.special.preferences.styles.ooui.less
+++ b/skinStyles/mediawiki/special/mediawiki.special.preferences.styles.ooui.less
@@ -36,6 +36,10 @@
 		@media ( max-width: @max-width-breakpoint-tablet ) {
 			bottom: var( --header-size );
 		}
+
+		.citizen-header-position-bottom & {
+			bottom: var( --header-size );
+		}
 	}
 }
 


### PR DESCRIPTION
closes #528, basically

* Add `wgCitizenHeaderPosition` config (`left` (default), `top`, `right`, `bottom`) for the desktop layout.
* Add `citizen-header-position-<pos>` class to `<html>` and adjust styles to support this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable desktop header position (left, right, top, bottom) with a safe default and consistent CSS class output.

* **Style**
  * Position-aware desktop layouts applied broadly (header, drawer, dropdowns, sticky header, ToC, page container, notifications, footer, cookie warning, media search, editor toolbars).
  * Dynamic header-offset handling for sticky behavior, transforms, margins and sizing to improve responsive alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->