### PR TITLE
fix(commandPalette): restore body height animation

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -529,7 +529,6 @@ module.exports = exports = defineComponent( {
 	}
 
 	&__body {
-		flex: 1;
 		min-height: 0;
 		overflow: hidden;
 		border-top: var( --border-subtle );


### PR DESCRIPTION
## Summary

The command palette body's height animation was instant — content size changes (e.g. typing a query, opening a mode) snapped between sizes instead of transitioning over the configured 250ms.

**Root cause:** `.citizen-command-palette__body` had `flex: 1` (= `flex: 1 1 0%`). The palette is a content-sized flex column (`max-height` only, no fixed `height`), so the flex algorithm computed body's main-axis size from grow-distributed space and ignored the inline `height` style. The CSS `transition: height` had no value change to animate; the JS-set inline value from the `ResizeObserver` was effectively decorative.

Verified in browser before/after:
- **Before** — `body.style.height = '50px'` and `'2000px'` both leave rendered height at 115px. Content changes jump instantly: `115 → 153 → 561` with no intermediate frames.
- **After** — `height` property drives rendered size. Content changes interpolate smoothly over ~250ms.

**Fix:** Remove `flex: 1`, fall back to default `flex: 0 1 auto`. The body's `height` is now honored, the transition animates, and shrink-on-overflow still works via the default `flex-shrink: 1` + existing `min-height: 0`.

## Test plan

- [x] `npm run lint:js` (no errors in App.vue)
- [x] `npm run lint:styles` (no errors)
- [x] `npm test` (all Vitest suites pass via pre-commit)
- [x] **Single-pane:** Typing 'a' animates `114 → 141 → 150 → 152` then `152 → 228 → 447 → 541 → 560` (smooth interpolation across ~250ms each)
- [x] **Two-pane (SMW with detail panel):** Mode change with detail visible animates `656 → 361 → 291 → 286` then `286 → 225 → 211 → 210`
- [x] **Max-height engaged (400px viewport):** Palette pinned to 304px max, body shrinks via `flex-shrink: 1` from inline 208px to rendered 198px. Animation still smooth: `114 → 121 → 128 → 133 → 141 → 146 → 149 → 150 → 152` then `152 → 172 → 180 → 197 → 198`. Results scrollbar engages correctly at the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)