### PR TITLE
feat(commandPalette): defer bundle load until user signals intent

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -98,6 +98,8 @@
 	"citizen-command-palette-heading-recent": "Recent",
 	"citizen-command-palette-heading-related": "Related",
 
+	"citizen-command-palette-load-error": "The command palette couldn't be loaded. Please try again.",
+
 	"citizen-command-palette-keyhint-enter-select": "Select",
 	"citizen-command-palette-keyhint-enter-open": "Open",
 	"citizen-command-palette-keyhint-enter-search": "Search",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -91,6 +91,7 @@
 	"citizen-command-palette-back": "Aria label for the back button in the command palette header when a mode is active.",
 	"citizen-command-palette-heading-recent": "Label for the recently searched results in the command palette",
 	"citizen-command-palette-heading-related": "Label for the related results in the command palette",
+	"citizen-command-palette-load-error": "Toast notification surfaced via mw.notify when the command palette module fails to load.",
 	"citizen-command-palette-keyhint-enter-select": "Keyboard hint for the key to select an item in the command palette",
 	"citizen-command-palette-keyhint-enter-open": "Keyboard hint for the key to open a link in the command palette",
 	"citizen-command-palette-keyhint-enter-search": "Keyboard hint for the key to perform a search in the command palette",

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -132,6 +132,9 @@ module.exports = exports = defineComponent( {
 		const getTokenPatterns = inject( 'getTokenPatterns' );
 		const getHelpCatalogItems = inject( 'getHelpCatalogItems', null );
 		const getHandler = inject( 'getHandler', null );
+		// Provided by commandPalette.js so the trigger orchestrator can hide
+		// its overlay wrapper after the palette closes from inside (Esc, backdrop).
+		const paletteExternalClose = inject( 'paletteExternalClose', null );
 
 		// Core refs
 		const isOpen = ref( false );
@@ -324,7 +327,13 @@ module.exports = exports = defineComponent( {
 		};
 
 		const close = () => {
+			if ( !isOpen.value ) {
+				return;
+			}
 			isOpen.value = false;
+			if ( typeof paletteExternalClose === 'function' ) {
+				paletteExternalClose();
+			}
 		};
 
 		const focusInput = () => {
@@ -543,8 +552,8 @@ module.exports = exports = defineComponent( {
 			}
 		}, { flush: 'post' } );
 
-		// This function is called externally from init.js
-		const open = () => {
+		// This function is called externally from commandPalette.js
+		const open = ( prefillText ) => {
 			isOpen.value = true;
 			orch.closeHelp();
 			if ( orch.activeMode.value ) {
@@ -553,6 +562,9 @@ module.exports = exports = defineComponent( {
 				orch.clearSearch();
 			}
 			tokenInput.clear();
+			if ( typeof prefillText === 'string' && prefillText.length > 0 ) {
+				tokenInput.setFreeText( prefillText );
+			}
 			nextTick( focusInput );
 		};
 
@@ -629,12 +641,6 @@ module.exports = exports = defineComponent( {
 	@media ( min-width: @max-width-breakpoint-tablet ) {
 		top: 3rem;
 		max-height: calc( 100vh - 3rem * 2 );
-	}
-
-	&-overlay {
-		position: absolute;
-		top: 0;
-		left: 0;
 	}
 
 	&-backdrop {

--- a/resources/skins.citizen.commandPalette/init.js
+++ b/resources/skins.citizen.commandPalette/init.js
@@ -25,24 +25,26 @@ const helpMode = require( './modes/help.js' );
 const createAppendQueryActions = require( './utils/appendQueryActions.js' );
 
 /**
- * Initialize the command palette
+ * Mount the command palette into the provided overlay element.
  *
- * @return {void}
+ * Caller (commandPalette.js) owns the trigger lifecycle: this function
+ * only mounts. Opening is the caller's responsibility — calling
+ * `open()` after mount lets Vue's standard enter transition play, so
+ * the first trigger on every fresh page gets a real open animation
+ * rather than a snap-in.
+ *
+ * @param {HTMLElement} overlayEl
+ * @param {Object} [options]
+ * @param {Function} [options.onClose] Called when the palette is dismissed from inside (Esc, backdrop).
+ * @return {Object} mounted palette instance with `open(prefill?)` and `close()`
  */
-function initApp() {
-	const teleportTarget = require( 'mediawiki.page.ready' ).teleportTarget;
+function initApp( overlayEl, options ) {
+	const opts = options || {};
 
-	// We can't mount directly to the teleportTarget or it will break OOUI overlays
-	const overlay = document.createElement( 'div' );
-	overlay.classList.add( 'citizen-command-palette-overlay' );
-	teleportTarget.appendChild( overlay );
-
-	// 1. Create services
 	const recentItemsService = createRecentItems();
 	const searchClient = createRestSearchClient( mw.config.get( 'wgScriptPath' ) );
 	const paletteRegistry = createPaletteRegistry();
 
-	// 2. Register built-in modes
 	paletteRegistry.register( namespaceMode );
 	paletteRegistry.register( createActionMode( document, mw.Api ) );
 	paletteRegistry.register( createUserMode( mw.Api ) );
@@ -50,11 +52,9 @@ function initApp() {
 	paletteRegistry.register( createHistoryMode( mw.Api ) );
 	paletteRegistry.register( helpMode );
 
-	// 3. Fire hook for extension commands
 	const hookData = { register: paletteRegistry.register };
 	mw.hook( 'citizen.commandPalette.register' ).fire( hookData );
 
-	// Backward-compat: fire old hook with deprecation notice
 	mw.hook( 'skins.citizen.commandPalette.registerCommand' ).fire( {
 		registerCommand: function ( command ) {
 			mw.log.warn(
@@ -65,7 +65,6 @@ function initApp() {
 		}
 	} );
 
-	// Conditionally load extension-specific modes
 	if ( config.isSemanticMediaWikiEnabled ) {
 		mw.loader.using( 'skins.citizen.commandPalette.smw' ).then( ( req ) => {
 			const smwMode = req( 'skins.citizen.commandPalette.smw' );
@@ -75,7 +74,6 @@ function initApp() {
 		} );
 	}
 
-	// 4. Create providers
 	const recentItemsProvider = createRecentItemsProvider( recentItemsService );
 	const relatedArticlesProvider = createRelatedArticlesProvider( mw.loader );
 	const providers = [
@@ -83,10 +81,8 @@ function initApp() {
 		createSearchProvider( searchClient )
 	];
 
-	// 5. Create result decorator
 	const appendQueryActions = createAppendQueryActions( config );
 
-	// 6. Mount Vue app with provide
 	const app = Vue.createMwApp( App, {}, config );
 	app.provide( 'providers', providers );
 	app.provide( 'recentItemsService', recentItemsService );
@@ -99,35 +95,18 @@ function initApp() {
 	app.provide( 'getHandler', paletteRegistry.getHandler );
 	app.provide( 'getHelpCatalogItems', () => paletteRegistry.getCommandListItems()
 		.filter( ( item ) => item.source !== 'command:help' ) );
+	// Called from App.vue's close() so the orchestrator can hide its
+	// overlay wrapper and reset the trigger's `<details>` open state when
+	// the palette is dismissed from inside (Esc, backdrop click). Falls
+	// back to just hiding the wrapper if no callback was supplied.
+	const externalClose = ( typeof opts.onClose === 'function' ) ?
+		opts.onClose :
+		() => {
+			overlayEl.hidden = true;
+		};
+	app.provide( 'paletteExternalClose', externalClose );
 
-	const commandPalette = app.mount( overlay );
-
-	// 7. Wire up trigger button
-	setupTrigger( commandPalette );
+	return app.mount( overlayEl );
 }
 
-/**
- * Setup the button to open the command palette
- *
- * @param {Object} commandPalette The mounted Vue app instance.
- * @return {void}
- */
-function setupTrigger( commandPalette ) {
-	const details = document.getElementById( 'citizen-search-details' );
-	if ( !details ) {
-		return;
-	}
-
-	// Remove the search card from the DOM so it won't be triggered by the button
-	document.getElementById( 'citizen-search__card' )?.remove();
-
-	// Remove aria-details since citizen-search__card no longer exists
-	document.getElementById( 'citizen-search-summary' )?.removeAttribute( 'aria-details' );
-
-	details.open = false;
-	details.addEventListener( 'click', () => {
-		commandPalette.open();
-	} );
-}
-
-initApp();
+module.exports = { initApp };

--- a/resources/skins.citizen.scripts/commandPalette.js
+++ b/resources/skins.citizen.scripts/commandPalette.js
@@ -1,0 +1,203 @@
+const MODULE = 'skins.citizen.commandPalette';
+const LOAD_TIMEOUT_MS = 10000;
+const { bindIntentPrefetch } = require( './intentPrefetch.js' );
+
+/**
+ * Create the command palette trigger orchestrator.
+ *
+ * Owns the lifecycle: intent prefetch on hover/focus/touch, lazy
+ * `mw.loader.using` on click/keyboard, prefill queueing, and dispatch
+ * to the mounted Vue app once it is ready. On cold cache the user
+ * sees nothing for the duration of the load (typically <300ms on
+ * broadband; longer on slow connections); on rejection or timeout we
+ * surface an `mw.notify` toast so the click is not silently lost.
+ *
+ * @param {Object} deps
+ * @param {Document} deps.document
+ * @param {Object} deps.mw
+ * @return {{init: Function, triggerOpen: Function, close: Function}}
+ */
+function createCommandPalette( { document, mw } ) {
+	let state = 'idle'; // 'idle' | 'loading' | 'mounted'
+	let paletteApp = null;
+	let pendingPrefill = null;
+	// Set to true if the user dismisses (Esc) while state is 'loading'.
+	// The in-flight load still completes — we mount Vue silently so the
+	// next trigger is instant — but we suppress the auto-open and the
+	// failure toast that would otherwise fire after a dismissal.
+	let cancelled = false;
+
+	let detailsEl = null;
+	let overlay = null;
+
+	/**
+	 * Mirror palette open/closed state onto the `<details>` element. The
+	 * `[ open ]` attribute drives the search-trigger CSS that morphs the
+	 * magnifier glyph into an X icon (Search__button.less). `triggerOpen`
+	 * and `close` are the canonical paths and may be invoked from
+	 * keyboard shortcuts or external triggers, so the toggle has to be
+	 * driven from code rather than the browser's auto-toggle.
+	 *
+	 * @param {boolean} open
+	 */
+	function setOpenState( open ) {
+		if ( detailsEl ) {
+			detailsEl.open = open;
+		}
+	}
+
+	function notifyClosed() {
+		// Do not hide the overlay wrapper here. Vue's `<Transition>` runs
+		// the leave animation on the backdrop and palette card after
+		// `isOpen` flips to false; setting `display: none` on the wrapper
+		// synchronously would cut the leave short and visually snap the
+		// palette closed. The wrapper is harmless when empty (zero-height
+		// block with no styles), so we just let Vue's `v-if` clean up the
+		// inner DOM after the leave transition completes.
+		setOpenState( false );
+		pendingPrefill = null;
+	}
+
+	/**
+	 * Lazily create the overlay element on first mount. We do not render
+	 * a server-side placeholder; the overlay only enters the DOM when
+	 * Vue is actually about to mount inside it.
+	 *
+	 * Appended to `mediawiki.page.ready`'s teleport target (rather than
+	 * `document.body`) so it inherits `#mw-teleport-target`'s
+	 * `z-index: @z-index-overlay`, which is what places it above
+	 * positioned page chrome like the skin header.
+	 *
+	 * @return {HTMLElement}
+	 */
+	function ensureOverlay() {
+		if ( overlay ) {
+			return overlay;
+		}
+		const teleportTarget = require( 'mediawiki.page.ready' ).teleportTarget;
+		overlay = document.createElement( 'div' );
+		overlay.id = 'citizen-command-palette-overlay';
+		overlay.className = 'citizen-command-palette-overlay';
+		teleportTarget.appendChild( overlay );
+		return overlay;
+	}
+
+	function load() {
+		state = 'loading';
+		cancelled = false;
+
+		let timeoutId = null;
+		const timeoutPromise = new Promise( ( _resolve, reject ) => {
+			timeoutId = setTimeout( () => reject( new Error( 'timeout' ) ), LOAD_TIMEOUT_MS );
+		} );
+
+		Promise.race( [ mw.loader.using( MODULE ), timeoutPromise ] ).then(
+			( req ) => {
+				clearTimeout( timeoutId );
+				const mod = req( MODULE );
+				const overlayEl = ensureOverlay();
+				paletteApp = mod.initApp( overlayEl, {
+					prefill: pendingPrefill,
+					onClose: notifyClosed
+				} );
+				state = 'mounted';
+				if ( !cancelled ) {
+					paletteApp.open( pendingPrefill );
+				}
+				pendingPrefill = null;
+				cancelled = false;
+			},
+			() => {
+				clearTimeout( timeoutId );
+				state = 'idle';
+				if ( cancelled ) {
+					// User already dismissed — no toast, just settle.
+					cancelled = false;
+					return;
+				}
+				setOpenState( false );
+				mw.notify(
+					mw.message( 'citizen-command-palette-load-error' ).text(),
+					{ type: 'error' }
+				);
+			}
+		);
+	}
+
+	function triggerOpen( prefillText ) {
+		const text = ( typeof prefillText === 'string' && prefillText.length > 0 ) ?
+			prefillText :
+			null;
+		setOpenState( true );
+		// Re-trigger after Esc-during-loading: clear the dismissal so the
+		// in-flight load opens the palette when it completes.
+		cancelled = false;
+
+		if ( state === 'mounted' ) {
+			paletteApp.open( text );
+			return;
+		}
+		if ( state === 'loading' ) {
+			pendingPrefill = text;
+			return;
+		}
+		pendingPrefill = text;
+		load();
+	}
+
+	function close() {
+		if ( state === 'mounted' && paletteApp && typeof paletteApp.close === 'function' ) {
+			// Vue's close path will call `notifyClosed` via the injected
+			// onClose callback, so the overlay/details state updates only
+			// happen once.
+			paletteApp.close();
+			return;
+		}
+		notifyClosed();
+	}
+
+	function init() {
+		const summary = document.getElementById( 'citizen-search-summary' );
+		if ( !summary ) {
+			return;
+		}
+		detailsEl = document.getElementById( 'citizen-search-details' );
+
+		// `templates/Search.mustache` renders a `<div id="citizen-search__card">`
+		// as a no-JS fallback search form (revealed by Search.less when the
+		// `<details>` opens), and `Search__button.mustache` carries an
+		// `aria-details="citizen-search__card"` attribute pointing at it.
+		// With JS active the palette supplants the fallback, so we strip
+		// both — the card prevents the trigger from receiving palette
+		// clicks, and the aria-details would point at a removed node.
+		const oldCard = document.getElementById( 'citizen-search__card' );
+		if ( oldCard ) {
+			oldCard.remove();
+		}
+		summary.removeAttribute( 'aria-details' );
+
+		bindIntentPrefetch( summary, MODULE, mw );
+
+		summary.addEventListener( 'click', ( event ) => {
+			event.preventDefault();
+			triggerOpen();
+		} );
+
+		// Cancel-during-loading affordance: Vue isn't mounted yet, so Esc
+		// can't be handled by App.vue's keyboard composable. Mark the
+		// load as cancelled — the in-flight bundle still completes (we
+		// keep the bytes for next time and mount Vue silently) but the
+		// palette won't auto-open and the failure toast is suppressed.
+		document.addEventListener( 'keydown', ( event ) => {
+			if ( event.key === 'Escape' && state === 'loading' ) {
+				cancelled = true;
+				setOpenState( false );
+				pendingPrefill = null;
+			}
+		} );
+	}
+
+	return { init, triggerOpen, close };
+}
+
+module.exports = { createCommandPalette };

--- a/resources/skins.citizen.scripts/intentPrefetch.js
+++ b/resources/skins.citizen.scripts/intentPrefetch.js
@@ -1,0 +1,40 @@
+const INTENT_EVENTS = [ 'pointerenter', 'focus', 'touchstart' ];
+
+/**
+ * Bind hover/focus/touch intent listeners that prefetch a ResourceLoader module.
+ *
+ * Each listener fires at most once via `{ once: true }`. The first event calls
+ * `mw.loader.load(moduleName)`; an internal `fired` flag short-circuits the
+ * remaining listeners so the second and third events don't re-call. Returns a
+ * `cancel` function that flips the flag and explicitly removes any listeners
+ * that haven't yet auto-removed themselves.
+ *
+ * @param {HTMLElement} trigger
+ * @param {string} moduleName ResourceLoader module name
+ * @param {Object} mw MediaWiki global
+ * @return {Function} cancel
+ */
+function bindIntentPrefetch( trigger, moduleName, mw ) {
+	let fired = false;
+
+	function fire() {
+		if ( fired ) {
+			return;
+		}
+		fired = true;
+		mw.loader.load( moduleName );
+	}
+
+	INTENT_EVENTS.forEach( ( evt ) => {
+		trigger.addEventListener( evt, fire, { once: true, passive: true } );
+	} );
+
+	return function cancel() {
+		fired = true;
+		INTENT_EVENTS.forEach( ( evt ) => {
+			trigger.removeEventListener( evt, fire );
+		} );
+	};
+}
+
+module.exports = { bindIntentPrefetch };

--- a/resources/skins.citizen.scripts/preferences.js
+++ b/resources/skins.citizen.scripts/preferences.js
@@ -1,5 +1,5 @@
 const MODULE = 'skins.citizen.preferences';
-const INTENT_EVENTS = [ 'pointerenter', 'focus', 'touchstart' ];
+const { bindIntentPrefetch } = require( './intentPrefetch.js' );
 
 /**
  * @param {Object} deps
@@ -34,17 +34,8 @@ function createPreferences( { document, mw } ) {
 			errorEl.querySelector( '.citizen-preferences-error__retry' ) :
 			null;
 
-		let prefetched = false;
 		let loading = false;
 		let mounted = false;
-
-		function prefetch() {
-			if ( prefetched || mounted ) {
-				return;
-			}
-			prefetched = true;
-			mw.loader.load( MODULE );
-		}
 
 		function showSkeleton() {
 			if ( errorEl ) {
@@ -66,6 +57,8 @@ function createPreferences( { document, mw } ) {
 			}
 		}
 
+		const cancelPrefetch = bindIntentPrefetch( summary, MODULE, mw );
+
 		function load() {
 			if ( mounted || loading ) {
 				return;
@@ -77,6 +70,7 @@ function createPreferences( { document, mw } ) {
 				() => {
 					mounted = true;
 					loading = false;
+					cancelPrefetch();
 				},
 				() => {
 					showError();
@@ -84,10 +78,6 @@ function createPreferences( { document, mw } ) {
 				}
 			);
 		}
-
-		INTENT_EVENTS.forEach( ( evt ) => {
-			summary.addEventListener( evt, prefetch, { once: true, passive: true } );
-		} );
 
 		details.addEventListener( 'toggle', () => {
 			if ( details.open ) {

--- a/resources/skins.citizen.scripts/search.js
+++ b/resources/skins.citizen.scripts/search.js
@@ -1,6 +1,7 @@
 /**
  * Check if the element is a HTML form element or content editable.
- * This is to prevent triggering search box when user is typing on a textfield, input, etc.
+ * Used to gate keyboard shortcuts so typing in an input does not
+ * accidentally open the command palette.
  *
  * @param {HTMLElement} element
  * @return {boolean}
@@ -18,23 +19,13 @@ function isFormField( element ) {
 }
 
 /**
- * Open the search UI.
- *
- * @param {HTMLDetailsElement} details
- * @return {void}
- */
-function openSearch( details ) {
-	details.click();
-}
-
-/**
- * Bind keyboard shortcuts to open the search UI.
+ * Bind keyboard shortcuts that open the command palette.
  *
  * @param {Window} window
- * @param {HTMLDetailsElement} details
+ * @param {Function} triggerOpen
  * @return {void}
  */
-function bindOpenOnSlash( window, details ) {
+function bindOpenOnSlash( window, triggerOpen ) {
 	const onExpandOnSlash = ( /** @type {KeyboardEvent} */ event ) => {
 		const isKeyPressed = () => {
 			// "/" key is standard on many sites
@@ -51,9 +42,9 @@ function bindOpenOnSlash( window, details ) {
 			}
 		};
 		if ( isKeyPressed() && !isFormField( event.target ) ) {
-			// Since Firefox quickfind interfere with this
+			// Firefox quickfind would otherwise intercept "/"
 			event.preventDefault();
-			openSearch( details );
+			triggerOpen();
 		}
 	};
 
@@ -61,53 +52,39 @@ function bindOpenOnSlash( window, details ) {
 }
 
 /**
- * Bind the search trigger to open the search UI and prefill the input.
+ * Bind external `.citizen-search-trigger` links (with optional
+ * `data-citizen-search-prefill`) to open the palette with optional
+ * prefill text.
  *
  * @param {Document} document
- * @param {Object} mw
- * @param {HTMLDetailsElement} details
+ * @param {Function} triggerOpen
  * @return {void}
  */
-function bindSearchTrigger( document, mw, details ) {
+function bindSearchTrigger( document, triggerOpen ) {
 	document.querySelectorAll( '.citizen-search-trigger' ).forEach( ( trigger ) => {
 		trigger.addEventListener( 'click', ( event ) => {
-			openSearch( details );
-			if ( event.target.dataset.citizenSearchPrefill ) {
-				// Add a delay to ensure the search UI is open
-				setTimeout( () => {
-					const input = document.querySelector(
-						'.citizen-command-palette-header__input .cdx-text-input__input'
-					);
-
-					if ( input === null ) {
-						return;
-					}
-
-					// Escape just to be safe
-					input.value = mw.html.escape(
-						event.target.dataset.citizenSearchPrefill
-					);
-				}, 0 );
-			}
+			const prefill = event.target.dataset && event.target.dataset.citizenSearchPrefill ?
+				event.target.dataset.citizenSearchPrefill :
+				null;
+			triggerOpen( prefill );
 		} );
 	} );
 }
 
 /**
- * Initializes the search functionality.
+ * Initializes the search functionality (keyboard shortcuts and
+ * auxiliary triggers). The command palette itself is owned by
+ * `commandPalette.js`; this module just routes user intent to it.
  *
  * @param {Object} deps
  * @param {Window} deps.window
  * @param {Document} deps.document
- * @param {Object} deps.mw
+ * @param {Function} deps.triggerOpen
  * @return {void}
  */
-function initSearch( { window, document, mw } ) {
-	const details = document.getElementById( 'citizen-search-details' );
-
-	bindOpenOnSlash( window, details );
-	bindSearchTrigger( document, mw, details );
-	mw.loader.load( 'skins.citizen.commandPalette' );
+function initSearch( { window, document, triggerOpen } ) {
+	bindOpenOnSlash( window, triggerOpen );
+	bindSearchTrigger( document, triggerOpen );
 }
 
 module.exports = {

--- a/resources/skins.citizen.scripts/skin.js
+++ b/resources/skins.citizen.scripts/skin.js
@@ -73,9 +73,13 @@ function main( window ) {
 		{ createShare } = require( './share.js' ),
 		setupObservers = require( './setupObservers.js' ),
 		{ createPerformanceMode } = require( './performance.js' ),
-		{ createPreferences } = require( './preferences.js' );
+		{ createPreferences } = require( './preferences.js' ),
+		{ createCommandPalette } = require( './commandPalette.js' );
 
-	search.init( { window, document, mw } );
+	const commandPalette = createCommandPalette( { document, mw } );
+	commandPalette.init();
+
+	search.init( { window, document, triggerOpen: commandPalette.triggerOpen } );
 	createEchoUpgrade( { document, mw } ).init();
 	setupObservers.init( { document, window, mw, IntersectionObserver } );
 	dropdown.init( { document, window } );

--- a/skin.json
+++ b/skin.json
@@ -189,6 +189,7 @@
 				"resources/skins.citizen.scripts/deferUntilFrame.js",
 				"resources/skins.citizen.scripts/dropdown.js",
 				"resources/skins.citizen.scripts/echo.js",
+				"resources/skins.citizen.scripts/intentPrefetch.js",
 				"resources/skins.citizen.scripts/lastModified.js",
 				"resources/skins.citizen.scripts/overflowElements/index.js",
 				"resources/skins.citizen.scripts/overflowElements/wrapper.js",

--- a/skin.json
+++ b/skin.json
@@ -185,6 +185,7 @@
 					"name": "resources/skins.citizen.scripts/config.json",
 					"callback": "MediaWiki\\Skins\\Citizen\\Hooks\\ResourceLoaderHooks::getCitizenResourceLoaderConfig"
 				},
+				"resources/skins.citizen.scripts/commandPalette.js",
 				"resources/skins.citizen.scripts/contentEnhancements.js",
 				"resources/skins.citizen.scripts/deferUntilFrame.js",
 				"resources/skins.citizen.scripts/dropdown.js",
@@ -227,6 +228,7 @@
 				}
 			],
 			"messages": [
+				"citizen-command-palette-load-error",
 				"citizen-share",
 				"citizen-share-copied"
 			],

--- a/tests/vitest/mocks/mediawikiPageReady.js
+++ b/tests/vitest/mocks/mediawikiPageReady.js
@@ -1,0 +1,17 @@
+// Stub for the virtual `mediawiki.page.ready` ResourceLoader module.
+//
+// Tests that exercise commandPalette.js need a `teleportTarget` element to
+// append the palette overlay to. The real module exposes a teleport target
+// that lives at the end of <body>; for jsdom we just point at `document.body`
+// itself.
+//
+// Important: this file is loaded once at test start, so `document.body` is
+// captured eagerly. Tests typically mutate `document.body.innerHTML` between
+// cases — that's safe because we cache the body *element*, not its contents.
+// Don't refactor this into something that resolves the body lazily; if a test
+// replaces the entire body element (rare), this stub becomes stale.
+module.exports = {
+	teleportTarget: ( typeof document !== 'undefined' ) ?
+		document.body :
+		null
+};

--- a/tests/vitest/setup.js
+++ b/tests/vitest/setup.js
@@ -20,6 +20,11 @@ Module._extensions[ '.mustache' ] = function ( mod, filename ) {
 const originalResolveFilename = Module._resolveFilename;
 const TEMPLATES_DIR = path.resolve( __dirname, '../../templates' );
 Module._resolveFilename = function ( request, parent, ...rest ) {
+	// Virtual ResourceLoader modules with bare names (no relative path),
+	// addressed by their module name from any consumer.
+	if ( request === 'mediawiki.page.ready' ) {
+		return path.resolve( __dirname, 'mocks/mediawikiPageReady.js' );
+	}
 	if ( parent && parent.filename &&
 		parent.filename.includes( 'skins.citizen.scripts' ) ) {
 		if ( request === './tableOfContentsConfig.json' ) {

--- a/tests/vitest/skins.citizen.scripts/commandPalette.test.js
+++ b/tests/vitest/skins.citizen.scripts/commandPalette.test.js
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+
+const mw = require( '../mocks/mw.js' );
+const { createCommandPalette } = require( '../../../resources/skins.citizen.scripts/commandPalette.js' );
+
+const FIXTURE = `
+<details id="citizen-search-details">
+	<summary id="citizen-search-summary">Search</summary>
+</details>
+`;
+
+describe( 'createCommandPalette', () => {
+	let resolveLoad;
+	let rejectLoad;
+	let mockOpen;
+	let mockClose;
+	let mockInitApp;
+
+	beforeEach( () => {
+		document.body.innerHTML = FIXTURE;
+		mw.loader.load.mockClear();
+		mw.loader.using.mockReset();
+
+		mockOpen = vi.fn();
+		mockClose = vi.fn();
+		mockInitApp = vi.fn().mockReturnValue( { open: mockOpen, close: mockClose } );
+		// `mw.loader.using` resolves with a `req` function that returns the
+		// loaded module's exports. Mirrors the real MediaWiki API contract
+		// and matches the SMW-mode-load pattern in palette init.js.
+		const req = vi.fn().mockReturnValue( { initApp: mockInitApp } );
+		const usingPromise = new Promise( ( resolve, reject ) => {
+			resolveLoad = () => resolve( req );
+			rejectLoad = reject;
+		} );
+		mw.loader.using.mockReturnValue( usingPromise );
+
+		mw.notify = vi.fn();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'triggerOpen from idle calls mw.loader.using and sets details.open', () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+
+		cp.triggerOpen();
+
+		const details = document.getElementById( 'citizen-search-details' );
+		expect( mw.loader.using ).toHaveBeenCalledWith( 'skins.citizen.commandPalette' );
+		expect( details.open ).toBe( true );
+	} );
+
+	it( 'on resolve, creates an overlay, mounts the palette, and opens it', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const overlay = document.getElementById( 'citizen-command-palette-overlay' );
+		expect( overlay ).not.toBeNull();
+		expect( mockInitApp ).toHaveBeenCalledWith( overlay, expect.objectContaining( {
+			prefill: null,
+			onClose: expect.any( Function )
+		} ) );
+		expect( mockOpen ).toHaveBeenCalledWith( null );
+	} );
+
+	it( 'forwards prefill text from triggerOpen through to palette.open', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen( 'hello world' );
+
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		expect( mockOpen ).toHaveBeenCalledWith( 'hello world' );
+	} );
+
+	it( 'on reject, surfaces an mw.notify toast and resets details.open', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+
+		rejectLoad( new Error( 'load failed' ) );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const details = document.getElementById( 'citizen-search-details' );
+		expect( details.open ).toBe( false );
+		expect( mw.notify ).toHaveBeenCalledWith(
+			expect.any( String ),
+			expect.objectContaining( { type: 'error' } )
+		);
+	} );
+
+	it( 'times out after 10s and surfaces an mw.notify toast', async () => {
+		vi.useFakeTimers();
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+
+		await vi.advanceTimersByTimeAsync( 10001 );
+
+		expect( mw.notify ).toHaveBeenCalledWith(
+			expect.any( String ),
+			expect.objectContaining( { type: 'error' } )
+		);
+	} );
+
+	it( 'on close from inside Vue, resets details.open without snapping the wrapper to display:none', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const details = document.getElementById( 'citizen-search-details' );
+		expect( details.open ).toBe( true );
+
+		// Simulate Vue's close path firing the onClose callback.
+		const onCloseArg = mockInitApp.mock.calls[ 0 ][ 1 ].onClose;
+		onCloseArg();
+
+		const overlay = document.getElementById( 'citizen-command-palette-overlay' );
+		expect( details.open ).toBe( false );
+		// Wrapper stays unhidden so Vue's <Transition> leave animation
+		// can play to completion before the inner DOM is removed by v-if.
+		expect( overlay.hidden ).toBe( false );
+	} );
+
+	it( 're-trigger after mounted skips the loader and calls paletteApp.open', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		// Simulate Vue's close path.
+		mockInitApp.mock.calls[ 0 ][ 1 ].onClose();
+
+		mw.loader.using.mockClear();
+		cp.triggerOpen( 'second' );
+
+		expect( mw.loader.using ).not.toHaveBeenCalled();
+		expect( mockOpen ).toHaveBeenCalledWith( 'second' );
+	} );
+
+	it( 'cp.close() from mounted state delegates to paletteApp.close', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		cp.close();
+
+		expect( mockClose ).toHaveBeenCalled();
+	} );
+
+	it( 'Esc during loading marks the trigger cancelled, mounts silently on resolve', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+
+		const details = document.getElementById( 'citizen-search-details' );
+		expect( details.open ).toBe( true );
+
+		document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape' } ) );
+		expect( details.open ).toBe( false );
+
+		// Bundle keeps loading; on resolve the palette mounts but does
+		// not auto-open. Subsequent triggerOpen reuses the mounted instance.
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		expect( mockInitApp ).toHaveBeenCalled();
+		expect( mockOpen ).not.toHaveBeenCalled();
+
+		// Re-trigger after cancellation: this time it actually opens.
+		cp.triggerOpen( 'after-cancel' );
+		expect( mockOpen ).toHaveBeenCalledWith( 'after-cancel' );
+	} );
+
+	it( 'Esc during loading suppresses the failure toast if load later rejects', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+
+		document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape' } ) );
+
+		rejectLoad( new Error( 'load failed' ) );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		// User already dismissed — no surprise toast.
+		expect( mw.notify ).not.toHaveBeenCalled();
+	} );
+
+	it( 'hover on summary fires mw.loader.load via intent prefetch', () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+
+		const summary = document.getElementById( 'citizen-search-summary' );
+		summary.dispatchEvent( new Event( 'pointerenter' ) );
+
+		expect( mw.loader.load ).toHaveBeenCalledWith( 'skins.citizen.commandPalette' );
+	} );
+
+	it( 'click on summary fires triggerOpen and preventDefaults the details toggle', () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+
+		const summary = document.getElementById( 'citizen-search-summary' );
+		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
+		const preventDefaultSpy = vi.spyOn( event, 'preventDefault' );
+
+		summary.dispatchEvent( event );
+
+		expect( preventDefaultSpy ).toHaveBeenCalled();
+		expect( mw.loader.using ).toHaveBeenCalledWith( 'skins.citizen.commandPalette' );
+	} );
+} );

--- a/tests/vitest/skins.citizen.scripts/intentPrefetch.test.js
+++ b/tests/vitest/skins.citizen.scripts/intentPrefetch.test.js
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+const mw = require( '../mocks/mw.js' );
+const { bindIntentPrefetch } = require( '../../../resources/skins.citizen.scripts/intentPrefetch.js' );
+
+afterEach( () => {
+	vi.restoreAllMocks();
+	mw.loader.load.mockClear();
+	document.body.innerHTML = '';
+} );
+
+describe( 'bindIntentPrefetch', () => {
+	function makeTrigger() {
+		document.body.innerHTML = '<button id="trigger">Trigger</button>';
+		return document.getElementById( 'trigger' );
+	}
+
+	it( 'fires mw.loader.load once on pointerenter', () => {
+		const trigger = makeTrigger();
+
+		bindIntentPrefetch( trigger, 'foo.module', mw );
+		trigger.dispatchEvent( new Event( 'pointerenter' ) );
+
+		expect( mw.loader.load ).toHaveBeenCalledTimes( 1 );
+		expect( mw.loader.load ).toHaveBeenCalledWith( 'foo.module' );
+	} );
+
+	it( 'fires mw.loader.load once on focus', () => {
+		const trigger = makeTrigger();
+
+		bindIntentPrefetch( trigger, 'foo.module', mw );
+		trigger.dispatchEvent( new Event( 'focus' ) );
+
+		expect( mw.loader.load ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'fires mw.loader.load once on touchstart', () => {
+		const trigger = makeTrigger();
+
+		bindIntentPrefetch( trigger, 'foo.module', mw );
+		trigger.dispatchEvent( new Event( 'touchstart' ) );
+
+		expect( mw.loader.load ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'dedupes across multiple events on the same trigger', () => {
+		const trigger = makeTrigger();
+
+		bindIntentPrefetch( trigger, 'foo.module', mw );
+		trigger.dispatchEvent( new Event( 'pointerenter' ) );
+		trigger.dispatchEvent( new Event( 'focus' ) );
+		trigger.dispatchEvent( new Event( 'touchstart' ) );
+
+		expect( mw.loader.load ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'suppresses fires after cancel() is called', () => {
+		const trigger = makeTrigger();
+
+		const cancel = bindIntentPrefetch( trigger, 'foo.module', mw );
+		cancel();
+		trigger.dispatchEvent( new Event( 'pointerenter' ) );
+
+		expect( mw.loader.load ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/vitest/skins.citizen.scripts/search.test.js
+++ b/tests/vitest/skins.citizen.scripts/search.test.js
@@ -1,31 +1,10 @@
 // @vitest-environment jsdom
 /* global document, window, KeyboardEvent */
 
-const mw = require( '../mocks/mw.js' );
-
-/**
- * Build a minimal search DOM structure with a details toggle.
- *
- * @return {{ details: HTMLDetailsElement }}
- */
 function buildSearchDom() {
-	document.body.innerHTML = `
-		<details id="citizen-search-details"></details>
-	`;
-
-	return {
-		details: document.getElementById( 'citizen-search-details' )
-	};
+	document.body.innerHTML = '<details id="citizen-search-details"></details>';
 }
 
-/**
- * Dispatch a keydown event from the given target element.
- * Because bindOpenOnSlash uses capture mode, the event reaches the
- * window listener during the capture phase with the correct target.
- *
- * @param {HTMLElement} target
- * @param {Object} opts KeyboardEvent init options
- */
 function dispatchKeydown( target, opts ) {
 	target.dispatchEvent( new KeyboardEvent( 'keydown', {
 		bubbles: true,
@@ -40,37 +19,35 @@ afterEach( () => {
 } );
 
 describe( 'search', () => {
+	let triggerOpen;
+	let init;
+
+	beforeEach( () => {
+		triggerOpen = vi.fn();
+		init = require( '../../../resources/skins.citizen.scripts/search.js' ).init;
+	} );
+
 	describe( 'initSearch', () => {
-		it( 'should load command palette module', () => {
-			const { init } = require( '../../../resources/skins.citizen.scripts/search.js' );
+		it( 'no longer requires an mw dependency (eager load is gone)', () => {
 			buildSearchDom();
-			mw.loader.load.mockClear();
 
-			init( { window, document, mw } );
-
-			expect( mw.loader.load ).toHaveBeenCalledWith( 'skins.citizen.commandPalette' );
+			expect( () => init( { window, document, triggerOpen } ) ).not.toThrow();
 		} );
 	} );
 
 	describe( 'keyboard shortcuts', () => {
-		it( 'should call details.click() when / key is pressed outside a form field', () => {
-			const { details } = buildSearchDom();
-			const clickSpy = vi.spyOn( details, 'click' );
-
-			const { init } = require( '../../../resources/skins.citizen.scripts/search.js' );
-			init( { window, document, mw } );
+		it( 'calls triggerOpen() when / is pressed outside a form field', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
 
 			dispatchKeydown( document.body, { code: 'Slash' } );
 
-			expect( clickSpy ).toHaveBeenCalled();
+			expect( triggerOpen ).toHaveBeenCalled();
 		} );
 
-		it( 'should call details.click() on Ctrl+K and call preventDefault', () => {
-			const { details } = buildSearchDom();
-			const clickSpy = vi.spyOn( details, 'click' );
-
-			const { init } = require( '../../../resources/skins.citizen.scripts/search.js' );
-			init( { window, document, mw } );
+		it( 'calls triggerOpen() on Ctrl+K and calls preventDefault', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
 
 			const event = new KeyboardEvent( 'keydown', {
 				code: 'KeyK',
@@ -82,16 +59,22 @@ describe( 'search', () => {
 
 			document.body.dispatchEvent( event );
 
-			expect( clickSpy ).toHaveBeenCalled();
+			expect( triggerOpen ).toHaveBeenCalled();
 			expect( preventDefaultSpy ).toHaveBeenCalled();
 		} );
 
-		it( 'should ignore shortcuts when target is a form field', () => {
-			const { details } = buildSearchDom();
-			const clickSpy = vi.spyOn( details, 'click' );
+		it( 'calls triggerOpen() on Alt+Shift+F', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
 
-			const { init } = require( '../../../resources/skins.citizen.scripts/search.js' );
-			init( { window, document, mw } );
+			dispatchKeydown( document.body, { code: 'KeyF', altKey: true, shiftKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'ignores shortcuts when target is a form field', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
 
 			const textInput = document.createElement( 'input' );
 			textInput.setAttribute( 'type', 'text' );
@@ -105,7 +88,6 @@ describe( 'search', () => {
 
 			const contentEditable = document.createElement( 'div' );
 			contentEditable.setAttribute( 'contenteditable', 'true' );
-			// JSDOM does not implement isContentEditable, so define it manually
 			Object.defineProperty( contentEditable, 'isContentEditable', { value: true } );
 			document.body.appendChild( contentEditable );
 
@@ -113,15 +95,12 @@ describe( 'search', () => {
 				dispatchKeydown( el, { code: 'Slash' } );
 			} );
 
-			expect( clickSpy ).not.toHaveBeenCalled();
+			expect( triggerOpen ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should fire shortcuts when target is a checkbox or button', () => {
-			const { details } = buildSearchDom();
-			const clickSpy = vi.spyOn( details, 'click' );
-
-			const { init } = require( '../../../resources/skins.citizen.scripts/search.js' );
-			init( { window, document, mw } );
+		it( 'fires shortcuts when target is a checkbox or button', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
 
 			const checkbox = document.createElement( 'input' );
 			checkbox.setAttribute( 'type', 'checkbox' );
@@ -129,14 +108,40 @@ describe( 'search', () => {
 
 			dispatchKeydown( checkbox, { code: 'Slash' } );
 
-			expect( clickSpy ).toHaveBeenCalledTimes( 1 );
+			expect( triggerOpen ).toHaveBeenCalledTimes( 1 );
 
 			const button = document.createElement( 'button' );
 			document.body.appendChild( button );
 
 			dispatchKeydown( button, { code: 'Slash' } );
 
-			expect( clickSpy ).toHaveBeenCalledTimes( 2 );
+			expect( triggerOpen ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+
+	describe( 'auxiliary search triggers', () => {
+		it( 'calls triggerOpen with prefill text from data attribute', () => {
+			document.body.innerHTML =
+				'<details id="citizen-search-details"></details>' +
+				'<a class="citizen-search-trigger" data-citizen-search-prefill="hello">go</a>';
+
+			init( { window, document, triggerOpen } );
+
+			document.querySelector( '.citizen-search-trigger' ).click();
+
+			expect( triggerOpen ).toHaveBeenCalledWith( 'hello' );
+		} );
+
+		it( 'calls triggerOpen with null when no prefill', () => {
+			document.body.innerHTML =
+				'<details id="citizen-search-details"></details>' +
+				'<a class="citizen-search-trigger">go</a>';
+
+			init( { window, document, triggerOpen } );
+
+			document.querySelector( '.citizen-search-trigger' ).click();
+
+			expect( triggerOpen ).toHaveBeenCalledWith( null );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

Stop loading `skins.citizen.commandPalette` on every pageview. The bundle is **~124KB compressed** (Vue 3 + Codex + modes/providers) and roughly 90% of pageviews are read-only wiki readers who never open the palette. The bytes are wasted bandwidth, parse time, and execute time for the vast majority of visitors.

The new flow defers the bundle until the user actually signals intent (hover, focus, touch, click, or keyboard shortcut). Hover/focus/touch fire `mw.loader.load` so most desktop users hit a warm cache by the time they click. Cold-cache first-trigger users see ~250-500ms of nothing on broadband before the palette opens with its standard `<Transition>` enter animation; subsequent triggers in the same session are instant.

A new `bindIntentPrefetch` primitive is extracted (n=2 with the existing preferences trigger justifies it). Failure UX surfaces an `mw.notify` toast rather than failing silently, and pressing Esc while loading cancels the open intent without aborting the in-flight bundle.

## Architectural notes

- **Lazy mount on `teleportTarget`**: the orchestrator's wrapper div is appended to `mediawiki.page.ready`'s teleport target so it inherits `@z-index-overlay` and stacks above the skin header.
- **No server-rendered HTML dependency**: the wrapper is created in JS at first trigger, so this PR is robust to deploy windows where new JS lands against still-cached old HTML — there's nothing in the HTML that the JS expects.
- **No-JS fallback preserved**: `templates/Search.mustache`'s `<div id=\"citizen-search__card\">` (a CSS-driven fallback search form when `<details>` opens) is intentionally retained; the orchestrator's `init()` strips it client-side as a JS-overriding-fallback pattern. Comment in `commandPalette.js:init` documents this.
- **Close transition preservation**: `notifyClosed()` deliberately does *not* set `overlay.hidden = true` — Vue's `<Transition>` leave animations need the wrapper to stay rendered until `v-if` removes the inner DOM after the leave completes.

## Why ~250-500ms first-trigger latency is acceptable

The latency is the symmetric cost of the bandwidth savings. Idle-prefetch could eliminate it for non-hover users, but at the cost of shipping the 124KB to all readers anyway — which defeats the entire premise. If telemetry later shows the latency hurting active users, idle-prefetch is a one-line follow-up that doesn't require touching the orchestrator.

## Commits

- \`feat(scripts): add bindIntentPrefetch shared primitive\`
- \`refactor(preferences): use shared bindIntentPrefetch helper\` (n=2 extraction; no behavior change)
- \`feat(commandPalette): defer bundle load until user signals intent\`

## Test plan

### Vitest (already passing locally — 675/675)

- [x] \`bindIntentPrefetch\` unit tests: pointerenter/focus/touchstart each fire \`mw.loader.load\` once; dedupe across events; cancel removes listeners
- [x] \`commandPalette\` unit tests: idle→loading transitions, prefill propagation, mw.notify on reject, 10s timeout, mounted re-trigger, Esc-during-loading cancel paths, close transition wrapper-stays-unhidden
- [x] All 15 existing preferences tests pass without modification

### Manual browser verification (please confirm against your environment)

- [x] Cold-cache load of any wiki page: \`skins.citizen.commandPalette\` is **not** in the initial network requests
- [x] Hover the search summary: \`commandPalette\` request fires
- [x] Click search before any hover (incognito + clear cache): palette opens with full enter transition after the bundle resolves
- [x] Press Esc during the loading window: search button reverts to magnifier; subsequent triggers reuse the silently-mounted palette
- [x] DevTools network throttle Slow 3G + force-block the \`commandPalette\` request: error toast surfaces after ~10s
- [x] \`?uselang=x-xss\` on a page where the error toast can be triggered: no XSS in the toast content
- [x] Keyboard shortcuts (\`/\`, \`Ctrl-K\`, \`Alt-Shift-F\`) trigger the palette
- [x] Backdrop click closes the palette with a smooth leave transition (not a snap)
- [x] Auxiliary \`.citizen-search-trigger\` link with \`data-citizen-search-prefill\`: palette opens with prefill text
- [x] No-JS fallback: with JavaScript disabled, the search summary still opens the legacy search card via CSS

## Related

- Documentation pattern PR for the defensive-fallback approach we considered and rejected: #1518 (separate, can merge independently)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command palette now supports prefilling search text when triggered.
  * Intent prefetching improves performance by loading palette resources before first interaction.
  * Command palette module is now lazily loaded on first use.

* **Bug Fixes**
  * Added error notification when command palette fails to load.

* **Documentation**
  * Added new translation key for command palette load error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->