### PR TITLE
style(file): 🎨 allow #filetoc to wrap for long localizations

### DIFF
--- a/skinStyles/mediawiki/action/mediawiki.action.view.filepage.less
+++ b/skinStyles/mediawiki/action/mediawiki.action.view.filepage.less
@@ -13,6 +13,7 @@
 
 #filetoc {
 	display: flex;
+	flex-wrap: wrap;
 	padding: 0;
 	margin: 0;
 	font-weight: var( --font-weight-medium );


### PR DESCRIPTION
The navigation menu (#filetoc) is forced into a single line. This causes it to overflow and go off-screen when the items don't fit. While it's most noticeable in languages with long strings (like Russian or German), it can also happen on English and other languages on narrow screens or high zoom levels.

Added flex-wrap: wrap to allow items to move to a new row when there isn't enough space.

**Before:**
<img width="564" height="950" alt="Снимок экрана_20260205_172953" src="https://github.com/user-attachments/assets/91ede39a-f81b-4373-bc4d-c2663ea8d9c5" />

**After:**
<img width="564" height="950" alt="Снимок экрана_20260205_173111" src="https://github.com/user-attachments/assets/0a5cc0e3-455c-4c2b-839f-0ba4a909c48e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved file table of contents layout to properly wrap items across multiple lines when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->