### PR TITLE
fix: derive inline script path relative to file location

### DIFF
--- a/includes/Hooks/SkinHooks.php
+++ b/includes/Hooks/SkinHooks.php
@@ -44,7 +44,7 @@ class SkinHooks implements
 			self::$inlineScript ??= Html::inlineScript(
 				RL\ResourceLoader::filter(
 					'minify-js',
-					file_get_contents( MW_INSTALL_PATH . '/skins/Citizen/resources/skins.citizen.scripts/inline.js' )
+					file_get_contents( __DIR__ . '/../../resources/skins.citizen.scripts/inline.js' )
 				)
 			);
 			$out->addHeadItem( 'skin.citizen.inline', self::$inlineScript );


### PR DESCRIPTION
## Summary
- Resolve `inline.js` path via `__DIR__` instead of `MW_INSTALL_PATH . '/skins/Citizen/...'` so the skin works when installed outside `/skins/Citizen/`.

Fixes #1479

## Test plan
- [x] Install Citizen in a non-default location (e.g. `/skins/MyCitizen/`) and verify no `file_get_contents` warning is logged
- [x] Confirm the inline theme switcher script still appears in `<head>` when `$wgCitizenEnablePreferences = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)