### PR TITLE
feat(typography): ✨ improve emphasis styles for East Asian scripts

### DIFF
--- a/resources/skins.citizen.styles/common/typography.less
+++ b/resources/skins.citizen.styles/common/typography.less
@@ -55,16 +55,20 @@ figcaption {
 }
 
 em {
-	// Languages that do not use italics for emphasis
-	// References:
-	// zh: https://www.w3.org/TR/2025/DNOTE-clreq-20251008/#id84
-	// ja: https://www.w3.org/TR/2020/NOTE-jlreq-20200811/#composition_of_emphasis_dots
-	// mn: https://www.w3.org/TR/2025/DNOTE-mlreq-20250710/#h_emphasis
-	// ko: emphasis not mentioned in klreq, further investigation needed
+	/**
+	 * Languages that do not use italics for emphasis
+	 *
+	 * References:
+	 * - zh: {@link https://www.w3.org/TR/2025/DNOTE-clreq-20251008/#id84}
+	 * - ja: {@link https://www.w3.org/TR/2020/NOTE-jlreq-20200811/#composition_of_emphasis_dots}
+	 * - mn: {@link https://www.w3.org/TR/2025/DNOTE-mlreq-20250710/#h_emphasis}
+	 * - ko: emphasis not mentioned in klreq, further investigation needed
+	 *
+	 * We assume that `mn` without `-Mong` is written in Cyrillic, namely `mn-Cyrl`
+	 */
 	&:lang( zh ),
 	&:lang( ja ),
 	&:lang( ko ),
-	// We assume that `mn` without `-Mong` is written in Cyrillic, namely `mn-Cyrl`
 	&:lang( mn-Mong ) {
 		font-style: normal;
 	}
@@ -86,7 +90,7 @@ em {
 
 	&:lang( mn-Mong ) {
 		// For vertical text, wavy line should appear on the right side
-		// but we are unable to implement this
+		// but we are unable to implement that
 		text-decoration: underline wavy;
 	}
 }


### PR DESCRIPTION
[clreq](https://www.w3.org/TR/2025/DNOTE-clreq-20251008/#id84): dots are used in both horizontal and vertical writing modes.
[mlreq](https://www.w3.org/TR/2025/DNOTE-mlreq-20250710/#h_emphasis): wavy lines are used instead of dots.

And I fixed a bug introduced in 2d9febf0e2f5210e14d4a998d6b720674ec54046 making Chinese `text-emphasis-position` failed to apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated Mongolian (mn-Mong) emphasis handling, including a vertical-text fallback using a wavy underline.
* **Bug Fixes**
  * Corrected emphasis rendering for Chinese and Korean with appropriate markers and positioning for improved readability.
  * Standardized Mongolian (mn) text style to avoid unintended italics.
* **Style**
  * Reorganized language-specific typography rules for clearer, more consistent emphasis behavior.
* **Documentation**
  * Added inline comments explaining language-specific emphasis assumptions and current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->