### PR TITLE
Prevent #1159 from being applied on the main page

### DIFF
--- a/resources/skins.citizen.styles/common/content.less
+++ b/resources/skins.citizen.styles/common/content.less
@@ -55,6 +55,10 @@
 	.citizen-body-container {
 		margin-top: var( --space-xl );
 	}
+
+	.page-actions {
+		margin-inline-start: 0;
+	}
 }
 
 // Heading HTML changes

--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -2,10 +2,7 @@
 	display: flex;
 	gap: var( --space-xxs );
 	align-items: center;
-
-	body:not( .page-Main_Page.action-view ) & {
-		margin-inline-start: auto;
-	}
+	margin-inline-start: auto;
 
 	// TODO: Merge this with header__item
 	&__item {


### PR DESCRIPTION
...as it seems to override the centering of page actions there.
<img width="1144" height="95" alt="image" src="https://github.com/user-attachments/assets/34a609f0-16dd-4936-ad5c-f9ebfa16b3de" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the spacing of page actions on the main page for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->