### PR TITLE
fix(toc): restore px on zero header tokens used in calc()

### DIFF
--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -127,8 +127,8 @@
 		}
 
 		.citizen-scroll--down {
-			// Need the unit for calc() (#1058)
-			--height-sticky-header: 0 !important;
+			// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
+			--height-sticky-header: 0px !important;
 			// Just do not modify --header-size-block-end
 			// Because we have already used `transform` to hide the header
 			// If we use bottom in the meantime, the transition will not work.

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -37,8 +37,8 @@
 	--toolbar-size: 2.5rem;
 	// Used to offset sticky elements with sticky header
 	// This is overriden by inline styles in the html element when sticky header is active
-	// Need the unit for calc() (#1058)
-	--height-sticky-header: 0;
+	// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
+	--height-sticky-header: 0px;
 	// Width or height of citizen-header, depending on the orientation
 	--header-size: @header-size;
 	// Max-height allowed for header card, 20vh is left for closing affordnance
@@ -128,8 +128,10 @@
 	--header-direction: row;
 	--header-size-inline-start: 0;
 	--header-size-inline-end: 0;
-	--header-size-block-start: 0;
-	--header-size-block-end: 0;
+	// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
+	--header-size-block-start: 0px;
+	// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
+	--header-size-block-end: 0px;
 	--header-inset-block-start: 0;
 	--header-inset-block-end: 0;
 	--header-inset-inline-start: 0;


### PR DESCRIPTION
## Summary

Restores the `px` unit on three zero-valued CSS variables that feed into `calc()` expressions:

- `--height-sticky-header` (tokens-citizen.less)
- `--header-size-block-start` (tokens-citizen.less)
- `--header-size-block-end` (tokens-citizen.less)
- `--height-sticky-header` override in `.citizen-scroll--down` (common/features.less)

Each line carries a `// stylelint-disable-next-line length-zero-no-unit` comment with a `#1058` rationale so the unit isn't stripped again.

## Background

Commit [4df28173](../commit/4df281738b26c0d2f1ef9b468cfe693ee9a3ed3f) (`style: 🎨 fix various stylelint issues`) silenced `length-zero-no-unit` warnings by changing `0px` → `0` on these custom properties. The pre-existing inline comment `// Need the unit for calc() (#1058)` warned this would break consumers; the warning was missed.

In CSS, an unadorned `0` inside `calc()` is type `<number>` (the unitless‑zero shortcut only applies at the property‑value level, not inside `calc()`). The downstream tokens are:

```less
--header-offset-block-start: calc( var(--header-size-block-start) + var(--height-sticky-header) );
--header-offset-block-end:   var( --header-size-block-end );
```

After the regression, `--header-offset-block-start` resolves to `calc(0 + 0)` → `<number> 0`, which is invalid for a `<length>` consumer. When the sticky header activates and JS sets `--height-sticky-header: 64px`, the calc becomes `calc(0 + 64px)` → `<number> + <length>`, also invalid in `calc()`.

The visible symptom: `.citizen-toc { top: var(--header-offset-block-start) }` (TableOfContents.less:198) silently falls back to `top: auto`, so `position: sticky` stops pinning the ToC in the desktop layout. `scroll-padding-bottom` in common.less and any consumer of `--header-offset-block-end` are similarly invalidated. Same root cause as #1058.

## Test plan

- [x] Open a page with a long ToC at desktop width. ToC should stick to the top of the viewport when scrolling, not scroll away with the article.
- [x] Activate the sticky header (scroll down past the page header). ToC `top` should offset by the sticky header height instead of overlapping it.
- [x] Mobile/tablet: ToC dropdown still anchors at the bottom (uses `--header-size-block-end` override inside the mobile media query, which is set to `var(--header-size)` and unaffected).
- [x] `npm run lint:styles` passes without flagging the restored `0px` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced styling code quality and standardization across theme token definitions for improved maintainability and linting compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->