### PR TITLE
fix(mixins): 🐛 fix unknown custom properties in hsl mode

### DIFF
--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -9,7 +9,7 @@
 	background: ~'oklch( var( --color-surface-@{surface}-oklch__l ) var( --color-surface-@{surface}-oklch__c ) var( --color-progressive-oklch__h ) / var( --opacity-glass ) )';
 
 	@supports not ( color: oklch( 100% 0 0 ) ) {
-		background: ~'hsl( var( --color-surface-@{surface}-hsl__h ), var( --color-surface-@{surface}-hsl__s ), var( --color-surface-@{surface}-hsl__l ) / var( --oapcity-glass ) )';
+		background: ~'hsl( var( --color-progressive-hsl__h ), var( --color-surface-@{surface}-hsl__s ), var( --color-surface-@{surface}-hsl__l ) / var( --opacity-glass ) )';
 	}
 }
 


### PR DESCRIPTION
P.S. there are 2 stylelint errors not caused by me.
```
resources/skins.citizen.styles/common/progressbar.less
  25:13  ✖  Expected single space after ":"  @stylistic/declaration-colon-space-after
  25:15  ✖  Expected indentation of 2 tabs   @stylistic/indentation
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved color rendering fallback for browsers without advanced color format support, ensuring consistent visual appearance across varying browser compatibility levels
* Corrected color styling configuration variable reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->