### PR TITLE
fix(page-actions, citizen-toc): Fixed the sudden disappearance of `.page-actions` and `.citizen-toc`. Fixes #1193

### DIFF
--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -126,9 +126,6 @@
 			transition-property: opacity;
 		}
 
-
-
-
 		.citizen-scroll--down {
 			// Need the unit for calc() (#1058)
 			// stylelint-disable-next-line length-zero-no-unit
@@ -137,8 +134,8 @@
 			// Because we have already used `transform` to hide the header
 			// If we use bottom in the meantime, the transition will not work.
 
-			
-            .citizen-sticky-header-container, // header should use the same timing function
+			// header should use the same timing function
+			.citizen-sticky-header-container,
 			.citizen-header,
 			.citizen-toc,
 			.page-actions {


### PR DESCRIPTION
此拉取请求修复了 #1193 .

## 起源
3.10.0中并未真正修复闪现的问题，仅仅是用`transition-property: transform` 覆盖了 `transition-property: transform, opacity`， 导致 `.page-actions` 瞬间消失，从而看不到闪现的过程。故将此行删除。

## 修复闪现
将 `--header-block-size-end` 添加 `px` 单位后，闪现会被修复，之前之所以出现错误是因为有单位和无单位的长度之间不能正常渐变。但仍然没有动画。

经研究，这其实是因为同时通过 `bottom` 和 `transform` 属性改变位置，导致浏览器不能创建渐变。故删除了 `--header-size-block-end: 0;` 一行。

已在本地用 Docker 搭建的 MediaWiki 1.44.2 上测试，表现正常。

## 其他
此外，本人对缓动函数做了微调，确保标题栏和底栏的动画一致性。

第一次提交 PR，如有不对敬请斧正。请在合并我的 PR 时添加协作者：
```
Co-authored-by: ChenWuwei404 <Uplantting@163.com>
Co-authored-by: SolidBlock <32444848+SolidBlock-cn@users.noreply.github.com>
```
**Patch from Rolling Sky Wiki Tech Team.**

----
English (Machine translation, and I roughly reviewed)
## Origin
The flickering issue was not actually fixed in version 3.10.0. It merely overrided `transition-property: transform, opacity` with `transition-property: transform`, which caused the `.page-actions` element to disappear instantly, thus hiding the flickering process. Therefore, I removed this line.

## Fixing the Flickering
After adding the `px` unit to `--header-block-size-end`, the flickering is fixed. This is because interpolation does not work correctly between a length with a unit and a unitless length. However, there is still no animation.

After investigation, the root cause is actually the simultaneous change of position via both the `bottom` and `transform` properties. This prevents the browser from creating a smooth transition. Therefore, the line `--header-size-block-end: 0;` has been removed.

Tested locally on a MediaWiki 1.44.2 instance set up with Docker, and it behaves normally.

## Others
Additionally, fine-tuning has been applied to the easing functions to ensure animation consistency between the header bar and the bottom bar.

This is my first PR submission. Please feel free to correct me if anything is amiss. Please add the following collaborators when merging this PR.
```
Co-authored-by: ChenWuwei404 <Uplantting@163.com>
Co-authored-by: SolidBlock <32444848+SolidBlock-cn@users.noreply.github.com>
```

Patch from Rolling Sky Wiki Tech Team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Smoother, more consistent transitions for the header, table of contents, sticky header area, and page actions on tablet and mobile.
  * Aligns transition timing and duration with the title bar for uniform show/hide motion when scrolling up and down.
  * Preserves header auto-hide behavior while removing a legacy flicker workaround for cleaner visuals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->