### PR TITLE
fix(commandPalette): 🐛 use page.key for id

### DIFF
--- a/resources/skins.citizen.commandPalette/searchClients/MwRestSearchClient.js
+++ b/resources/skins.citizen.commandPalette/searchClients/MwRestSearchClient.js
@@ -78,7 +78,7 @@ class MwRestSearchClient {
 			results: response.pages.map( ( page ) => {
 				const thumbnail = page.thumbnail;
 				return {
-					id: `citizen-command-palette-item-page-${ page.id }`,
+					id: `citizen-command-palette-item-page-${ page.key }`,
 					type: 'page',
 					label: page.title,
 					description: showDescription ? page.description : undefined,


### PR DESCRIPTION
Currently, the Command Palette uses the page ID for item IDs and v-bind:keys.

However, according to [the documentation](https://www.mediawiki.org/wiki/Help:Page_ID), Special pages do not come with page IDs.

In fact, when you search for Special pages in the Command Palette, 0 is used as the ID. 

<img width="1905" height="756" alt="Search for Special pages on the Star Citizen Wiki" src="https://github.com/user-attachments/assets/10eed28d-0454-4987-981d-5f264adedf1d" />

Instead, we use the page key. The [HTML Living Standard](
https://html.spec.whatwg.org/multipage/dom.html#global-attributes) does not restrict the types of characters that can be used in IDs, except for spaces, so this should be fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of command palette search results by refining how each result is identified, reducing mismatches and duplicate entries.
  * Ensures selections, quick actions, and navigation consistently target the correct item.
  * Enhances stability for features that rely on result identity (e.g., recent items and shortcuts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->