### PR TITLE
fix(SyntaxHighlight): 🐛 remove background color that exceeds the border

### DIFF
--- a/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
+++ b/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
@@ -11,7 +11,7 @@
 /* pygments.generated.css */
 .skin-citizen {
 	.mw-highlight {
-		background: var( --color-surface-2 );
+		background: none;
 
 		.c {
 			color: var( --color-syntax-grey );


### PR DESCRIPTION
This fixes an issue where SyntaxHighlight background is showing beyond the border.

Before fixing:
<img width="1338" height="770" alt="SyntaxHighlight background extends beyond the border" src="https://github.com/user-attachments/assets/945dfe37-b297-4288-a249-c194bf7c0f54" />
After fixing:
<img width="1263" height="786" alt="SyntaxHighlight background does not extend beyond borders" src="https://github.com/user-attachments/assets/8a6c91f4-2b53-48c5-8911-a07140bcaf90" />
