### PR TITLE
feat(commandPalette): suggest Category in SMW mode

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -113,6 +113,7 @@
 	"citizen-command-palette-type-command": "Command",
 	"citizen-command-palette-type-smw": "SMW",
 	"citizen-command-palette-type-smw-category": "SMW category",
+	"citizen-command-palette-type-smw-namespace": "SMW namespace",
 	"citizen-command-palette-type-smw-printout": "SMW printout",
 	"citizen-command-palette-type-smw-property": "SMW property",
 	"citizen-command-palette-type-smw-value": "SMW value",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -105,6 +105,7 @@
 	"citizen-command-palette-type-command": "Label for the command type of the result in the command palette",
 	"citizen-command-palette-type-smw": "Type label shown for Semantic MediaWiki query results in the command palette",
 	"citizen-command-palette-type-smw-category": "Type label for SMW category suggestions in the command palette",
+	"citizen-command-palette-type-smw-namespace": "Type label for SMW namespace primitives (e.g. the Category entry-point) in the command palette",
 	"citizen-command-palette-type-smw-printout": "Type label for SMW printout suggestions in the command palette",
 	"citizen-command-palette-type-smw-property": "Type label for SMW property suggestions in the command palette",
 	"citizen-command-palette-type-smw-value": "Type label for SMW value suggestions in the command palette",

--- a/resources/skins.citizen.commandPalette.smw/init.js
+++ b/resources/skins.citizen.commandPalette.smw/init.js
@@ -340,7 +340,26 @@ async function getSmwResults( subQuery, _signal, tokens ) {
 				) ) );
 		}
 		if ( incomplete.stage === 'property' ) {
-			return fetchPropertySuggestions( incomplete.fragment );
+			return fetchPropertySuggestions( incomplete.fragment ).then( ( items ) => {
+				// Surface "Category" as a primitive at the top of property
+				// suggestions so users can discover the category-namespace
+				// path (`[[Category:...]]`) without knowing the syntax.
+				// Hide it once the fragment can no longer prefix-match
+				// "Category" so it doesn't clutter unrelated lookups.
+				if ( 'category'.startsWith( incomplete.fragment.toLowerCase() ) ) {
+					return [
+						{
+							id: 'citizen-command-palette-item-smw-namespace-category',
+							type: 'smw-namespace',
+							thumbnailIcon: cdxIconTag,
+							label: 'Category',
+							highlightQuery: true
+						},
+						...items
+					];
+				}
+				return items;
+			} );
 		}
 		if ( incomplete.stage === 'category' ) {
 			return fetchCategorySuggestions( incomplete.fragment );
@@ -400,6 +419,8 @@ module.exports = {
 				return { action: 'updateQuery', payload: '[[' + item.value + '::' + item.label + ']]' };
 			case 'smw-property':
 				return { action: 'updateQuery', payload: '[[' + item.label + '::' };
+			case 'smw-namespace':
+				return { action: 'updateQuery', payload: '[[' + item.label + ':' };
 			case 'smw-category':
 				return { action: 'updateQuery', payload: '[[Category:' + item.label + ']]' };
 			case 'smw-printout':

--- a/skin.json
+++ b/skin.json
@@ -513,6 +513,7 @@
 				"citizen-command-palette-mode-smw-placeholder",
 				"citizen-command-palette-type-smw",
 				"citizen-command-palette-type-smw-category",
+				"citizen-command-palette-type-smw-namespace",
 				"citizen-command-palette-type-smw-printout",
 				"citizen-command-palette-type-smw-property",
 				"citizen-command-palette-type-smw-value"

--- a/tests/vitest/commandPalette.smw/smw.test.js
+++ b/tests/vitest/commandPalette.smw/smw.test.js
@@ -215,6 +215,12 @@ describe( 'SMW mode', () => {
 			expect( result ).toEqual( { action: 'updateQuery', payload: '[[Located in::' } );
 		} );
 
+		it( 'should return updateQuery action for smw-namespace items', () => {
+			const result = smwMode.onResultSelect( { type: 'smw-namespace', label: 'Category' } );
+
+			expect( result ).toEqual( { action: 'updateQuery', payload: '[[Category:' } );
+		} );
+
 		it( 'should return addToken action for smw-printout items', () => {
 			const result = smwMode.onResultSelect( { type: 'smw-printout', label: 'Population' } );
 
@@ -416,6 +422,56 @@ describe( 'SMW mode', () => {
 				browse: 'property',
 				params: JSON.stringify( { search: '', limit: 10 } )
 			} ) );
+		} );
+
+		it( 'should prepend Category namespace primitive at empty property fragment', async () => {
+			mockGet.mockResolvedValue( {
+				query: {
+					'Located in': { label: 'Located in', key: 'Located_in' }
+				}
+			} );
+
+			const result = await smwMode.getResults( '[[' );
+
+			expect( result[ 0 ] ).toEqual( {
+				id: 'citizen-command-palette-item-smw-namespace-category',
+				type: 'smw-namespace',
+				thumbnailIcon: expect.any( String ),
+				label: 'Category',
+				highlightQuery: true
+			} );
+			expect( result[ 1 ] ).toMatchObject( { type: 'smw-property', label: 'Located in' } );
+		} );
+
+		it( 'should keep Category primitive while fragment prefix-matches "Category"', async () => {
+			mockGet.mockResolvedValue( { query: {} } );
+
+			const result = await smwMode.getResults( '[[Cat' );
+
+			expect( result ).toHaveLength( 1 );
+			expect( result[ 0 ].type ).toBe( 'smw-namespace' );
+		} );
+
+		it( 'should keep Category primitive at exact-match fragment "Category"', async () => {
+			mockGet.mockResolvedValue( { query: {} } );
+
+			const result = await smwMode.getResults( '[[Category' );
+
+			expect( result ).toHaveLength( 1 );
+			expect( result[ 0 ].type ).toBe( 'smw-namespace' );
+		} );
+
+		it( 'should drop Category primitive once fragment cannot prefix-match "Category"', async () => {
+			mockGet.mockResolvedValue( {
+				query: {
+					'Located in': { label: 'Located in', key: 'Located_in' }
+				}
+			} );
+
+			const result = await smwMode.getResults( '[[Lo' );
+
+			expect( result.every( ( item ) => item.type !== 'smw-namespace' ) ).toBe( true );
+			expect( result[ 0 ] ).toMatchObject( { type: 'smw-property', label: 'Located in' } );
 		} );
 
 		it( 'should execute Ask query with printout token', async () => {


### PR DESCRIPTION
## Summary

Closes a discoverability gap in the SMW (`/smw:`) command palette mode.

When a user typed `[[` to start an Ask query condition, the only suggestions shown were property names. The parser already supported `[[Category:...]]` as a separate stage, but nothing in the UI surfaced that path — users had to know the syntax to type `Category:` themselves.

This PR prepends a **Category** item at the top of property-stage results whenever the user's fragment is a case-insensitive prefix of "Category". Selecting it advances the query to `[[Category:`, which the parser then routes into the existing category-suggestion stage.

The item disappears once the fragment can no longer prefix-match (e.g. `[[Located`), so it does not clutter unrelated lookups.

## Behaviour

| Input | Category item shown? |
| --- | --- |
| `[[` | yes (first) |
| `[[C` / `[[Cat` / `[[Category` | yes (first) |
| `[[Located` / `[[Has` | no |
| `[[Category:` | no — parser is now in category stage, real category suggestions show |

## Implementation notes

- New item type `smw-namespace`, with `cdxIconTag` (matches existing category suggestion visuals) and `highlightQuery: true`.
- New dispatch case: `case 'smw-namespace': return { action: 'updateQuery', payload: '[[' + item.label + ':' };` — uses `item.label` so a future namespace item (e.g. `Concept`) would just need a new entry, no dispatch change.
- New i18n message `citizen-command-palette-type-smw-namespace` ("SMW namespace") for the type badge.
- The literal "Category" label is intentionally not localized — the parser at `queryParser.js:40` hardcodes the English `Category:` keyword (it's the canonical SMW Ask syntax keyword), so localizing only the displayed label would create a mismatch.

## Test plan

- [x] `npm run preflight` — 38 test files, 571 tests pass, no new lint warnings
- [x] 5 new Vitest cases: prepend at empty fragment, prefix-match at `Cat`, exact-match at `Category`, disappear at `Lo`, dispatch produces `updateQuery '[[Category:'`
- [x] Browser-verified `/smw:[[` — Category appears first with "SMW namespace" badge, properties below
- [x] Browser-verified `/smw:[[Lo` — Category absent, only property suggestions
- [x] Independent code review — verdict: ready to merge