### PR TITLE
fix: VE edit button has wrong border-radius on source code edit page

### DIFF
--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -125,7 +125,7 @@
 // Merge two buttons together
 .client-js .citizen-ve-edit-merged {
 	// Additional check to check if there are actually source edit button (#929)
-	&#ca-ve-edit:has( + #ca-edit ) {
+	&#ca-ve-edit:has( + #ca-edit:not( .selected ) ) {
 		> a {
 			border-top-right-radius: 0;
 			border-bottom-right-radius: 0;


### PR DESCRIPTION
<img width="479" height="128" alt="QQ_1766042609639" src="https://github.com/user-attachments/assets/ccc28772-e480-4e2a-9fbe-4b9d77e373fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined edit button styling in page tools to improve visual consistency of merged button groups. The update narrows when rounded corners and merge borders are applied based on the selection state of nearby edit controls, reducing awkward visual transitions and improving the appearance of adjacent controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->