### PR TITLE
Update font-family for profile header attributes

### DIFF
--- a/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
+++ b/skinStyles/extensions/UserProfileV2/ext.userProfileV2.less
@@ -11,8 +11,7 @@
 /* ext.userProfileV2.less */
 
 .profile-header-attributes > h1,
-.profile-header-attributes > h2,
-.ext-discussiontools-init-section > * {
+.profile-header-attributes > h2 {
 	font-family: var( --font-family-base ) !important;
 }
 


### PR DESCRIPTION
adds a little !important since it still stays in helvetica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enforced font usage for profile header titles to ensure consistent typography on user profile pages by making the font declaration take precedence, preventing unintended overrides across themes and display contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->