### PR TITLE
fix(core): 🐛 style issues when `calc(breakpoint -1px) < viewport_width < breakpoint`

### DIFF
--- a/resources/mediawiki.less/mediawiki.skin.variables.less
+++ b/resources/mediawiki.less/mediawiki.skin.variables.less
@@ -37,3 +37,8 @@
 @color-link-external: var( --color-link );
 @color-link-external--visited: var( --color-link );
 @color-link-external--active: var( --color-link--active );
+// work around the limitations of `min-` and `max-` prefixes and viewports with fractional widths.
+// see https://github.com/twbs/bootstrap/blob/8f3d0580a36d3eba2a9f90d90ceaf6e50f452365/scss/mixins/_breakpoints.scss#L43 for why `- 0.02px` is used.
+@max-width-breakpoint-mobile: ( @min-width-breakpoint-tablet - 0.02px );
+@max-width-breakpoint-tablet: ( @min-width-breakpoint-desktop - 0.02px );
+@max-width-breakpoint-desktop: ( @min-width-breakpoint-desktop-wide - 0.02px );


### PR DESCRIPTION
It is possible for a viewport to have a non-integer width when the user's system/browser scales.

![Image](https://github.com/user-attachments/assets/a5fd9427-c119-4931-a2b4-f36b6f95015d)

~~I removed some of the `screnn and`. That is because in [CSS Conditional Rules Module Level 3](https://drafts.csswg.org/css-conditional-3/#at-media), the `not` keyword can't be used to negate an individual media feature expression, only an entire media query, which affects Chrome \< 104, Safari \< 16.4. I believe the removal won't cause an issue. I don't think there is any reason that these styles should not be applied to printer views.~~

~~Update: Fine, I've noticed that almost all files are imported inside a huge `@media screen { }` in resources/skins.citizen.styles/skin.less. I have no word to say...~~

Update 2: I switched to another solution, which is the same as Bootstrap's. It will have no compatibility issues. Another day, I will submit the changes to the upstream MediaWiki source code, or you can submit them for me, as I don't have a developer account for now.