### PR TITLE
build(docs): upgrade vitepress to 2.0.0-alpha.17

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17,268 +17,10 @@
 				"oxfmt": "^0.48.0",
 				"oxlint": "^1.63.0",
 				"oxlint-tsgolint": "^0.22.1",
-				"vitepress": "^1.0.0",
+				"vitepress": "2.0.0-alpha.17",
 				"vitepress-plugin-group-icons": "^1.6.5",
-				"vitepress-plugin-tabs": "^0.7.3",
-				"vue": "^3.0.0"
-			}
-		},
-		"node_modules/@algolia/abtesting": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.11.0.tgz",
-			"integrity": "sha512-a7oQ8dwiyoyVmzLY0FcuBqyqcNSq78qlcOtHmNBumRlHCSnXDcuoYGBGPN1F6n8JoGhviDDsIaF/oQrzTzs6Lg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/autocomplete-core": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
-			"integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
-				"@algolia/autocomplete-shared": "1.17.7"
-			}
-		},
-		"node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
-			"integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/autocomplete-shared": "1.17.7"
-			},
-			"peerDependencies": {
-				"search-insights": ">= 1 < 3"
-			}
-		},
-		"node_modules/@algolia/autocomplete-preset-algolia": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
-			"integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/autocomplete-shared": "1.17.7"
-			},
-			"peerDependencies": {
-				"@algolia/client-search": ">= 4.9.1 < 6",
-				"algoliasearch": ">= 4.9.1 < 6"
-			}
-		},
-		"node_modules/@algolia/autocomplete-shared": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
-			"integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"@algolia/client-search": ">= 4.9.1 < 6",
-				"algoliasearch": ">= 4.9.1 < 6"
-			}
-		},
-		"node_modules/@algolia/client-abtesting": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.45.0.tgz",
-			"integrity": "sha512-WTW0VZA8xHMbzuQD5b3f41ovKZ0MNTIXkWfm0F2PU+XGcLxmxX15UqODzF2sWab0vSbi3URM1xLhJx+bXbd1eQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/client-analytics": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.45.0.tgz",
-			"integrity": "sha512-I3g7VtvG/QJOH3tQO7E7zWTwBfK/nIQXShFLR8RvPgWburZ626JNj332M3wHCYcaAMivN9WJG66S2JNXhm6+Xg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/client-common": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.45.0.tgz",
-			"integrity": "sha512-/nTqm1tLiPtbUr+8kHKyFiCOfhRfgC+JxLvOCq471gFZZOlsh6VtFRiKI60/zGmHTojFC6B0mD80PB7KeK94og==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/client-insights": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.45.0.tgz",
-			"integrity": "sha512-suQTx/1bRL1g/K2hRtbK3ANmbzaZCi13487sxxmqok+alBDKKw0/TI73ZiHjjFXM2NV52inwwcmW4fUR45206Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/client-personalization": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.45.0.tgz",
-			"integrity": "sha512-CId/dbjpzI3eoUhPU6rt/z4GrRsDesqFISEMOwrqWNSrf4FJhiUIzN42Ac+Gzg69uC0RnzRYy60K1y4Na5VSMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/client-query-suggestions": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.45.0.tgz",
-			"integrity": "sha512-tjbBKfA8fjAiFtvl9g/MpIPiD6pf3fj7rirVfh1eMIUi8ybHP4ovDzIaE216vHuRXoePQVCkMd2CokKvYq1CLw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/client-search": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.45.0.tgz",
-			"integrity": "sha512-nxuCid+Nszs4xqwIMDw11pRJPes2c+Th1yup/+LtpjFH8QWXkr3SirNYSD3OXAeM060HgWWPLA8/Fxk+vwxQOA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/ingestion": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.45.0.tgz",
-			"integrity": "sha512-t+1doBzhkQTeOOjLHMlm4slmXBhvgtEGQhOmNpMPTnIgWOyZyESWdm+XD984qM4Ej1i9FRh8VttOGrdGnAjAng==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/monitoring": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.45.0.tgz",
-			"integrity": "sha512-IaX3ZX1A/0wlgWZue+1BNWlq5xtJgsRo7uUk/aSiYD7lPbJ7dFuZ+yTLFLKgbl4O0QcyHTj1/mSBj9ryF1Lizg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/recommend": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.45.0.tgz",
-			"integrity": "sha512-1jeMLoOhkgezCCPsOqkScwYzAAc1Jr5T2hisZl0s32D94ZV7d1OHozBukgOjf8Dw+6Hgi6j52jlAdUWTtkX9Mg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.45.0.tgz",
-			"integrity": "sha512-46FIoUkQ9N7wq4/YkHS5/W9Yjm4Ab+q5kfbahdyMpkBPJ7IBlwuNEGnWUZIQ6JfUZuJVojRujPRHMihX4awUMg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/requester-fetch": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.45.0.tgz",
-			"integrity": "sha512-XFTSAtCwy4HdBhSReN2rhSyH/nZOM3q3qe5ERG2FLbYId62heIlJBGVyAPRbltRwNlotlydbvSJ+SQ0ruWC2cw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@algolia/requester-node-http": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.45.0.tgz",
-			"integrity": "sha512-8mTg6lHx5i44raCU52APsu0EqMsdm4+7Hch/e4ZsYZw0hzwkuaMFh826ngnkYf9XOl58nHoou63aZ874m8AbpQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/client-common": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
+				"vitepress-plugin-tabs": "^0.9.0",
+				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/@antfu/install-pkg": {
@@ -316,13 +58,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.5"
+				"@babel/types": "^7.29.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -332,9 +74,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -346,60 +88,30 @@
 			}
 		},
 		"node_modules/@docsearch/css": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
-			"integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
+			"integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@docsearch/js": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
-			"integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.6.3.tgz",
+			"integrity": "sha512-qUIX2b4Apew3tv4F0qhmgShsl/Lfw4m6mqv/5/5dWNxwTcDdLMp2s3YwZ+NMGh3IKCg0pBaXm7Q5VdyU5Rj+cQ==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@docsearch/react": "3.8.2",
-				"preact": "^10.0.0"
-			}
+			"license": "MIT"
 		},
-		"node_modules/@docsearch/react": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
-			"integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+		"node_modules/@docsearch/sidepanel-js": {
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/@docsearch/sidepanel-js/-/sidepanel-js-4.6.3.tgz",
+			"integrity": "sha512-grGSmvXzG0if+mrzdIKykvpIAuEQ9u0sEJ2eLRRCaQfJvsWqh2C2/aY04bIzWvDh7myi5rvl8D+tUNsVrjYQ3A==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/autocomplete-core": "1.17.7",
-				"@algolia/autocomplete-preset-algolia": "1.17.7",
-				"@docsearch/css": "3.8.2",
-				"algoliasearch": "^5.14.2"
-			},
-			"peerDependencies": {
-				"@types/react": ">= 16.8.0 < 19.0.0",
-				"react": ">= 16.8.0 < 19.0.0",
-				"react-dom": ">= 16.8.0 < 19.0.0",
-				"search-insights": ">= 1 < 3"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"react-dom": {
-					"optional": true
-				},
-				"search-insights": {
-					"optional": true
-				}
-			}
+			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-			"integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -410,13 +122,13 @@
 				"aix"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-			"integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
 			"cpu": [
 				"arm"
 			],
@@ -427,13 +139,13 @@
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-			"integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -444,13 +156,13 @@
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-			"integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
 			"cpu": [
 				"x64"
 			],
@@ -461,13 +173,13 @@
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-			"integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -478,13 +190,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-			"integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
 			"cpu": [
 				"x64"
 			],
@@ -495,13 +207,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-			"integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -512,13 +224,13 @@
 				"freebsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-			"integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
 			"cpu": [
 				"x64"
 			],
@@ -529,13 +241,13 @@
 				"freebsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-			"integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
 			"cpu": [
 				"arm"
 			],
@@ -546,13 +258,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-			"integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -563,13 +275,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-			"integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
 			"cpu": [
 				"ia32"
 			],
@@ -580,13 +292,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-			"integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
 			"cpu": [
 				"loong64"
 			],
@@ -597,13 +309,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-			"integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -614,13 +326,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-			"integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -631,13 +343,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-			"integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -648,13 +360,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-			"integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
 			"cpu": [
 				"s390x"
 			],
@@ -665,13 +377,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-			"integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
 			"cpu": [
 				"x64"
 			],
@@ -682,13 +394,30 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-			"integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
 			"cpu": [
 				"x64"
 			],
@@ -699,13 +428,30 @@
 				"netbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-			"integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
 			"cpu": [
 				"x64"
 			],
@@ -716,13 +462,30 @@
 				"openbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-			"integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
 			"cpu": [
 				"x64"
 			],
@@ -733,13 +496,13 @@
 				"sunos"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-			"integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
 			"cpu": [
 				"arm64"
 			],
@@ -750,13 +513,13 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-			"integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
 			"cpu": [
 				"ia32"
 			],
@@ -767,13 +530,13 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-			"integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
 			"cpu": [
 				"x64"
 			],
@@ -784,7 +547,7 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@iconify-json/logos": {
@@ -798,9 +561,9 @@
 			}
 		},
 		"node_modules/@iconify-json/simple-icons": {
-			"version": "1.2.60",
-			"resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.60.tgz",
-			"integrity": "sha512-KlwLBKCdMCqfySdkAA+jehdUx6VSjnj6lvzQKus7HjkPSQ6QP58d6xiptkIp0jd/Hw3PW2++nRuGvCvSYaF0Mg==",
+			"version": "1.2.81",
+			"resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.81.tgz",
+			"integrity": "sha512-Utjw4sPtoVdbpAQAkC4O0cYpt4ehQZYr6aFHhmvdeW8mQwkINyAe0ogTPqNptSSKogZ2lfgXM8zpuhO961Wnng==",
 			"dev": true,
 			"license": "CC0-1.0",
 			"dependencies": {
@@ -1787,6 +1550,13 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.13",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+			"integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -2138,78 +1908,76 @@
 			]
 		},
 		"node_modules/@shikijs/core": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
-			"integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+			"integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/engine-javascript": "2.5.0",
-				"@shikijs/engine-oniguruma": "2.5.0",
-				"@shikijs/types": "2.5.0",
+				"@shikijs/types": "3.23.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4",
-				"hast-util-to-html": "^9.0.4"
+				"hast-util-to-html": "^9.0.5"
 			}
 		},
 		"node_modules/@shikijs/engine-javascript": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
-			"integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+			"integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "2.5.0",
+				"@shikijs/types": "3.23.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
-				"oniguruma-to-es": "^3.1.0"
+				"oniguruma-to-es": "^4.3.4"
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
-			"integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "2.5.0",
+				"@shikijs/types": "3.23.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
 		"node_modules/@shikijs/langs": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
-			"integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "2.5.0"
+				"@shikijs/types": "3.23.0"
 			}
 		},
 		"node_modules/@shikijs/themes": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
-			"integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "2.5.0"
+				"@shikijs/types": "3.23.0"
 			}
 		},
 		"node_modules/@shikijs/transformers": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
-			"integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.23.0.tgz",
+			"integrity": "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "2.5.0",
-				"@shikijs/types": "2.5.0"
+				"@shikijs/core": "3.23.0",
+				"@shikijs/types": "3.23.0"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
-			"integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2325,197 +2093,208 @@
 			"license": "MIT"
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/@vitejs/plugin-vue": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-			"integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+			"integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@rolldown/pluginutils": "1.0.0-rc.13"
+			},
 			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"peerDependencies": {
-				"vite": "^5.0.0 || ^6.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
 				"vue": "^3.2.25"
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.25.tgz",
-			"integrity": "sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+			"integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@vue/shared": "3.5.25",
-				"entities": "^4.5.0",
+				"@babel/parser": "^7.29.3",
+				"@vue/shared": "3.5.34",
+				"entities": "^7.0.1",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.2.1"
 			}
 		},
+		"node_modules/@vue/compiler-core/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz",
-			"integrity": "sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+			"integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-core": "3.5.25",
-				"@vue/shared": "3.5.25"
+				"@vue/compiler-core": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
-			"integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+			"integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@vue/compiler-core": "3.5.25",
-				"@vue/compiler-dom": "3.5.25",
-				"@vue/compiler-ssr": "3.5.25",
-				"@vue/shared": "3.5.25",
+				"@babel/parser": "^7.29.3",
+				"@vue/compiler-core": "3.5.34",
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/compiler-ssr": "3.5.34",
+				"@vue/shared": "3.5.34",
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.30.21",
-				"postcss": "^8.5.6",
+				"postcss": "^8.5.14",
 				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz",
-			"integrity": "sha512-ritPSKLBcParnsKYi+GNtbdbrIE1mtuFEJ4U1sWeuOMlIziK5GtOL85t5RhsNy4uWIXPgk+OUdpnXiTdzn8o3A==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+			"integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.25",
-				"@vue/shared": "3.5.25"
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/devtools-api": {
-			"version": "7.7.9",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
-			"integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.1.tgz",
+			"integrity": "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/devtools-kit": "^7.7.9"
+				"@vue/devtools-kit": "^8.1.1"
 			}
 		},
 		"node_modules/@vue/devtools-kit": {
-			"version": "7.7.9",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
-			"integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.1.tgz",
+			"integrity": "sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/devtools-shared": "^7.7.9",
-				"birpc": "^2.3.0",
+				"@vue/devtools-shared": "^8.1.1",
+				"birpc": "^2.6.1",
 				"hookable": "^5.5.3",
-				"mitt": "^3.0.1",
-				"perfect-debounce": "^1.0.0",
-				"speakingurl": "^14.0.1",
-				"superjson": "^2.2.2"
+				"perfect-debounce": "^2.0.0"
 			}
 		},
 		"node_modules/@vue/devtools-shared": {
-			"version": "7.7.9",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
-			"integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.1.tgz",
+			"integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"rfdc": "^1.4.1"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz",
-			"integrity": "sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+			"integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/shared": "3.5.25"
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
-			"integrity": "sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+			"integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.25",
-				"@vue/shared": "3.5.25"
+				"@vue/reactivity": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz",
-			"integrity": "sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+			"integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.25",
-				"@vue/runtime-core": "3.5.25",
-				"@vue/shared": "3.5.25",
-				"csstype": "^3.1.3"
+				"@vue/reactivity": "3.5.34",
+				"@vue/runtime-core": "3.5.34",
+				"@vue/shared": "3.5.34",
+				"csstype": "^3.2.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz",
-			"integrity": "sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+			"integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.5.25",
-				"@vue/shared": "3.5.25"
+				"@vue/compiler-ssr": "3.5.34",
+				"@vue/shared": "3.5.34"
 			},
 			"peerDependencies": {
-				"vue": "3.5.25"
+				"vue": "3.5.34"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz",
-			"integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+			"integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vueuse/core": {
-			"version": "12.8.2",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
-			"integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "12.8.2",
-				"@vueuse/shared": "12.8.2",
-				"vue": "^3.5.13"
+				"@vueuse/metadata": "14.3.0",
+				"@vueuse/shared": "14.3.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/@vueuse/integrations": {
-			"version": "12.8.2",
-			"resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
-			"integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-14.3.0.tgz",
+			"integrity": "sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vueuse/core": "12.8.2",
-				"@vueuse/shared": "12.8.2",
-				"vue": "^3.5.13"
+				"@vueuse/core": "14.3.0",
+				"@vueuse/shared": "14.3.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -2525,14 +2304,15 @@
 				"axios": "^1",
 				"change-case": "^5",
 				"drauu": "^0.4",
-				"focus-trap": "^7",
+				"focus-trap": "^7 || ^8",
 				"fuse.js": "^7",
 				"idb-keyval": "^6",
 				"jwt-decode": "^4",
 				"nprogress": "^0.2",
 				"qrcode": "^1.5",
 				"sortablejs": "^1",
-				"universal-cookie": "^7"
+				"universal-cookie": "^7 || ^8",
+				"vue": "^3.5.0"
 			},
 			"peerDependenciesMeta": {
 				"async-validator": {
@@ -2574,9 +2354,9 @@
 			}
 		},
 		"node_modules/@vueuse/metadata": {
-			"version": "12.8.2",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
-			"integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2584,16 +2364,16 @@
 			}
 		},
 		"node_modules/@vueuse/shared": {
-			"version": "12.8.2",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
-			"integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+			"integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"vue": "^3.5.13"
-			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/acorn": {
@@ -2607,32 +2387,6 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/algoliasearch": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.45.0.tgz",
-			"integrity": "sha512-wrj4FGr14heLOYkBKV3Fbq5ZBGuIFeDJkTilYq/G+hH1CSlQBtYvG2X1j67flwv0fUeQJwnWxxRIunSemAZirA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/abtesting": "1.11.0",
-				"@algolia/client-abtesting": "5.45.0",
-				"@algolia/client-analytics": "5.45.0",
-				"@algolia/client-common": "5.45.0",
-				"@algolia/client-insights": "5.45.0",
-				"@algolia/client-personalization": "5.45.0",
-				"@algolia/client-query-suggestions": "5.45.0",
-				"@algolia/client-search": "5.45.0",
-				"@algolia/ingestion": "1.45.0",
-				"@algolia/monitoring": "1.45.0",
-				"@algolia/recommend": "5.45.0",
-				"@algolia/requester-browser-xhr": "5.45.0",
-				"@algolia/requester-fetch": "5.45.0",
-				"@algolia/requester-node-http": "5.45.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/argparse": {
@@ -2650,9 +2404,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/birpc": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.8.0.tgz",
-			"integrity": "sha512-Bz2a4qD/5GRhiHSwj30c/8kC8QGj12nNDwz3D4ErQ4Xhy35dsSDvF+RA/tWpjyU0pdGtSDiEk6B5fBGE1qNVhw==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+			"integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2742,22 +2496,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/copy-anything": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
-			"integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-what": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
-			}
-		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2831,13 +2569,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/emoji-regex-xs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-			"integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/entities": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -2866,9 +2597,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -2876,32 +2607,35 @@
 				"esbuild": "bin/esbuild"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.21.5",
-				"@esbuild/android-arm": "0.21.5",
-				"@esbuild/android-arm64": "0.21.5",
-				"@esbuild/android-x64": "0.21.5",
-				"@esbuild/darwin-arm64": "0.21.5",
-				"@esbuild/darwin-x64": "0.21.5",
-				"@esbuild/freebsd-arm64": "0.21.5",
-				"@esbuild/freebsd-x64": "0.21.5",
-				"@esbuild/linux-arm": "0.21.5",
-				"@esbuild/linux-arm64": "0.21.5",
-				"@esbuild/linux-ia32": "0.21.5",
-				"@esbuild/linux-loong64": "0.21.5",
-				"@esbuild/linux-mips64el": "0.21.5",
-				"@esbuild/linux-ppc64": "0.21.5",
-				"@esbuild/linux-riscv64": "0.21.5",
-				"@esbuild/linux-s390x": "0.21.5",
-				"@esbuild/linux-x64": "0.21.5",
-				"@esbuild/netbsd-x64": "0.21.5",
-				"@esbuild/openbsd-x64": "0.21.5",
-				"@esbuild/sunos-x64": "0.21.5",
-				"@esbuild/win32-arm64": "0.21.5",
-				"@esbuild/win32-ia32": "0.21.5",
-				"@esbuild/win32-x64": "0.21.5"
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
 			}
 		},
 		"node_modules/estree-walker": {
@@ -2947,13 +2681,13 @@
 			}
 		},
 		"node_modules/focus-trap": {
-			"version": "7.6.6",
-			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.6.tgz",
-			"integrity": "sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.0.tgz",
+			"integrity": "sha512-CaBdQ9P4fa/yCA6pDf/3aJd8bf9IOG5QGK21/E+86o2V4V8kzXaR4A9E6tNR7KkkS1+T5ZIU1tJDBDLwsucz9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tabbable": "^6.3.0"
+				"tabbable": "^6.4.0"
 			}
 		},
 		"node_modules/fsevents": {
@@ -3129,19 +2863,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/is-what": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
-			"integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
 			}
 		},
 		"node_modules/js-yaml": {
@@ -4004,13 +3725,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/mitt": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/mlly": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -4068,15 +3782,22 @@
 				"node": ">= 4.4.x"
 			}
 		},
+		"node_modules/oniguruma-parser": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+			"integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/oniguruma-to-es": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
-			"integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+			"integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex-xs": "^1.0.0",
-				"regex": "^6.0.1",
+				"oniguruma-parser": "^0.12.2",
+				"regex": "^6.1.0",
 				"regex-recursion": "^6.0.2"
 			}
 		},
@@ -4235,9 +3956,9 @@
 			"license": "MIT"
 		},
 		"node_modules/perfect-debounce": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+			"integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4285,9 +4006,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4311,17 +4032,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
-			}
-		},
-		"node_modules/preact": {
-			"version": "10.28.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
-			"integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
 			}
 		},
 		"node_modules/property-information": {
@@ -4354,9 +4064,9 @@
 			}
 		},
 		"node_modules/regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
-			"integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4377,13 +4087,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
 			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/rfdc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4464,27 +4167,19 @@
 			"license": "BlueOak-1.0.0",
 			"optional": true
 		},
-		"node_modules/search-insights": {
-			"version": "2.17.3",
-			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-			"integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/shiki": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
-			"integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+			"integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "2.5.0",
-				"@shikijs/engine-javascript": "2.5.0",
-				"@shikijs/engine-oniguruma": "2.5.0",
-				"@shikijs/langs": "2.5.0",
-				"@shikijs/themes": "2.5.0",
-				"@shikijs/types": "2.5.0",
+				"@shikijs/core": "3.23.0",
+				"@shikijs/engine-javascript": "3.23.0",
+				"@shikijs/engine-oniguruma": "3.23.0",
+				"@shikijs/langs": "3.23.0",
+				"@shikijs/themes": "3.23.0",
+				"@shikijs/types": "3.23.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
 			}
@@ -4534,16 +4229,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/speakingurl": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-			"integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/stringify-entities": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4572,23 +4257,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/superjson": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
-			"integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"copy-anything": "^4"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/tabbable": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
-			"integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4711,9 +4383,9 @@
 			}
 		},
 		"node_modules/unist-util-visit": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4779,21 +4451,24 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.4.21",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+			"integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.21.3",
-				"postcss": "^8.4.43",
-				"rollup": "^4.20.0"
+				"esbuild": "^0.27.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -4802,17 +4477,23 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^18.0.0 || >=20.0.0",
-				"less": "*",
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
 				"lightningcss": "^1.21.0",
-				"sass": "*",
-				"sass-embedded": "*",
-				"stylus": "*",
-				"sugarss": "*",
-				"terser": "^5.4.0"
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
 			},
 			"peerDependenciesMeta": {
 				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
 					"optional": true
 				},
 				"less": {
@@ -4835,44 +4516,55 @@
 				},
 				"terser": {
 					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
 				}
 			}
 		},
 		"node_modules/vitepress": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
-			"integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+			"version": "2.0.0-alpha.17",
+			"resolved": "https://registry.npmjs.org/vitepress/-/vitepress-2.0.0-alpha.17.tgz",
+			"integrity": "sha512-Z3VPUpwk/bHYqt1uMVOOK1/4xFiWQov1GNc2FvMdz6kvje4JRXEOngVI9C+bi5jeedMSHiA4dwKkff1NCvbZ9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docsearch/css": "3.8.2",
-				"@docsearch/js": "3.8.2",
-				"@iconify-json/simple-icons": "^1.2.21",
-				"@shikijs/core": "^2.1.0",
-				"@shikijs/transformers": "^2.1.0",
-				"@shikijs/types": "^2.1.0",
+				"@docsearch/css": "^4.5.3",
+				"@docsearch/js": "^4.5.3",
+				"@docsearch/sidepanel-js": "^4.5.3",
+				"@iconify-json/simple-icons": "^1.2.69",
+				"@shikijs/core": "^3.22.0",
+				"@shikijs/transformers": "^3.22.0",
+				"@shikijs/types": "^3.22.0",
 				"@types/markdown-it": "^14.1.2",
-				"@vitejs/plugin-vue": "^5.2.1",
-				"@vue/devtools-api": "^7.7.0",
-				"@vue/shared": "^3.5.13",
-				"@vueuse/core": "^12.4.0",
-				"@vueuse/integrations": "^12.4.0",
-				"focus-trap": "^7.6.4",
+				"@vitejs/plugin-vue": "^6.0.4",
+				"@vue/devtools-api": "^8.0.5",
+				"@vue/shared": "^3.5.27",
+				"@vueuse/core": "^14.2.0",
+				"@vueuse/integrations": "^14.2.0",
+				"focus-trap": "^8.0.0",
 				"mark.js": "8.11.1",
-				"minisearch": "^7.1.1",
-				"shiki": "^2.1.0",
-				"vite": "^5.4.14",
-				"vue": "^3.5.13"
+				"minisearch": "^7.2.0",
+				"shiki": "^3.22.0",
+				"vite": "^7.3.1",
+				"vue": "^3.5.27"
 			},
 			"bin": {
 				"vitepress": "bin/vitepress.js"
 			},
 			"peerDependencies": {
 				"markdown-it-mathjax3": "^4",
+				"oxc-minify": "*",
 				"postcss": "^8"
 			},
 			"peerDependenciesMeta": {
 				"markdown-it-mathjax3": {
+					"optional": true
+				},
+				"oxc-minify": {
 					"optional": true
 				},
 				"postcss": {
@@ -4901,28 +4593,32 @@
 			}
 		},
 		"node_modules/vitepress-plugin-tabs": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/vitepress-plugin-tabs/-/vitepress-plugin-tabs-0.7.3.tgz",
-			"integrity": "sha512-CkUz49UrTLcVOszuiHIA7ZBvfsg9RluRkFjRG1KvCg/NwuOTLZwcBRv7vBB3vMlDp0bWXIFOIwdI7bE93cV3Hw==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/vitepress-plugin-tabs/-/vitepress-plugin-tabs-0.9.0.tgz",
+			"integrity": "sha512-OB+/T6SkwGIQHIQi1NLl011kWCMzfsVEx0/q+NfF6EmvvpcfDzRClc/iEwUlq8TkQnFxANu+GTdmvtXEjJM2Lg==",
 			"dev": true,
 			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/sapphi-red"
+			},
 			"peerDependencies": {
-				"vitepress": "^1.0.0",
+				"vitepress": "^1.0.0 || ^2.0.0-alpha.17",
 				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/vue": {
-			"version": "3.5.25",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
-			"integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+			"integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.25",
-				"@vue/compiler-sfc": "3.5.25",
-				"@vue/runtime-dom": "3.5.25",
-				"@vue/server-renderer": "3.5.25",
-				"@vue/shared": "3.5.25"
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/compiler-sfc": "3.5.34",
+				"@vue/runtime-dom": "3.5.34",
+				"@vue/server-renderer": "3.5.34",
+				"@vue/shared": "3.5.34"
 			},
 			"peerDependencies": {
 				"typescript": "*"

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,9 +26,9 @@
 		"oxfmt": "^0.48.0",
 		"oxlint": "^1.63.0",
 		"oxlint-tsgolint": "^0.22.1",
-		"vitepress": "^1.0.0",
+		"vitepress": "2.0.0-alpha.17",
 		"vitepress-plugin-group-icons": "^1.6.5",
-		"vitepress-plugin-tabs": "^0.7.3",
-		"vue": "^3.0.0"
+		"vitepress-plugin-tabs": "^0.9.0",
+		"vue": "^3.5.0"
 	}
 }


### PR DESCRIPTION
## Summary

Bumps VitePress in `docs/` from `^1.0.0` to `2.0.0-alpha.17` (latest pre-release as of writing). Alongside:

- `vitepress-plugin-tabs` `^0.7.3` → `^0.9.0` (declares VitePress 2 alpha 17 compat in its peerDeps)
- `vue` `^3.0.0` → `^3.5.0` (required by vitepress-plugin-tabs 0.9.0 peerDeps)

`vitepress` is pinned to the exact alpha (no caret) since pre-release versions do not satisfy `^` semantics across alpha lines.

## Why

VitePress 2 brings Vite 7, shiki v3, markdown-it-async, plus theme polish. The docs site does not use any of the breaking-change APIs (`useLocalNav`, `useSidebar`, `cjkFriendly`, `postcssIsolateStyles`, `DocSidebar`, `DocLocalNav`), so this is a low-risk upgrade.

## Verification

- `npm run lint` exits 0 (oxlint with type-aware, markdownlint, oxfmt --check)
- `npm run docs:build` exits 0; produces 162 HTML pages with correct titles
- `npm run docs:dev` starts cleanly; serves HTTP 200
- Browser walkthrough on home, command-palette, changelogs index + tag page, theming, installation: zero console errors. Tabs plugin, data loaders, dynamic `[tag]` routes, sidebar nav, and Algolia search all functional under 2.0.0-alpha.17.

Build emits two non-blocking Rollup warnings unrelated to this upgrade:
- `/* #__PURE__ */` annotation in `@vueuse/core` (Vue/Rollup interplay; cosmetic)
- Chunk size > 500 kB (pre-existing performance optimization opportunity)

## Test plan

- [x] CI Docs lint job green
- [x] Local: `cd docs && rm -rf node_modules && npm install && npm run lint && npm run docs:build` exits 0
- [x] Spot-check the GitHub Pages preview for any visual regressions from VitePress 2's theme polish (code-group margins, sidebar slash handling, etc.)