### PR TITLE
refactor(docs): tighten oxlint config and adopt vue 3.5 props destructuring

### DIFF
--- a/docs/.oxlintrc.json
+++ b/docs/.oxlintrc.json
@@ -30,8 +30,8 @@
 		"sort-keys": "off",
 		// reason: import order in this codebase groups by source (deps, then local) rather than alphabetizing; alphabetic sort fights that grouping
 		"sort-imports": "off",
-		// reason: the codebase uses function declarations for top-level helpers (hoisted, named in stack traces); switching to expressions is pure churn
-		"func-style": "off",
+		// Enforce function declarations consistently — the codebase already uses them everywhere for top-level helpers
+		"func-style": ["warn", "declaration"],
 		// reason: named exports are used throughout for constants and utility helpers; default exports would force renaming on every consumer
 		"import/no-named-export": "off",
 		// reason: contradicts our use of named exports for utilities — keeping single-named-export files named is intentional
@@ -50,22 +50,16 @@
 		"no-magic-numbers": "off",
 		// reason: short identifiers like `r`, `md`, `a`, `b` are conventional in callbacks and well-scoped; enforcing a min length is churn
 		"id-length": "off",
-		// reason: Vue SFC filenames follow PascalCase by Vue convention (matches component name); kebab-case would diverge from the rest of the project
-		"unicorn/filename-case": "off",
+		// Vue SFCs use PascalCase, TS files use camelCase — allow both
+		"unicorn/filename-case": ["warn", { "cases": { "camelCase": true, "pascalCase": true } }],
 		// reason: ternary expressions are used idiomatically for the search-provider toggle and other config branches; a guard-style rewrite would be less readable
 		"no-ternary": "off",
 		// reason: `!!value` is a concise, idiomatic boolean coercion in this codebase
 		"no-implicit-coercion": "off",
 		// reason: `const x = obj.prop` is clearer than destructuring when only one property is read
 		"prefer-destructuring": "off",
-		// reason: `() => { return expr; }` blocks are sometimes clearer than implicit-return arrows, especially with multi-line expressions
-		"arrow-body-style": "off",
 		// reason: default parameters only trigger on `undefined`; the existing `body ?? fallback` pattern handles `null` too, which the type signature allows
 		"unicorn/prefer-default-parameters": "off",
-		// reason: `arr.slice()` is more familiar than `[...arr]` for shallow-copying before in-place ops; behavior is identical
-		"unicorn/prefer-spread": "off",
-		// reason: `defineProps` + `toRefs` is the destructure-with-reactivity pattern this codebase uses; the rule pushes a different style without semantic improvement
-		"vue/define-props-destructuring": "off",
 		// reason: enforcing readonly on every parameter (including framework-typed ones like MarkdownIt and Octokit response items) generates dozens of warnings without catching real mutation bugs
 		"typescript/prefer-readonly-parameter-types": "off",
 		// reason: `process.env.X && process.env.Y && ...` is idiomatic for "all are set"; the rule wants explicit `!== undefined && !== ''` chains which are noisier without catching bugs

--- a/docs/.vitepress/theme/components/ChangelogByTag.vue
+++ b/docs/.vitepress/theme/components/ChangelogByTag.vue
@@ -22,13 +22,12 @@
 
 <script setup lang="ts">
 import MarkdownIt from "markdown-it";
-import { computed, toRefs } from "vue";
+import { computed } from "vue";
 import { data as changelogs } from "../data/changelogs.data";
 import { formatChangelog } from "../utils/formatChangelog.ts";
 import ContributorList from "./ContributorList.vue";
 
-const props = defineProps<{ tag: string }>();
-const { tag } = toRefs(props);
+const { tag } = defineProps<{ tag: string }>();
 
 const md = new MarkdownIt({ html: true });
 
@@ -36,7 +35,7 @@ function renderMarkdown(string: string | null | undefined) {
 	return formatChangelog(md, string);
 }
 
-const release = computed(() => changelogs.find((r) => r.tag_name === tag.value));
+const release = computed(() => changelogs.find((r) => r.tag_name === tag));
 const latestStableTag = computed(() => {
 	const stable = changelogs
 		.filter((r) => !r.draft && !r.prerelease)
@@ -45,7 +44,7 @@ const latestStableTag = computed(() => {
 		);
 	return stable[0]?.tag_name;
 });
-const isLatest = computed(() => latestStableTag.value === tag.value);
+const isLatest = computed(() => latestStableTag.value === tag);
 </script>
 
 <style lang="less" scoped>

--- a/docs/.vitepress/theme/components/ContributorList.vue
+++ b/docs/.vitepress/theme/components/ContributorList.vue
@@ -26,16 +26,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRefs } from "vue";
+import { computed, ref } from "vue";
 import { extractContributors } from "../utils/contributors";
 
-const props = defineProps<{ body: string }>();
-const { body } = toRefs(props);
+const { body } = defineProps<{ body: string }>();
 
 const nonExistent = ref<Set<string>>(new Set());
 
 const contributors = computed(() =>
-	extractContributors(body.value).filter((user) => !nonExistent.value.has(user)),
+	extractContributors(body).filter((user) => !nonExistent.value.has(user)),
 );
 
 const listFormatter = new Intl.ListFormat("en", {

--- a/docs/.vitepress/theme/components/CopyCode.vue
+++ b/docs/.vitepress/theme/components/CopyCode.vue
@@ -17,7 +17,7 @@
 import { ref } from "vue";
 import { withBase } from "vitepress";
 
-const props = defineProps<{
+const { code } = defineProps<{
 	code: string;
 }>();
 
@@ -32,7 +32,7 @@ async function copy() {
 		if (!clipboard) {
 			throw new Error("Clipboard API not supported");
 		}
-		await clipboard.writeText(props.code);
+		await clipboard.writeText(code);
 		copied.value = true;
 		setTimeout(() => {
 			copied.value = false;

--- a/docs/.vitepress/theme/components/LinkCard.vue
+++ b/docs/.vitepress/theme/components/LinkCard.vue
@@ -20,16 +20,11 @@
 </template>
 
 <script setup lang="ts">
-withDefaults(
-	defineProps<{
-		href: string;
-		title: string;
-		target?: string;
-	}>(),
-	{
-		target: "_blank",
-	},
-);
+const { target = "_blank" } = defineProps<{
+	href: string;
+	title: string;
+	target?: string;
+}>();
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Fresh audit of the 22 oxlint rules currently disabled in `docs/.oxlintrc.json`. Re-enables 5 of them and refactors 4 Vue components for Vue 3.5's reactive props destructuring.

## How the audit was done

Temporarily flipped every disabled rule to `warn`, ran `oxlint --type-aware` against the codebase, and counted real fires per rule. For each rule, decided based on what it actually flags here:

- 0 fires → re-enable as a free future-guard
- Fires that point to consistent intentional patterns → keep disabled
- Fires that have changed value with new ecosystem (e.g. Vue 3.5) → re-enable

## Re-enables

| Rule | Was | Now | Why |
|---|---|---|---|
| `func-style` | off | `["warn", "declaration"]` | All 13 default fires were the rule wanting expressions; codebase is 100% declarations. Switching to `"declaration"` mode = 0 fires + locked-in convention. |
| `unicorn/filename-case` | off | `["warn", { cases: { camelCase: true, pascalCase: true } }]` | Default forced kebab-case which fights Vue (PascalCase) and TS (camelCase). Multi-case matches reality, 0 fires. |
| `vue/define-props-destructuring` | off | re-enabled (style category default) | Vue 3.5 makes destructured props reactive inside computed/watch/templates. The rule now points at a real idiom upgrade. Refactored 4 components below. |
| `arrow-body-style` | off | re-enabled | 0 fires; locks current consistent style. |
| `unicorn/prefer-spread` | off | re-enabled | 0 fires; future guard. |

## Component refactors (Vue 3.5 destructuring)

- `CopyCode.vue` — drop `props.code` indirection
- `ContributorList.vue` — drop `toRefs(props)` wrapper, use `body` directly
- `ChangelogByTag.vue` — drop `toRefs(props)`, use `tag` directly inside `computed` (reactive in 3.5+)
- `LinkCard.vue` — replace `withDefaults(...)` with destructure-with-defaults syntax

Net diff: more code removed than added (`-31, +18`).

## Kept disabled

The remaining 17 rules each fire on patterns that are deliberately part of how this docs site is written (named exports for utilities, framework-shaped objects in VitePress config, idiomatic implicit truthy checks, etc.) or on third-party types where strict readonly/boolean-expressions rules don't catch real bugs. The existing inline `// reason:` comments document each one.

## Verification

- `npm run lint` exits 0 (396 active rules now)
- `npm run docs:build` exits 0; produces 162 pages
- Dev server smoke test on `/changelogs/v3.15.1` — `ChangelogByTag` and `ContributorList` render correctly, confirming reactive destructuring works inside `computed()`

## Test plan

- [x] CI Docs lint job green
- [x] Browse a deployed preview to confirm no visual regressions in the refactored components (LinkCard on showcase, ChangelogByTag on `/changelogs/<tag>`, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Vue component property handling patterns across multiple documentation components by streamlining property declaration, removing intermediate abstraction layers, and simplifying default value logic for enhanced code clarity and maintainability.

* **Chores**
  * Updated linting configuration rules to enforce consistent function declaration style as warnings, establishing code quality standards for the documentation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->