### PR TITLE
Revise introduction for Citizen MediaWiki skin

### DIFF
--- a/docs/src/guide/introduction.md
+++ b/docs/src/guide/introduction.md
@@ -5,7 +5,7 @@ description: Introduction to the Citizen skin
 
 # Introduction
 
-![](https://upload.wikimedia.org/wikipedia/commons/0/07/Screenshot-skin-citizen.png)
+![Citizen skin screenshot showing the responsive layout and modern interface](https://upload.wikimedia.org/wikipedia/commons/0/07/Screenshot-skin-citizen.png)
 
 Citizen is a beautiful, usable, responsive <a href="https://www.mediawiki.org">MediaWiki</a> skin that makes <a href="https://www.mediawiki.org/wiki/Manual:Extensions">extensions</a> part of the cohesive experience. Originally made for the Star Citizen Wiki, it has now been made flexible to run on various MediaWiki configurations.
 
@@ -31,7 +31,7 @@ Unlike the other standard MediaWiki skins, Citizen has a lot more to offer:
         Article sections on the wiki can be collapsed and expanded.
     </LinkCard>
     <LinkCard title="Progressive web app">
-        Users can add your wiki to their home screen, giving a more app-like experience.
+        Users can add a wiki using Citizen to their home screen, giving a more app-like experience.
     </LinkCard>
 </LinkGrid>
 


### PR DESCRIPTION
Removed construction warning and added detailed introduction to the Citizen MediaWiki skin, highlighting its features and community contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the "Under Construction" notice in the introduction with a rich, visual overview of the Citizen skin: an image, an intro paragraph, feature cards (responsive layout, command palette, theme modes, cohesive extension styles, reading preferences, collapsible sections, PWA support), visual examples, and a call-to-contribute.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->