### PR TITLE
feat(commandPalette): opt help overlay and SMW mode into compact rows

### DIFF
--- a/resources/skins.citizen.commandPalette.smw/init.js
+++ b/resources/skins.citizen.commandPalette.smw/init.js
@@ -2,7 +2,7 @@
  * Semantic MediaWiki Ask query mode for the command palette.
  * Loaded conditionally only when SMW is installed.
  */
-const { cdxIconAdd, cdxIconListBullet, cdxIconTag, cdxIconWikitext } = require( './icons.json' );
+const { cdxIconAdd, cdxIconArticle, cdxIconListBullet, cdxIconTag, cdxIconWikitext } = require( './icons.json' );
 const config = require( './config.json' );
 const parseIncompleteCondition = require( './queryParser.js' );
 
@@ -144,7 +144,8 @@ function adaptSmwResult( subject, index ) {
 		id: 'citizen-command-palette-item-smw-' + index,
 		type: 'smw',
 		label: subject.fulltext,
-		url: subject.fullurl
+		url: subject.fullurl,
+		thumbnailIcon: cdxIconArticle
 	};
 	const detail = adaptPrintouts( subject.printouts );
 	if ( detail ) {
@@ -361,6 +362,7 @@ module.exports = {
 	id: 'smw',
 	triggers: [ '/smw:' ],
 	icon: cdxIconWikitext,
+	compactResults: true,
 	label: mw.message( 'citizen-command-palette-command-smw-label' ).text(),
 	description: mw.message( 'citizen-command-palette-command-smw-description' ).text(),
 	placeholder: mw.message( 'citizen-command-palette-mode-smw-placeholder' ).text(),

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteHelpView.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteHelpView.vue
@@ -9,6 +9,7 @@
 			:highlighted-item-index="highlightedItemIndex"
 			:search-query="searchQuery"
 			:set-item-ref="setItemRef"
+			:compact="true"
 			@select="( result ) => $emit( 'select', result )"
 			@hover="( index ) => $emit( 'hover', index )"
 		></command-palette-list>

--- a/resources/skins.citizen.commandPalette/modes/help.js
+++ b/resources/skins.citizen.commandPalette/modes/help.js
@@ -13,7 +13,6 @@ module.exports = {
 	triggers: [ '/help', '?' ],
 	label: mw.message( 'citizen-command-palette-command-help-label' ).text(),
 	description: mw.message( 'citizen-command-palette-command-help-description' ).text(),
-	compactResults: true,
 	onResultSelect() {
 		return { action: 'toggleHelp' };
 	}

--- a/skin.json
+++ b/skin.json
@@ -485,6 +485,7 @@
 					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",
 					"callbackParam": [
 						"cdxIconAdd",
+						"cdxIconArticle",
 						"cdxIconListBullet",
 						"cdxIconTag",
 						"cdxIconWikitext"

--- a/tests/vitest/commandPalette.smw/smw.test.js
+++ b/tests/vitest/commandPalette.smw/smw.test.js
@@ -334,13 +334,15 @@ describe( 'SMW mode', () => {
 				maxage: 1200,
 				smaxage: 1200
 			} );
-			expect( result ).toHaveLength( 1 );
-			expect( result[ 0 ] ).toMatchObject( {
-				id: 'citizen-command-palette-item-smw-category-0',
-				type: 'smw-category',
-				label: 'City',
-				highlightQuery: true
-			} );
+			expect( result ).toEqual( [
+				{
+					id: 'citizen-command-palette-item-smw-category-0',
+					type: 'smw-category',
+					thumbnailIcon: expect.any( String ),
+					label: 'City',
+					highlightQuery: true
+				}
+			] );
 		} );
 
 		it( 'should fetch value suggestions for incomplete value condition', async () => {
@@ -357,21 +359,24 @@ describe( 'SMW mode', () => {
 				maxage: 1200,
 				smaxage: 1200
 			} );
-			expect( result ).toHaveLength( 2 );
-			expect( result[ 0 ] ).toMatchObject( {
-				id: 'citizen-command-palette-item-smw-value-0',
-				type: 'smw-value',
-				label: 'Germany',
-				value: 'Located in',
-				highlightQuery: true
-			} );
-			expect( result[ 1 ] ).toMatchObject( {
-				id: 'citizen-command-palette-item-smw-value-1',
-				type: 'smw-value',
-				label: 'Greece',
-				value: 'Located in',
-				highlightQuery: true
-			} );
+			expect( result ).toEqual( [
+				{
+					id: 'citizen-command-palette-item-smw-value-0',
+					type: 'smw-value',
+					thumbnailIcon: expect.any( String ),
+					label: 'Germany',
+					value: 'Located in',
+					highlightQuery: true
+				},
+				{
+					id: 'citizen-command-palette-item-smw-value-1',
+					type: 'smw-value',
+					thumbnailIcon: expect.any( String ),
+					label: 'Greece',
+					value: 'Located in',
+					highlightQuery: true
+				}
+			] );
 		} );
 
 		it( 'should fetch property suggestions for incomplete printout', async () => {
@@ -390,9 +395,15 @@ describe( 'SMW mode', () => {
 				maxage: 1200,
 				smaxage: 1200
 			} );
-			expect( result ).toHaveLength( 1 );
-			expect( result[ 0 ].type ).toBe( 'smw-printout' );
-			expect( result[ 0 ].id ).toContain( 'smw-printout' );
+			expect( result ).toEqual( [
+				{
+					id: 'citizen-command-palette-item-smw-printout-0',
+					type: 'smw-printout',
+					thumbnailIcon: expect.any( String ),
+					label: 'Population',
+					highlightQuery: true
+				}
+			] );
 		} );
 
 		it( 'should fetch all properties for empty printout fragment', async () => {
@@ -466,13 +477,15 @@ describe( 'SMW mode', () => {
 					id: 'citizen-command-palette-item-smw-0',
 					type: 'smw',
 					label: 'Berlin',
-					url: 'https://example.org/wiki/Berlin'
+					url: 'https://example.org/wiki/Berlin',
+					thumbnailIcon: expect.any( String )
 				},
 				{
 					id: 'citizen-command-palette-item-smw-1',
 					type: 'smw',
 					label: 'Munich',
-					url: 'https://example.org/wiki/Munich'
+					url: 'https://example.org/wiki/Munich',
+					thumbnailIcon: expect.any( String )
 				}
 			] );
 		} );

--- a/tests/vitest/mocks/commandPaletteIcons.js
+++ b/tests/vitest/mocks/commandPaletteIcons.js
@@ -1,7 +1,7 @@
 // Stub for command palette icons.json — a virtual ResourceLoader module
 // generated from Codex icon definitions declared in skin.json.
 module.exports = {
-	cdxIconSearch: 'M12 2a10 10 0 1 0 0 20',
+	cdxIconAdd: 'M5 1a2 2 0 0 0-2 2v14',
 	cdxIconArticle: 'M5 1a2 2 0 0 0-2 2v14',
 	cdxIconArticleRedirect: 'M5 1a2 2 0 0 0-2 2v14',
 	cdxIconArticleSearch: 'M12 2a10 10 0 1 0 0 20',
@@ -11,10 +11,14 @@ module.exports = {
 	cdxIconCode: 'M5 1a2 2 0 0 0-2 2v14',
 	cdxIconEdit: 'M16.77 8l1.94-2a1 1 0 0 0 0-1.41',
 	cdxIconImageGallery: 'M5 1a2 2 0 0 0-2 2v14',
+	cdxIconListBullet: 'M5 1a2 2 0 0 0-2 2v14',
 	cdxIconPlay: 'M5 1a2 2 0 0 0-2 2v14',
+	cdxIconSearch: 'M12 2a10 10 0 1 0 0 20',
 	cdxIconSpecialPages: 'M5 1a2 2 0 0 0-2 2v14',
+	cdxIconTag: 'M5 1a2 2 0 0 0-2 2v14',
 	cdxIconTrash: 'M5 1a2 2 0 0 0-2 2v14',
 	cdxIconUserAvatar: 'M10 0a10 10 0 1 0 0 20',
 	cdxIconUserContributions: 'M5 1a2 2 0 0 0-2 2v14',
-	cdxIconUserTalk: 'M5 1a2 2 0 0 0-2 2v14'
+	cdxIconUserTalk: 'M5 1a2 2 0 0 0-2 2v14',
+	cdxIconWikitext: 'M5 1a2 2 0 0 0-2 2v14'
 };


### PR DESCRIPTION
## Summary

Follow-up to #1507 — opts the remaining two modes (`/?` help overlay list, `/smw:`) into the compact result-row variant.

- **Help overlay mode list** — `CommandPaletteHelpView.vue` already renders its modes list through `<command-palette-list>`. Just pass `:compact="true"` on that invocation. The right-pane detail summary is unaffected (different component, different styling).
- **SMW mode** — adds `compactResults: true`. SMW Ask query results (`adaptSmwResult`) previously shipped without a `thumbnailIcon`, which compact mode renders as an invisible icon slot. Set `cdxIconArticle` as the default so every Ask result row carries an icon — matches the convention used in `category.js` for page-type results. `cdxIconArticle` is registered in `skin.json` for the SMW Codex module.
- **Cleanup** — `modes/help.js` had `compactResults: true` from the parent PR, but `/help` is a Command (no `getResults`), so the flag was never read by the rendering path. The help overlay's compactness now comes from the explicit prop above.
- **Test tightening** — SMW suggestion-result tests used `toMatchObject`, which silently passed because four icons (`cdxIconAdd`, `cdxIconTag`, `cdxIconListBullet`, `cdxIconWikitext`) were missing from the shared icon mock. Added them, then flipped the assertions to `toEqual` with `thumbnailIcon: expect.any( String )` so a missing icon would now fail.

## Test plan

- [x] `npm run preflight` — 38 test files, 566 tests pass, no new lint warnings
- [x] Browser-verified `/?` (help overlay) — modes list renders compact with bare `{}` icons, single-line `/ns:`, `/action:`, `/user:`, `/cat:`, `/smw:` entries
- [x] Browser-verified `/smw:[[Has type::Page]]` — Ask query result rows show `cdxIconArticle` glyph + page title (was previously rendering with no icon at all)
- [x] Browser-verified `/smw:` property/category/value suggestion lookups still work and render with their existing icons
- [x] Independent code review — verdict: ready to merge
- [x] No console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual icon indicators to Semantic MediaWiki search results to improve content organization and help users quickly identify different result types at a glance.
  * Optimized the help results display in the command palette with a more compact layout for more efficient use of screen space while maintaining readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->