### PR TITLE
Fix "strtolower(): Argument #1 ($string) must be of type string, bool given"

### DIFF
--- a/includes/Components/CitizenComponentPageHeading.php
+++ b/includes/Components/CitizenComponentPageHeading.php
@@ -214,9 +214,11 @@ class CitizenComponentPageHeading implements CitizenComponent {
 			return $this->buildUserTagline();
 		}
 
-		$nsMsgKey = 'citizen-tagline-ns-' . strtolower( $title->getNsText() );
-		if ( !$this->localizer->msg( $nsMsgKey )->isDisabled() ) {
-			return $this->localizer->msg( $nsMsgKey )->parse();
+		if ( $title->getNsText() ) {
+			$nsMsgKey = 'citizen-tagline-ns-' . strtolower( $title->getNsText() );
+			if ( !$this->localizer->msg( $nsMsgKey )->isDisabled() ) {
+				return $this->localizer->msg( $nsMsgKey )->parse();
+			}
 		}
 
 		return $this->getCitizenTagline( 'citizen-tagline' );


### PR DESCRIPTION
->getNsText() can return false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Page heading now skips namespace tagline lookup when no namespace text is present, reducing unnecessary processing and improving performance; retains fallback to the default citizen tagline when no namespace-specific tagline applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->