### PR TITLE
feat(DismissableSiteNotice): modernize dismiss button styling

### DIFF
--- a/skinStyles/extensions/DismissableSiteNotice/ext.dismissableSiteNotice.less
+++ b/skinStyles/extensions/DismissableSiteNotice/ext.dismissableSiteNotice.less
@@ -16,8 +16,8 @@
 					line-height: 1;
 					color: var( --color-base );
 					text-align: center;
-					content: '\00d7'; // close icon
 					cursor: pointer;
+					content: '\00d7'; // close icon
 				}
 
 				&:hover {


### PR DESCRIPTION
minor css improvement to DismissableSiteNotice extension styling

before/after:

<img width="633" height="324" alt="Screenshot 2026-01-01 at 22 44 45 1" src="https://github.com/user-attachments/assets/5908c434-8740-46d6-933b-1f3cc127bb3a" />
<img width="616" height="311" alt="Screenshot 2026-01-01 at 17 37 58" src="https://github.com/user-attachments/assets/1b560219-ed50-44c2-ad7f-ffced66ae32f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the site notice close control: increased spacing, added rounded corners, and a pointer cursor for clearer affordance.
  * Updated hover and active feedback to use subtle background-color changes instead of color-only shifts for more consistent and accessible interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->