### PR TITLE
[WIP] fix(sticky-header): Make the sticky header and the title header fit together better

### DIFF
--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -52,10 +52,13 @@
 }
 
 .mixin-citizen-sticky-header-element() {
-	top: var( --header-offset-block-start ) !important;
-	transition-timing-function: var( --transition-timing-function-ease );
+	top: 0 !important;
+	// If we use `top` to position sticky elements,
+	// the sticky header does not fit together with the title header perfectly.
+	transform: translateY( var( --header-offset-block-start ) );
+	transition-timing-function: @mobile-header-transition-timing-function;
 	transition-duration: var( --transition-duration-medium );
-	transition-property: top;
+	transition-property: transform;
 }
 
 .mixin-citizen-sticky-header-background() {

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -107,7 +107,7 @@
 		.citizen-toc,
 		.page-actions {
 			// use ease-out when scrolling up, in consistence with the title bar (.citizen-sticky-header-container)
-			transition-timing-function: var( --transition-timing-function-ease-out );
+			transition-timing-function: @mobile-header-transition-timing-function;
 			// use the same duration as the title bar
 			transition-duration: var( --transition-duration-medium );
 		}
@@ -133,14 +133,6 @@
 			// Just do not modify --header-size-block-end
 			// Because we have already used `transform` to hide the header
 			// If we use bottom in the meantime, the transition will not work.
-
-			// header should use the same timing function
-			.citizen-sticky-header-container,
-			.citizen-header,
-			.citizen-toc,
-			.page-actions {
-				transition-timing-function: var( --transition-timing-function-ease-in );
-			}
 
 			.citizen-header {
 				transform: translate3d( 0, 100%, 0 );

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -99,3 +99,13 @@
 @dark-bg-40: #2b2f36;
 @dark-bg-50: #33363d;
 @dark-bg-60: #34383f;
+
+// We use this for title header, ToC, page-actions, bottom header,
+// and .mixin-citizen-sticky-header-element,
+// whether the user is scrolling up or down on mobile.
+// Although it seems that we should use ease-in for fade-out, symmetrical to ease-out for fade-in,
+// but actually using ease-out for both does not look weird.
+// Instead, ease-out is actually better because fading out with ease-in is laggy.
+// Also, using different timing functions for fade-in and fade-out creates the trouble
+// that we cannot use a single mixin class `.mixin-citizen-sticky-header-element` for both cases.
+@mobile-header-transition-timing-function: var( --transition-timing-function-ease-out );


### PR DESCRIPTION
我又来了。

讲个笑话，我跑linter给我报了28351个错误，全是“行尾序列应为Unix风格（LF）”的错误😂。

我把标题栏进入和收回的缓动都改成了`ease-out`。（请看注释）尽管有人可能会认为这个不对称，我觉得还好，毕竟以前的版本其实也没有用`ease-in`。而且这样我们就可以用一个LESS混入类解决问题。

但是我遇到了点困难。我把sticky header的定位改为了`top: 0`，位置变换完全由`transform`处理。（您可以试试用`top`，它不如用`transform`严丝合缝。）这样一来虽然说贴合更好了，但是定位不太对了，如果快速翻向文件页顶部，这个吸顶的文件页目录会明显地跳一下。

一个解决办法是把标题栏改成也必须用`top`的。我不知道这合不合适。

请帮我解决这个问题，然后合并修改，谢谢。

Machine translated:

Hello again!

A (not so) little linting story:​ The linter reported 28,351 errors all of which were about "Line ending sequences should be Unix-style (LF)". Let's just say I had a fun time scrolling through those 😂.

Animation Easing:​ I've changed the easing curves for both the title bar's expand and collapse animations to ease-out. (Please see the code comments). While some might consider this asymmetrical, I think it's acceptable because the previous version didn't use `ease-in` either. The main advantage is that we can now handle both states using a single LESS mixin.

Sticky Header Positioning Challenge:​ I encountered a slight issue while working on the sticky header. I changed its positioning to use top: 0, intending to handle all movement solely through `transform` for better performance/consistency (You can try using `top` for animations; it's not as seamless as `transform`). While this makes the positioning tighter, it introduced a new problem. e.g. When quickly scrolling to the top of a file page, the sticky ToC now has a noticeable jump.

----

A potential fix is to adjust the title bar's styling so it mustalso be positioned using top. I'm not entirely sure if this is the appropriate approach or if it might have unintended side effects. Could you please advise on the best way to resolve this jumping issue?

Please help me fix the issue before merging. Thanks.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined sticky header positioning to use transform-based offsetting for smoother, more consistent animations.
  * Introduced a new mobile header transition timing setting to standardize easing on small screens.
  * Updated transition timing for table of contents and page actions for improved responsiveness.
  * Removed a redundant transition rule to simplify header state transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->