### PR TITLE
feat(commandPalette): compact result row variant for command-style modes

### DIFF
--- a/docs/src/customization/command-palette.md
+++ b/docs/src/customization/command-palette.md
@@ -114,6 +114,7 @@ Every entry must have at minimum an `id`, `triggers`, and `description`. If the 
 | `description` | `string` | Yes | Short explanation shown in the command list. |
 | `placeholder` | `string` | No | Input placeholder when mode is active (e.g., "Search users"). Modes only. |
 | `icon` | `Object` | No | Codex icon for the header when mode is active. Modes only. |
+| `compactResults` | `boolean` | No | Render results in a denser layout — a small icon instead of a thumbnail and the description inline beside the label. Use this for command-style modes whose items don't have real thumbnail images. Modes only. |
 | `getResults` | `function` | No | `(subQuery, signal?, tokens?, modeContext?) => Promise<Array>` — if provided, this entry is a mode. The optional fourth argument is the current [mode context](#mode-context) stack. |
 | `onResultSelect` | `function` | No | `(item) => { action, payload }` — handles selection of a result item. |
 | `headerLabel` | `function` | No | `(modeContext) => string \| null` — replaces the input placeholder with a custom label. Return `null` to fall back to the regular placeholder — useful for showing a breadcrumb only when the mode is drilled in. Typically used with [mode context](#mode-context). Modes only. |

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -68,6 +68,7 @@
 								:highlighted-item-index="highlightedItemIndex"
 								:search-query="query"
 								:set-item-ref="setItemRef"
+								:compact="!!activeMode?.compactResults"
 								@select="selectResult"
 								@action="handleAction"
 								@hover="handleHover"
@@ -688,7 +689,8 @@ module.exports = exports = defineComponent( {
 				// alias/type badges and inline description that would
 				// otherwise crowd the row.
 				.citizen-command-palette-list-item__metadata,
-				.citizen-command-palette-list-item__text__description {
+				.citizen-command-palette-list-item__text__description,
+				.citizen-command-palette-list-item__text-inline__description {
 					display: none;
 				}
 			}

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
@@ -22,6 +22,7 @@
 				:key="item.id"
 				v-bind="getListItemBindings( item, getGlobalIndex( sectionIndex, localIndex ) )"
 				:ref="( el ) => setItemRef && setItemRef( el, getGlobalIndex( sectionIndex, localIndex ) )"
+				:compact="compact"
 				@change="( property, value ) => onItemChange( item.id, property, value )"
 				@select="( result ) => $emit( 'select', result )"
 				@action="( action ) => $emit( 'action', action )"
@@ -58,6 +59,10 @@ module.exports = exports = defineComponent( {
 			type: Function,
 			required: false,
 			default: null
+		},
+		compact: {
+			type: Boolean,
+			default: false
 		}
 	},
 	emits: [ 'select', 'action', 'hover' ],

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
@@ -25,6 +25,7 @@ Partially based on the MenuItem component from Codex.
 			:search-query="searchQuery"
 			:url="url"
 			:highlight-query="highlightQuery"
+			:compact="compact"
 			@click="onClick"
 		></command-palette-list-item-content>
 		<command-palette-list-item-actions
@@ -106,6 +107,10 @@ module.exports = exports = defineComponent( {
 			default: () => []
 		},
 		highlightQuery: {
+			type: Boolean,
+			default: false
+		},
+		compact: {
 			type: Boolean,
 			default: false
 		},

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
@@ -4,16 +4,45 @@
 		:href="url || undefined"
 		:type="url ? undefined : 'button'"
 		class="citizen-command-palette-list-item__content"
+		:class="{ 'citizen-command-palette-list-item__content--compact': compact }"
 	>
+		<cdx-icon
+			v-if="compact"
+			:icon="thumbnailIcon"
+			size="medium"
+			class="citizen-command-palette-list-item__icon"
+		></cdx-icon>
 		<cdx-thumbnail
+			v-else
 			:thumbnail="thumbnail"
 			:placeholder-icon="thumbnailIcon || undefined"
 			class="citizen-command-palette-list-item__thumbnail"
 		></cdx-thumbnail>
 
-		<div class="citizen-command-palette-list-item__text">
+		<div
+			v-if="compact"
+			class="citizen-command-palette-list-item__text-inline"
+		>
+			<span class="citizen-command-palette-list-item__text__label">
+				<cdx-search-result-title
+					v-if="highlightQuery"
+					:title="label"
+					:search-query="searchQuery"
+				></cdx-search-result-title>
+				<template v-else>{{ label }}</template>
+			</span>
+			<span
+				v-if="description"
+				class="citizen-command-palette-list-item__text-inline__description"
+			>
+				<bdi>{{ description }}</bdi>
+			</span>
+		</div>
+		<div
+			v-else
+			class="citizen-command-palette-list-item__text"
+		>
 			<div class="citizen-command-palette-list-item__text__label">
-				<!-- Technically you are not supposed to use CdxSearchResultTitle... -->
 				<cdx-search-result-title
 					v-if="highlightQuery"
 					:title="label"
@@ -120,6 +149,10 @@ module.exports = exports = defineComponent( {
 		highlightQuery: {
 			type: Boolean,
 			default: false
+		},
+		compact: {
+			type: Boolean,
+			default: false
 		}
 	}
 } );
@@ -150,6 +183,15 @@ module.exports = exports = defineComponent( {
 		&:hover {
 			text-decoration: none;
 		}
+
+		&--compact {
+			padding-block: var( --space-xs );
+		}
+	}
+
+	&__icon {
+		flex-shrink: 0;
+		color: var( --color-subtle );
 	}
 
 	&__text {
@@ -190,6 +232,45 @@ module.exports = exports = defineComponent( {
 		}
 	}
 
+	&__text-inline {
+		display: flex;
+		flex: 1;
+		column-gap: var( --space-xs );
+		align-items: baseline;
+		min-width: 0;
+		.mixin-citizen-font-styles( 'body' );
+
+		.citizen-command-palette-list-item__text__label {
+			flex-shrink: 0;
+			min-width: 0;
+			max-width: 100%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			font-weight: var( --font-weight-semi-bold );
+			color: var( --color-emphasized );
+			white-space: nowrap;
+
+			.cdx-search-result-title {
+				display: inline;
+				font-weight: var( --font-weight-semi-bold );
+				color: var( --color-emphasized );
+
+				&__match {
+					color: var( --color-subtle );
+				}
+			}
+		}
+
+		&__description {
+			flex: 1 1 0;
+			min-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			color: var( --color-subtle );
+			white-space: nowrap;
+		}
+	}
+
 	&__metadata {
 		display: flex;
 		gap: var( --space-xxs );
@@ -201,7 +282,7 @@ module.exports = exports = defineComponent( {
 			align-items: center;
 			padding: 2px var( --space-xs );
 			line-height: var( --line-height-small );
-			background: var( --color-surface-3 );
+			background: var( --color-surface-2 );
 			border: var( --border-subtle );
 			border-radius: var( --border-radius-base );
 

--- a/resources/skins.citizen.commandPalette/modes/action.js
+++ b/resources/skins.citizen.commandPalette/modes/action.js
@@ -136,6 +136,7 @@ function createActionCommand( documentRef, ApiConstructor ) {
 		description: mw.message( 'citizen-command-palette-command-action-description' ).text(),
 		placeholder: mw.message( 'citizen-command-palette-mode-action-placeholder' ).text(),
 		icon: cdxIconSpecialPages,
+		compactResults: true,
 		help: {
 			description: 'citizen-command-palette-mode-action-description-help'
 		},

--- a/resources/skins.citizen.commandPalette/modes/category.js
+++ b/resources/skins.citizen.commandPalette/modes/category.js
@@ -227,6 +227,7 @@ function createCategoryMode( ApiConstructor ) {
 		description: mw.message( 'citizen-command-palette-command-category-description' ).text(),
 		placeholder: mw.message( 'citizen-command-palette-mode-category-placeholder' ).text(),
 		icon: cdxIconTag,
+		compactResults: true,
 		emptyState: {
 			title: mw.message( 'citizen-command-palette-mode-category-empty-title' ).text(),
 			description: mw.message( 'citizen-command-palette-mode-category-empty-description' ).text(),

--- a/resources/skins.citizen.commandPalette/modes/help.js
+++ b/resources/skins.citizen.commandPalette/modes/help.js
@@ -13,6 +13,7 @@ module.exports = {
 	triggers: [ '/help', '?' ],
 	label: mw.message( 'citizen-command-palette-command-help-label' ).text(),
 	description: mw.message( 'citizen-command-palette-command-help-description' ).text(),
+	compactResults: true,
 	onResultSelect() {
 		return { action: 'toggleHelp' };
 	}

--- a/resources/skins.citizen.commandPalette/modes/namespace.js
+++ b/resources/skins.citizen.commandPalette/modes/namespace.js
@@ -120,6 +120,7 @@ module.exports = {
 	description: mw.message( 'citizen-command-palette-command-ns-description' ).text(),
 	placeholder: mw.message( 'citizen-command-palette-mode-ns-placeholder' ).text(),
 	icon: cdxIconArticles,
+	compactResults: true,
 	tokenPattern: {
 		modeId: 'namespace',
 		position: 'prefix',

--- a/resources/skins.citizen.commandPalette/modes/user.js
+++ b/resources/skins.citizen.commandPalette/modes/user.js
@@ -108,6 +108,7 @@ function createUserCommand( ApiConstructor ) {
 		description: mw.message( 'citizen-command-palette-command-user-description' ).text(),
 		placeholder: mw.message( 'citizen-command-palette-mode-user-placeholder' ).text(),
 		icon: cdxIconUserAvatar,
+		compactResults: true,
 		emptyState: {
 			title: mw.message( 'citizen-command-palette-mode-user-empty-title' ).text(),
 			description: mw.message( 'citizen-command-palette-mode-user-empty-description' ).text(),

--- a/tests/vitest/commandPalette/components/CommandPaletteListItemContent.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteListItemContent.test.js
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+const { mount } = require( '@vue/test-utils' );
+const mw = require( '../../mocks/mw.js' );
+globalThis.mw = mw;
+
+mw.loader.require = vi.fn( () => ( {
+	CdxIcon: {
+		name: 'CdxIcon',
+		template: '<span class="cdx-icon"></span>',
+		props: [ 'icon', 'size' ]
+	},
+	CdxSearchResultTitle: {
+		name: 'CdxSearchResultTitle',
+		template: '<span class="cdx-search-result-title">{{ title }}</span>',
+		props: [ 'title', 'searchQuery' ]
+	},
+	CdxThumbnail: {
+		name: 'CdxThumbnail',
+		template: '<div class="cdx-thumbnail"></div>',
+		props: [ 'thumbnail', 'placeholderIcon' ]
+	}
+} ) );
+
+let CommandPaletteListItemContent;
+
+const BASE_PROPS = {
+	url: '/wiki/Foo',
+	label: 'Foo',
+	description: '',
+	thumbnail: null,
+	thumbnailIcon: 'icon-name',
+	metadata: [],
+	type: 'page',
+	typeLabel: 'Page',
+	searchQuery: '',
+	highlightQuery: false,
+	compact: false
+};
+
+function mountContent( propsOverrides = {} ) {
+	return mount( CommandPaletteListItemContent, {
+		props: { ...BASE_PROPS, ...propsOverrides }
+	} );
+}
+
+beforeAll( async () => {
+	const mod = await import(
+		'../../../../resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue'
+	);
+	CommandPaletteListItemContent = mod.default;
+} );
+
+afterEach( () => {
+	vi.restoreAllMocks();
+} );
+
+describe( 'CommandPaletteListItemContent', () => {
+	describe( 'default (non-compact) layout', () => {
+		it( 'renders a CdxThumbnail', () => {
+			const wrapper = mountContent();
+
+			expect( wrapper.findComponent( { name: 'CdxThumbnail' } ).exists() ).toBe( true );
+			expect( wrapper.findComponent( { name: 'CdxIcon' } ).exists() ).toBe( false );
+		} );
+
+		it( 'renders the description block when description is present', () => {
+			const wrapper = mountContent( { description: 'A description' } );
+
+			const description = wrapper.find( '.citizen-command-palette-list-item__text__description' );
+			expect( description.exists() ).toBe( true );
+			expect( description.text() ).toBe( 'A description' );
+		} );
+
+		it( 'omits the description block when description is empty', () => {
+			const wrapper = mountContent( { description: '' } );
+
+			expect( wrapper.find( '.citizen-command-palette-list-item__text__description' ).exists() ).toBe( false );
+		} );
+	} );
+
+	describe( 'compact layout', () => {
+		it( 'renders a CdxIcon and not a CdxThumbnail', () => {
+			const wrapper = mountContent( { compact: true } );
+
+			expect( wrapper.findComponent( { name: 'CdxIcon' } ).exists() ).toBe( true );
+			expect( wrapper.findComponent( { name: 'CdxThumbnail' } ).exists() ).toBe( false );
+		} );
+
+		it( 'renders the icon at medium size', () => {
+			const wrapper = mountContent( { compact: true } );
+
+			const icon = wrapper.findComponent( { name: 'CdxIcon' } );
+			expect( icon.props( 'size' ) ).toBe( 'medium' );
+		} );
+
+		it( 'renders label and description as siblings inside one inline container', () => {
+			const wrapper = mountContent( { compact: true, description: 'Group: admin' } );
+
+			const inline = wrapper.find( '.citizen-command-palette-list-item__text-inline' );
+			expect( inline.exists() ).toBe( true );
+
+			const label = inline.find( '.citizen-command-palette-list-item__text__label' );
+			const description = inline.find( '.citizen-command-palette-list-item__text-inline__description' );
+
+			expect( label.exists() ).toBe( true );
+			expect( description.exists() ).toBe( true );
+			expect( label.text() ).toContain( 'Foo' );
+			expect( description.text() ).toBe( 'Group: admin' );
+		} );
+
+		it( 'omits the description node when description is empty', () => {
+			const wrapper = mountContent( { compact: true, description: '' } );
+
+			expect( wrapper.find( '.citizen-command-palette-list-item__text-inline__description' ).exists() ).toBe( false );
+		} );
+
+		it( 'renders CdxSearchResultTitle for the label when highlightQuery is true', () => {
+			const wrapper = mountContent( {
+				compact: true,
+				highlightQuery: true,
+				searchQuery: 'Foo'
+			} );
+
+			const title = wrapper.findComponent( { name: 'CdxSearchResultTitle' } );
+			expect( title.exists() ).toBe( true );
+			expect( title.props( 'title' ) ).toBe( 'Foo' );
+			expect( title.props( 'searchQuery' ) ).toBe( 'Foo' );
+		} );
+
+		it( 'still renders metadata items', () => {
+			const wrapper = mountContent( {
+				compact: true,
+				metadata: [ { label: 'meta', icon: '' } ]
+			} );
+
+			const items = wrapper.findAll( '.citizen-command-palette-list-item__metadata__item' );
+			// One for the metadata entry, one for the type label
+			expect( items.length ).toBeGreaterThanOrEqual( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

- Adds a per-mode `compactResults: true` flag that swaps the 40px `cdx-thumbnail` placeholder box for a bare 20px `cdx-icon` and renders label + description inline on a single line at the same body font size.
- Opts in `/action`, `/namespace`, `/category`, `/user`, and `/help` — modes whose items have icons rather than real thumbnail images.
- Changes the metadata badge background globally from `--color-surface-3` to `--color-surface-2` so chips sit one surface step lighter against the row background (applies to default-layout rows too).

The non-compact branch is structurally unchanged. The compact branch is a `v-if`/`v-else` split inside `CommandPaletteListItemContent.vue` rather than a separate component, since the metadata block and prop interface are shared.

## Behaviour

- **Compact rows**: bare icon, single-line label + description (whitespace separator, color contrast carries the visual break), tighter vertical padding. Description shrinks first under truncation pressure; label keeps its content width and ellipses only when forced.
- **Default rows**: untouched apart from the badge background tweak.
- **Detail-pane layout**: when the two-pane detail view is active, both `__text__description` (default) and `__text-inline__description` (compact) are hidden — the new selector was added to the existing rule.
- **Trigger**: per-mode opt-in. Mixed compact/non-compact rows in one list would look chaotic, so the choice is at the mode level, not per-item.

## Test plan

- [x] `npm run preflight` — 38 test files, 566 tests pass, no new lint warnings
- [x] New Vitest cases in `tests/vitest/commandPalette/components/CommandPaletteListItemContent.test.js` cover both layouts, the `description`-empty case, and the `highlightQuery` path in compact mode
- [x] Browser smoke test (`/action`) — bare icons, inline label+description, badges with `--color-surface-2`
- [x] Default-mode rendering unchanged (recent / search results)
- [x] RTL (`?uselang=he`) — icon mirrors to the right, metadata to the left
- [x] XSS (`?uselang=x-xss`) — 190 compact rows rendered, all payloads escaped to `&lt;script&gt;`, no `<script>` tags injected, no console errors
- [x] Dark mode — icons and badges legible
- [x] Independent code review (Sonnet) — verdict: Ready to merge, one Important issue found and fixed before push