### PR TITLE
Fix progress indicator styling for language pills in Translate extension

### DIFF
--- a/skinStyles/extensions/Translate/ext.translate.tag.languages.less
+++ b/skinStyles/extensions/Translate/ext.translate.tag.languages.less
@@ -48,9 +48,9 @@
 		display: flex;
 		padding: var( --space-xs ) var( --space-md );
 		color: var( --color-subtle );
+		text-decoration: none;
 		border: var( --border-width-base ) solid var( --border-color-interactive );
 		border-radius: var( --border-radius-pill );
-		text-decoration: none;
 
 		&:hover,
 		&:active {
@@ -109,21 +109,21 @@
 		&.mw-pt-progress--med {
 			&.mw-pt-languages-selected::after,
 			&:hover::after {
-				background: conic-gradient(var( --color-inverted-fixed ) 180deg, var( --background-color-transparent ) 0deg);
+				background: conic-gradient( var( --color-inverted-fixed ) 180deg, var( --background-color-transparent ) 0deg );
 			}
 		}
 
 		&.mw-pt-progress--high {
 			&.mw-pt-languages-selected::after,
 			&:hover::after {
-				background: conic-gradient(var( --color-inverted-fixed ) 252deg, var( --background-color-transparent ) 0deg);
+				background: conic-gradient( var( --color-inverted-fixed ) 252deg, var( --background-color-transparent ) 0deg );
 			}
 		}
 
 		&.mw-pt-progress--complete {
 			&.mw-pt-languages-selected::after,
 			&:hover::after {
-				background: conic-gradient(var( --color-inverted-fixed ) 360deg, var( --background-color-transparent ) 0deg);
+				background: conic-gradient( var( --color-inverted-fixed ) 360deg, var( --background-color-transparent ) 0deg );
 			}
 		}
 	}


### PR DESCRIPTION
From
<img width="543" height="88" alt="image" src="https://github.com/user-attachments/assets/7fe5a3f7-90e3-4aee-b590-c9370efd6cc5" />
To
<img width="543" height="88" alt="image" src="https://github.com/user-attachments/assets/bfc1f4d5-7afa-43fa-8420-301454cf5f3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling for language selection and translation progress indicators.
  * Switched layout to improve alignment and spacing of language items.
  * Enhanced hover and selected states with clearer outline and spacing.
  * Added dynamic gradient and outline visuals to represent multiple progress levels.
  * Minor accessibility-focused visual tweaks for selected/hovered items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->