### PR TITLE
fix(print): hide sticky header

### DIFF
--- a/resources/skins.citizen.styles/common/print.less
+++ b/resources/skins.citizen.styles/common/print.less
@@ -13,6 +13,7 @@
 .citizen-header,
 .citizen-sitenotice-container,
 .citizen-page-actions,
+.citizen-sticky-header-container,
 #citizen-page-header-sticky-sentinel,
 #citizen-page-header-sticky-placeholder,
 .citizen-page-footer,


### PR DESCRIPTION
When printing, hide the sticky header, including page info and actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sticky header appearing in printed documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->