### PR TITLE
refactor(commandPalette): rewrite history section parser without regex

### DIFF
--- a/resources/skins.citizen.commandPalette/modes/history.js
+++ b/resources/skins.citizen.commandPalette/modes/history.js
@@ -95,11 +95,28 @@ function htmlToText( html ) {
  * @return {{section: string|null, text: string}}
  */
 function parseSectionComment( comment ) {
-	const match = /^\s*\/\*\s*(.+?)\s*\*\/\s*(.*)$/.exec( comment || '' );
-	if ( match ) {
-		return { section: match[ 1 ], text: match[ 2 ] };
+	// String operations only — no regex. Earlier regex versions kept
+	// tripping S5852 on overlapping quantifiers. indexOf + slice + trim
+	// is O(n), no backtracking possible. MediaWiki's auto-generated
+	// section prefix is always at position 0, so no leading-whitespace
+	// tolerance is needed.
+	const input = comment || '';
+	if ( !input.startsWith( '/*' ) ) {
+		return { section: null, text: input };
 	}
-	return { section: null, text: comment || '' };
+	const closeIdx = input.indexOf( '*/', 2 );
+	if ( closeIdx === -1 ) {
+		return { section: null, text: input };
+	}
+	const section = input.slice( 2, closeIdx ).trim();
+	if ( section === '' ) {
+		return { section: null, text: input };
+	}
+	let textStart = closeIdx + 2;
+	if ( input.charAt( textStart ) === ' ' ) {
+		textStart++;
+	}
+	return { section, text: input.slice( textStart ) };
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1516. SonarQube flagged `parseSectionComment` as a Security Hotspot ([javascript:S5852](https://rules.sonarsource.com/javascript/RSPEC-5852/) — slow regex / catastrophic backtracking).

Two prior attempts tried to keep the regex and tighten it:

1. Swap `.+?` for `[^*]+?` so the closer is the only place `*` can appear. → Still flagged.
2. Drop the inner `\s*` quantifiers and trim in JS so no two adjacent quantifiers match the same characters. → Still flagged.

Each iteration killed one backtracking path and exposed another. SonarQube's analyzer flags any pair of adjacent quantifiers that *could* overlap, even when the actual runtime is linear in practice. Whack-a-mole inside the regex was the wrong shape of fix.

This commit drops the regex entirely in favour of `indexOf` + `slice` + `trim`. Linear time, no quantifiers, no static-analyzer surface area. MediaWiki's auto-generated section prefix is always at position 0, so the leading-whitespace tolerance the regex carried was never needed.

## Why ship this even though the practical risk was low

In practice MediaWiki edit-summary length bounds already kept the worst case at sub-millisecond levels — this isn't a runtime fix. The reason to land it: the safety property becomes **structural** rather than dependent on a config value (`$wgCommentByteLimit`) that the upstream codebase doesn't control, and the static analyzer stops flagging the file.

Performance impact is noise — both the regex and the string-op version are O(n) on input capped at ~500 bytes, called at most 50 times per palette open.

## Test plan

- [x] All 41 `history.test.js` tests pass with the rewritten parser (no behavior change for any of the existing fixtures, including `/* Section */` with internal whitespace, just-a-prefix `/* Notes */`, and plain comments).
- [x] `npm run lint:js` clean (no errors, no new warnings).
- [x] Full vitest suite green (655/655).