### PR TITLE
feat(commandPalette): runtime contract for modes and commands

### DIFF
--- a/docs/src/customization/command-palette.md
+++ b/docs/src/customization/command-palette.md
@@ -115,6 +115,22 @@ mw.hook( 'citizen.commandPalette.register' ).add( function ( data ) {
 } );
 ```
 
+The hook payload exposes three things:
+
+| Field | Purpose |
+| :--- | :--- |
+| `register( entry )` | Add a mode or command to the palette. |
+| `defineMode( config )` | Validate a mode and fill in defaults. Returns the normalized config, or `null` if validation fails. |
+| `defineCommand( config )` | Same as `defineMode`, but for entries that fire an action immediately on selection. |
+
+Wrapping your entry with `defineMode` or `defineCommand` is optional — `register()` accepts plain objects too — but it catches mistakes at load time instead of letting them slip through silently. You get:
+
+- **Typo warnings.** Write `placholder` instead of `placeholder` and the console flags it. The field is kept on the config, so a newer Citizen version that knows about the new key can still use it.
+- **Sane defaults.** An unknown `layout` falls back to `'list'`, `compactResults` is coerced to a boolean, and `compactResults: true` paired with `layout: 'gallery'` is dropped (gallery has no rows to compact).
+- **Refusal on broken shapes.** Modes missing an `id`, with empty `triggers`, with non-string trigger entries, or without `getResults` return `null` instead of registering a broken entry.
+
+`register()` accepts `null` safely — it logs a warning and skips registration without touching other modes — so you can chain `data.register( data.defineMode( ... ) )` without a null guard.
+
 Check out these live examples from other wikis. To try them, visit the site, press `/` to open the palette, and type the command:
 
 <LinkGrid>
@@ -248,18 +264,16 @@ A command triggers an action directly when selected. Triggers should **not** end
 ::: details Toggle code
 
 ```js
-const myCommand = {
-    id: 'my-simple-command',
-    triggers: [ '/simple', '/sim' ],
-    description: 'Executes a simple action directly.',
-    onResultSelect: function ( item ) {
-        mw.notify( 'Simple command executed!' );
-        return { action: 'none' };
-    }
-};
-
 mw.hook( 'citizen.commandPalette.register' ).add( function ( data ) {
-    data.register( myCommand );
+    data.register( data.defineCommand( {
+        id: 'my-simple-command',
+        triggers: [ '/simple', '/sim' ],
+        description: 'Executes a simple action directly.',
+        onResultSelect: function ( item ) {
+            mw.notify( 'Simple command executed!' );
+            return { action: 'none' };
+        }
+    } ) );
 } );
 ```
 
@@ -272,61 +286,59 @@ A mode accepts a sub-query and returns dynamic results. Triggers **must** end wi
 ::: details Toggle code
 
 ```js
-const myMode = {
-    id: 'my-mode',
-    triggers: [ '/mymode:', '/mm:' ],
-    description: 'Shows results based on your input.',
-    placeholder: 'Search my items',
-    // icon: cdxIconMyIcon, // Optional Codex icon
-
-    // Shown when the mode is active but no query has been typed
-    emptyState: {
-        title: 'My custom mode',
-        description: 'Type something to search your items.'
-        // icon: cdxIconMyIcon // Optional Codex icon
-    },
-
-    // Shown when a query returns no results
-    noResults: function ( query ) {
-        return {
-            title: 'No items found',
-            description: 'Try a different search term.'
-            // icon: cdxIconMyIcon // Optional Codex icon
-        };
-    },
-
-    getResults: function ( subQuery ) {
-        // Return a Promise resolving to an array of result items
-        return new Promise( function ( resolve ) {
-            setTimeout( resolve, 150 ); // Simulate network delay
-        } ).then( function () {
-            if ( !subQuery ) {
-                return [];
-            }
-
-            return [
-                {
-                    id: 'subquery-result-1',
-                    label: 'Result for "' + subQuery + '"',
-                    description: 'First result.',
-                    url: mw.util.getUrl( subQuery ),
-                    type: 'command-subquery',
-                    highlightQuery: true
-                }
-            ];
-        } );
-    },
-
-    onResultSelect: function ( item ) {
-        if ( item.url ) {
-            return { action: 'navigate', payload: item.url };
-        }
-        return { action: 'none' };
-    }
-};
-
 mw.hook( 'citizen.commandPalette.register' ).add( function ( data ) {
-    data.register( myMode );
+    data.register( data.defineMode( {
+        id: 'my-mode',
+        triggers: [ '/mymode:', '/mm:' ],
+        description: 'Shows results based on your input.',
+        placeholder: 'Search my items',
+        // icon: cdxIconMyIcon, // Optional Codex icon
+
+        // Shown when the mode is active but no query has been typed
+        emptyState: {
+            title: 'My custom mode',
+            description: 'Type something to search your items.'
+            // icon: cdxIconMyIcon // Optional Codex icon
+        },
+
+        // Shown when a query returns no results
+        noResults: function ( query ) {
+            return {
+                title: 'No items found',
+                description: 'Try a different search term.'
+                // icon: cdxIconMyIcon // Optional Codex icon
+            };
+        },
+
+        getResults: function ( subQuery ) {
+            // Return a Promise resolving to an array of result items
+            return new Promise( function ( resolve ) {
+                setTimeout( resolve, 150 ); // Simulate network delay
+            } ).then( function () {
+                if ( !subQuery ) {
+                    return [];
+                }
+
+                return [
+                    {
+                        id: 'subquery-result-1',
+                        label: 'Result for "' + subQuery + '"',
+                        description: 'First result.',
+                        url: mw.util.getUrl( subQuery ),
+                        type: 'command-subquery',
+                        highlightQuery: true
+                    }
+                ];
+            } );
+        },
+
+        onResultSelect: function ( item ) {
+            if ( item.url ) {
+                return { action: 'navigate', payload: item.url };
+            }
+            return { action: 'none' };
+        }
+    } ) );
 } );
 ```
 

--- a/resources/skins.citizen.commandPalette/init.js
+++ b/resources/skins.citizen.commandPalette/init.js
@@ -6,6 +6,7 @@ const config = require( './config.json' );
 const createRecentItems = require( './services/recentItems.js' );
 const createRestSearchClient = require( './services/searchClient.js' );
 const createPaletteRegistry = require( './services/paletteRegistry.js' );
+const { defineMode, defineCommand } = require( './services/defineMode.js' );
 
 // Provider factories
 const createSearchProvider = require( './providers/SearchProvider.js' );
@@ -54,7 +55,16 @@ function initApp( overlayEl, options ) {
 	paletteRegistry.register( createFileMode( mw.Api ) );
 	paletteRegistry.register( helpMode );
 
-	const hookData = { register: paletteRegistry.register };
+	// `defineMode` / `defineCommand` are exposed on the hook payload so
+	// extension authors get the same registration-time diagnostics that
+	// built-in modes do — typo warnings, layout/compactResults coercion,
+	// and hard-fails for missing-id/missing-getResults shapes. Using them
+	// stays optional; the registry still accepts plain object literals.
+	const hookData = {
+		register: paletteRegistry.register,
+		defineMode,
+		defineCommand
+	};
 	mw.hook( 'citizen.commandPalette.register' ).fire( hookData );
 
 	mw.hook( 'skins.citizen.commandPalette.registerCommand' ).fire( {

--- a/resources/skins.citizen.commandPalette/modes/action.js
+++ b/resources/skins.citizen.commandPalette/modes/action.js
@@ -1,6 +1,7 @@
 const { cdxIconSpecialPages, cdxIconPlay } = require( '../icons.json' );
 const config = require( '../config.json' );
 const { getNavigationAction } = require( '../utils/providerActions.js' );
+const { defineMode } = require( '../services/defineMode.js' );
 
 /**
  * Creates the action command handler.
@@ -129,7 +130,7 @@ function createActionCommand( documentRef, ApiConstructor ) {
 		return allItems.filter( ( item ) => itemMatchesQuery( item, lowerSubQuery ) );
 	}
 
-	return {
+	return defineMode( {
 		id: 'action',
 		triggers: [ '/action:', '>' ],
 		label: mw.message( 'citizen-command-palette-command-action-label' ).text(),
@@ -144,7 +145,7 @@ function createActionCommand( documentRef, ApiConstructor ) {
 		async onResultSelect( item ) {
 			return getNavigationAction( item );
 		}
-	};
+	} );
 }
 
 module.exports = createActionCommand;

--- a/resources/skins.citizen.commandPalette/modes/category.js
+++ b/resources/skins.citizen.commandPalette/modes/category.js
@@ -12,6 +12,7 @@
  */
 const { cdxIconTag, cdxIconArticle, cdxIconEdit } = require( '../icons.json' );
 const config = require( '../config.json' );
+const { defineMode } = require( '../services/defineMode.js' );
 
 const CATEGORY_NS_ID = 14;
 const CATEGORY_NS_NAME = 'Category';
@@ -220,7 +221,7 @@ function createCategoryMode( ApiConstructor ) {
 		return segments.join( ' / ' );
 	}
 
-	return {
+	return defineMode( {
 		id: 'category',
 		triggers: [ '/cat:', '#' ],
 		label: mw.message( 'citizen-command-palette-command-category-label' ).text(),
@@ -246,7 +247,7 @@ function createCategoryMode( ApiConstructor ) {
 		getResults,
 		onResultSelect,
 		headerLabel
-	};
+	} );
 }
 
 module.exports = createCategoryMode;

--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -25,6 +25,7 @@ const {
 	cdxIconPlay
 } = require( '../icons.json' );
 const config = require( '../config.json' );
+const { defineMode } = require( '../services/defineMode.js' );
 
 const FILE_NAMESPACE = 6;
 const RESULT_LIMIT = 50;
@@ -414,7 +415,7 @@ function createFileMode( ApiConstructor ) {
 		};
 	}
 
-	return {
+	return defineMode( {
 		id: 'file',
 		triggers: [ '/file:', '~' ],
 		label: mw.message( 'citizen-command-palette-command-file-label' ).text(),
@@ -439,7 +440,7 @@ function createFileMode( ApiConstructor ) {
 		},
 		getResults,
 		onResultSelect
-	};
+	} );
 }
 
 module.exports = createFileMode;

--- a/resources/skins.citizen.commandPalette/modes/help.js
+++ b/resources/skins.citizen.commandPalette/modes/help.js
@@ -1,3 +1,5 @@
+const { defineCommand } = require( '../services/defineMode.js' );
+
 /**
  * Help command for the command palette.
  *
@@ -8,7 +10,7 @@
  *
  * @type {import('../types.js').PaletteCommand}
  */
-module.exports = {
+module.exports = defineCommand( {
 	id: 'help',
 	triggers: [ '/help', '?' ],
 	label: mw.message( 'citizen-command-palette-command-help-label' ).text(),
@@ -16,4 +18,4 @@ module.exports = {
 	onResultSelect() {
 		return { action: 'toggleHelp' };
 	}
-};
+} );

--- a/resources/skins.citizen.commandPalette/modes/history.js
+++ b/resources/skins.citizen.commandPalette/modes/history.js
@@ -12,6 +12,7 @@
  */
 const { cdxIconHistory } = require( '../icons.json' );
 const config = require( '../config.json' );
+const { defineMode } = require( '../services/defineMode.js' );
 
 const REV_LIMIT = 50;
 
@@ -337,7 +338,7 @@ function createHistoryMode( ApiConstructor ) {
 		};
 	}
 
-	return {
+	return defineMode( {
 		id: 'history',
 		triggers: [ '/hist:', '!' ],
 		label: mw.message( 'citizen-command-palette-command-history-label' ).text(),
@@ -362,7 +363,7 @@ function createHistoryMode( ApiConstructor ) {
 		},
 		getResults,
 		onResultSelect
-	};
+	} );
 }
 
 module.exports = createHistoryMode;

--- a/resources/skins.citizen.commandPalette/modes/namespace.js
+++ b/resources/skins.citizen.commandPalette/modes/namespace.js
@@ -3,6 +3,7 @@
  */
 const { CommandPaletteItem, PaletteMode, CommandPaletteExitWithQueryAction, CommandPaletteNoneAction } = require( '../types.js' );
 const { cdxIconArticles } = require( '../icons.json' );
+const { defineMode } = require( '../services/defineMode.js' );
 
 const MAIN_NAMESPACE_ID = '0';
 
@@ -113,7 +114,7 @@ function matchNamespacePrefix( text ) {
 }
 
 /** @type {PaletteMode} */
-module.exports = {
+module.exports = defineMode( {
 	id: 'namespace',
 	triggers: [ '/ns:', ':' ],
 	label: mw.message( 'citizen-command-palette-command-ns-label' ).text(),
@@ -144,4 +145,4 @@ module.exports = {
 		}
 		return { action: 'none' };
 	}
-};
+} );

--- a/resources/skins.citizen.commandPalette/modes/user.js
+++ b/resources/skins.citizen.commandPalette/modes/user.js
@@ -1,6 +1,7 @@
 const { cdxIconEdit, cdxIconUserAvatar, cdxIconUserContributions, cdxIconUserTalk } = require( '../icons.json' );
 const config = require( '../config.json' );
 const { getNavigationAction } = require( '../utils/providerActions.js' );
+const { defineMode } = require( '../services/defineMode.js' );
 
 /**
  * Creates the user command handler.
@@ -101,7 +102,7 @@ function createUserCommand( ApiConstructor ) {
 		}
 	}
 
-	return {
+	return defineMode( {
 		id: 'user',
 		triggers: [ '/user:', '@' ],
 		label: mw.message( 'citizen-command-palette-command-user-label' ).text(),
@@ -128,7 +129,7 @@ function createUserCommand( ApiConstructor ) {
 		async onResultSelect( item ) {
 			return getNavigationAction( item );
 		}
-	};
+	} );
 }
 
 module.exports = createUserCommand;

--- a/resources/skins.citizen.commandPalette/services/defineMode.js
+++ b/resources/skins.citizen.commandPalette/services/defineMode.js
@@ -1,0 +1,245 @@
+/**
+ * Factories for declaring command-palette modes and commands with
+ * runtime validation, default-filling, and typo-warning. The mode
+ * contract is implicit — `paletteRegistry.register` accepts any
+ * object with an `id` — and these factories add a layer that
+ * surfaces shape mistakes loudly instead of letting them rot
+ * silently into "this mode quietly does nothing."
+ *
+ * Use `defineMode( config )` for entries that take a sub-query and
+ * return results; use `defineCommand( config )` for entries that
+ * fire an action immediately on selection. Both return the input
+ * with defaults filled, or `null` when validation fails hard. The
+ * registry already accepts `null` and warns, so a single bad
+ * third-party mode never crashes the whole palette.
+ */
+
+const VALID_LAYOUTS = [ 'list', 'gallery' ];
+
+// Fields any registry entry may carry. Anything outside this set
+// triggers an "unknown field" warning to catch typos. Mode- and
+// command-specific allowlists extend this base.
+const COMMON_FIELDS = [
+	'id',
+	'triggers',
+	'label',
+	'description',
+	'help',
+	'onResultSelect'
+];
+
+const MODE_FIELDS = COMMON_FIELDS.concat( [
+	'placeholder',
+	'icon',
+	'layout',
+	'compactResults',
+	'keybindings',
+	'emptyState',
+	'noResults',
+	'tokenPattern',
+	'getResults',
+	'headerLabel'
+] );
+
+const COMMAND_FIELDS = COMMON_FIELDS;
+
+/**
+ * Shared shape checks for a registry entry. Returns true when the
+ * entry has the universal required pieces (object, id, triggers).
+ * Hard-fails are logged to mw.log.error so build-time test runs
+ * surface them.
+ *
+ * @param {*} config
+ * @param {string} kind 'mode' or 'command' — used in log messages
+ * @return {boolean}
+ */
+function validateBase( config, kind ) {
+	if ( typeof config !== 'object' || config === null || Array.isArray( config ) ) {
+		mw.log.error( `[commandPalette] ${ kind } config must be a non-array object.` );
+		return false;
+	}
+
+	if ( typeof config.id !== 'string' || config.id.trim() === '' ) {
+		mw.log.error( `[commandPalette] ${ kind } config is missing a non-empty string \`id\`.` );
+		return false;
+	}
+
+	if ( !Array.isArray( config.triggers ) || config.triggers.length === 0 ) {
+		mw.log.error( `[commandPalette] ${ kind } "${ config.id }" must declare a non-empty \`triggers\` array.` );
+		return false;
+	}
+	if ( !config.triggers.every( ( t ) => typeof t === 'string' && t.trim() !== '' ) ) {
+		mw.log.error( `[commandPalette] ${ kind } "${ config.id }" \`triggers\` must contain only non-empty strings.` );
+		return false;
+	}
+
+	if ( config.onResultSelect !== undefined && typeof config.onResultSelect !== 'function' ) {
+		mw.log.error( `[commandPalette] ${ kind } "${ config.id }" \`onResultSelect\` must be a function when present.` );
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Warn for any top-level key not in `allowedFields`. Catches typos
+ * like `placholder` or `layoput` at registration time. Doesn't
+ * mutate the config — the unknown field is preserved so future
+ * Citizen versions reading new fields keep working when registered
+ * against an older defineMode build.
+ *
+ * @param {Object} config
+ * @param {string[]} allowedFields
+ * @param {string} kind 'mode' or 'command'
+ */
+function warnUnknownFields( config, allowedFields, kind ) {
+	const allowed = new Set( allowedFields );
+	Object.keys( config ).forEach( ( key ) => {
+		if ( !allowed.has( key ) ) {
+			mw.log.warn(
+				`[commandPalette] ${ kind } "${ config.id }" has unknown field \`${ key }\`. ` +
+				'Typo, or a field added in a newer Citizen version?'
+			);
+		}
+	} );
+}
+
+/**
+ * Validate optional fields and coerce / drop ones that are present
+ * but malformed. Returns a new object — the caller's config is
+ * never mutated.
+ *
+ * @param {Object} config
+ * @return {Object}
+ */
+function applyOptionalFieldChecks( config ) {
+	const out = Object.assign( {}, config );
+
+	if ( out.layout !== undefined && !VALID_LAYOUTS.includes( out.layout ) ) {
+		mw.log.warn(
+			`[commandPalette] mode "${ out.id }" has invalid \`layout\` ` +
+			`"${ out.layout }". Valid values: ${ VALID_LAYOUTS.join( ', ' ) }. Falling back to "list".`
+		);
+		out.layout = 'list';
+	}
+
+	if ( out.compactResults !== undefined && typeof out.compactResults !== 'boolean' ) {
+		mw.log.warn(
+			`[commandPalette] mode "${ out.id }" \`compactResults\` must be a boolean. Coercing.`
+		);
+		out.compactResults = Boolean( out.compactResults );
+	}
+
+	// compactResults is meaningless in gallery layout (gallery has no
+	// rows to compact). Drop it so downstream code can rely on the
+	// fields being mutually exclusive.
+	if ( out.compactResults && out.layout === 'gallery' ) {
+		mw.log.warn(
+			`[commandPalette] mode "${ out.id }" combines \`compactResults: true\` with ` +
+			'`layout: "gallery"`. Gallery has no rows to compact — ignoring `compactResults`.'
+		);
+		out.compactResults = false;
+	}
+
+	if ( out.keybindings !== undefined && !Array.isArray( out.keybindings ) ) {
+		mw.log.warn(
+			`[commandPalette] mode "${ out.id }" \`keybindings\` must be an array. Dropping the field.`
+		);
+		delete out.keybindings;
+	}
+
+	if (
+		out.tokenPattern !== undefined &&
+		( out.tokenPattern === null || typeof out.tokenPattern !== 'object' )
+	) {
+		// `typeof null === 'object'` in JS, so the null branch is explicit —
+		// otherwise `tokenPattern: null` would slip through without a warning
+		// and contradict the contract this rule enforces.
+		mw.log.warn(
+			`[commandPalette] mode "${ out.id }" \`tokenPattern\` must be an object or array. Dropping the field.`
+		);
+		delete out.tokenPattern;
+	}
+
+	return out;
+}
+
+/**
+ * Apply default values for fields that have one. Today this is just
+ * `layout: 'list'` and `compactResults: false`. Other optional
+ * fields stay absent so the rest of the palette can use truthiness
+ * checks without false positives.
+ *
+ * Argument order matters: defaults come first, caller config second,
+ * so any value the caller already set (including a coerced one from
+ * `applyOptionalFieldChecks`) wins over the default.
+ *
+ * @param {Object} config
+ * @return {Object}
+ */
+function applyDefaults( config ) {
+	return Object.assign( {
+		layout: 'list',
+		compactResults: false
+	}, config );
+}
+
+/**
+ * Validate and normalize a mode (sub-query-driven entry that produces
+ * results via `getResults`). Returns the normalized object, or `null`
+ * when validation fails hard.
+ *
+ * @param {Object} config
+ * @return {import('../types.js').PaletteMode|null}
+ */
+function defineMode( config ) {
+	if ( !validateBase( config, 'mode' ) ) {
+		return null;
+	}
+
+	if ( typeof config.getResults !== 'function' ) {
+		mw.log.error(
+			`[commandPalette] mode "${ config.id }" must declare a \`getResults\` function. ` +
+			'Use `defineCommand` for entries that fire an action immediately on selection.'
+		);
+		return null;
+	}
+
+	warnUnknownFields( config, MODE_FIELDS, 'mode' );
+
+	const checked = applyOptionalFieldChecks( config );
+	return applyDefaults( checked );
+}
+
+/**
+ * Validate and normalize a command (no sub-query; fires an action
+ * immediately on selection). Returns the normalized object, or
+ * `null` when validation fails hard.
+ *
+ * @param {Object} config
+ * @return {import('../types.js').PaletteCommand|null}
+ */
+function defineCommand( config ) {
+	if ( !validateBase( config, 'command' ) ) {
+		return null;
+	}
+
+	if ( config.onResultSelect === undefined ) {
+		mw.log.error(
+			`[commandPalette] command "${ config.id }" must declare an \`onResultSelect\` function. ` +
+			'Use `defineMode` for entries that take a sub-query and return results.'
+		);
+		return null;
+	}
+
+	warnUnknownFields( config, COMMAND_FIELDS, 'command' );
+
+	// Commands don't carry layout / compactResults / keybindings, so no
+	// defaults to fill. Return the validated config as-is.
+	return Object.assign( {}, config );
+}
+
+module.exports = {
+	defineMode,
+	defineCommand
+};

--- a/resources/skins.citizen.commandPalette/services/paletteRegistry.js
+++ b/resources/skins.citizen.commandPalette/services/paletteRegistry.js
@@ -33,7 +33,14 @@ function createPaletteRegistry() {
 	 * @return {boolean} True if registration was successful, false otherwise.
 	 */
 	function register( handler ) {
-		if ( typeof handler !== 'object' || handler === null ) {
+		if ( handler === null ) {
+			mw.log.warn(
+				'[paletteRegistry] Invalid handler provided for registration: null. ' +
+				'Likely a `defineMode` / `defineCommand` call that hard-failed validation — check earlier console errors.'
+			);
+			return false;
+		}
+		if ( typeof handler !== 'object' ) {
 			mw.log.warn( '[paletteRegistry] Invalid handler provided for registration: not an object.' );
 			return false;
 		}
@@ -45,6 +52,38 @@ function createPaletteRegistry() {
 
 		if ( handlers.has( handlerId ) ) {
 			mw.log.warn( `[paletteRegistry] Handler "${ handlerId }" is already registered. Overwriting.` );
+		}
+
+		// Defensive registration warnings — defineMode catches these at
+		// build time, but raw object-literal modes (or third-party modes
+		// that bypass defineMode) bottleneck through here. Cheap to check;
+		// silent failures are expensive to debug.
+		if ( !Array.isArray( handler.triggers ) || handler.triggers.length === 0 ) {
+			mw.log.warn(
+				`[paletteRegistry] Handler "${ handlerId }" has no triggers — it cannot be activated.`
+			);
+		} else {
+			handler.triggers.forEach( ( trigger ) => {
+				const conflict = flatTriggerList.find(
+					( t ) => t.lowerTrigger === trigger.toLowerCase() && t.id !== handlerId
+				);
+				if ( conflict ) {
+					mw.log.warn(
+						`[paletteRegistry] Handler "${ handlerId }" trigger "${ trigger }" ` +
+						`collides with existing handler "${ conflict.id }". Last registration wins.`
+					);
+				}
+			} );
+		}
+
+		if (
+			typeof handler.getResults !== 'function' &&
+			typeof handler.onResultSelect !== 'function'
+		) {
+			mw.log.warn(
+				`[paletteRegistry] Handler "${ handlerId }" has neither \`getResults\` nor \`onResultSelect\` — ` +
+				'selecting it can never produce a useful action.'
+			);
 		}
 
 		handlers.set( handlerId, handler );

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -38,10 +38,27 @@
  */
 
 /**
+ * Optional header rendered above the detail panel's pairs. When set, the
+ * panel renders a label + subtitle (and an inline copy-to-clipboard button
+ * when `copyValue` is provided). Consumers needing a fully custom header
+ * can still override the panel's `#header` slot — the inline default
+ * shape exists so modes don't have to.
+ *
+ * @typedef {Object} CommandPaletteItemDetailHeader
+ * @property {string} label Primary heading text (e.g. a filename).
+ * @property {string} [description] Subtle subtitle text (e.g. "PNG image").
+ * @property {string} [copyValue] When set, the panel renders a copy
+ *   button next to the label. Clicking it (or pressing Cmd/Ctrl+C with
+ *   the item highlighted and no text selected) copies this value to the
+ *   clipboard and shows a success-tinted check icon for ~1.5s.
+ */
+
+/**
  * Detail data shown in the side panel when an item is focused.
  *
  * @typedef {Object} CommandPaletteItemDetail
- * @property {Array<CommandPaletteDetailPair>} pairs Key-value pairs to display.
+ * @property {Array<CommandPaletteDetailPair>} [pairs] Key-value pairs to display.
+ * @property {CommandPaletteItemDetailHeader} [header] Optional header rendered above the pairs.
  */
 
 /**
@@ -98,6 +115,9 @@
  * @property {string} [description] Short explanation shown in the command list.
  * @property {string} [placeholder] Input placeholder when mode is active (e.g., "Search users").
  * @property {Object} [icon] Codex icon object for the header when mode is active.
+ * @property {'list'|'gallery'} [layout='list'] Result rendering layout. `'list'` (default) renders a vertical list. `'gallery'` renders a tiled grid for thumbnail-driven content and widens the palette to fit. Mutually exclusive with `compactResults`.
+ * @property {boolean} [compactResults=false] Render results in a denser layout — small icon instead of thumbnail, description inline. Use for command-style modes whose items lack real thumbnails. Ignored in gallery layout.
+ * @property {KeyBinding[]} [keybindings] Optional mode-contributed keyboard bindings. Prepended onto the core binding list at dispatch time, so mode bindings win on key collisions within their own zone.
  * @property {StateContent} [emptyState] Content shown when the mode is active with no query. Falls back to default search messaging.
  * @property {function(string, Array?): StateContent} [noResults] Returns content shown when query produces no results. Receives the query string and optional tokens array. Falls back to default no-results messaging.
  * @property {TokenPattern|TokenPattern[]} [tokenPattern] Optional token detection pattern(s) for auto-tokenization.
@@ -129,6 +149,32 @@
  * @property {string} [description] Short explanation shown in the command list.
  * @property {PaletteHelp} [help] Optional content surfaced by the help overlay.
  * @property {function(CommandPaletteItem): (CommandPaletteActionResult|Promise<CommandPaletteActionResult>)} [onResultSelect] Handles selection — executes the command action.
+ */
+
+/**
+ * A footer hint surfaced when its parent binding's `when` predicate
+ * passes. Bindings with `keys: []` are hint-only — the corresponding
+ * handler lives in a sibling binding entry.
+ *
+ * @typedef {Object} KeyBindingHint
+ * @property {string} msgKey i18n message key for the hint label.
+ * @property {string} kbd Keyboard glyph shown next to the label (e.g. '↵', '↑↓', '⌘C').
+ * @property {number} [order] Sort order within the footer (lower = leftmost).
+ */
+
+/**
+ * A single keyboard binding in the palette's binding registry. Both the
+ * dispatcher and the footer derive from this list, so a hint is visible
+ * iff its handler will fire — by construction.
+ *
+ * @typedef {Object} KeyBinding
+ * @property {string} id Unique binding identifier (used for debugging).
+ * @property {'input'|'action'} zone Which focus zone the binding applies to.
+ * @property {string[]} keys Event `key` values that fire `handle`. An empty array marks the binding as hint-only.
+ * @property {function(Object): boolean} when Predicate over the dispatch state — false suppresses both the handler and the hint.
+ * @property {function(Object, KeyboardEvent)} handle Called when a `keys` entry matches and `when` passes. Should call `event.preventDefault()` to claim the keystroke.
+ * @property {boolean} [worksDuringHelp] When true, the binding fires even with the help overlay open. Defaults to false.
+ * @property {KeyBindingHint|null} [hint] Footer hint to surface, or null to omit one.
  */
 
 /**

--- a/skin.json
+++ b/skin.json
@@ -351,6 +351,7 @@
 				"resources/skins.citizen.commandPalette/services/recentItems.js",
 				"resources/skins.citizen.commandPalette/services/searchClient.js",
 				"resources/skins.citizen.commandPalette/services/paletteRegistry.js",
+				"resources/skins.citizen.commandPalette/services/defineMode.js",
 				"resources/skins.citizen.commandPalette/providers/createProvider.js",
 				"resources/skins.citizen.commandPalette/providers/PaletteCommandProvider.js",
 				"resources/skins.citizen.commandPalette/providers/RecentItemsProvider.js",

--- a/tests/vitest/commandPalette/services/defineMode.test.js
+++ b/tests/vitest/commandPalette/services/defineMode.test.js
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+
+const mw = require( '../../mocks/mw.js' );
+globalThis.mw = mw;
+
+const { defineMode, defineCommand } = require(
+	'../../../../resources/skins.citizen.commandPalette/services/defineMode.js'
+);
+
+const VALID_MODE = {
+	id: 'test',
+	triggers: [ '/test:' ],
+	getResults: async () => []
+};
+
+const VALID_COMMAND = {
+	id: 'test-cmd',
+	triggers: [ '/cmd' ],
+	onResultSelect: () => ( { action: 'none' } )
+};
+
+describe( 'defineMode', () => {
+	beforeEach( () => {
+		mw.log.error.mockClear();
+		mw.log.warn.mockClear();
+	} );
+
+	describe( 'happy path', () => {
+		it( 'returns the config with defaults filled', () => {
+			const result = defineMode( VALID_MODE );
+
+			expect( result ).not.toBeNull();
+			expect( result.id ).toBe( 'test' );
+			expect( result.layout ).toBe( 'list' );
+			expect( result.compactResults ).toBe( false );
+		} );
+
+		it( 'preserves explicit layout and compactResults', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, {
+				layout: 'gallery'
+			} ) );
+
+			expect( result.layout ).toBe( 'gallery' );
+		} );
+
+		it( 'returns a new object — does not mutate the input', () => {
+			const input = Object.assign( {}, VALID_MODE );
+			const result = defineMode( input );
+
+			expect( result ).not.toBe( input );
+			expect( input.layout ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'hard fails', () => {
+		it( 'returns null and logs error when config is not an object', () => {
+			expect( defineMode( null ) ).toBeNull();
+			expect( defineMode( 'string' ) ).toBeNull();
+			expect( defineMode( [] ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'returns null when id is missing or empty', () => {
+			expect( defineMode( Object.assign( {}, VALID_MODE, { id: '' } ) ) ).toBeNull();
+			expect( defineMode( Object.assign( {}, VALID_MODE, { id: '   ' } ) ) ).toBeNull();
+			expect( defineMode( { triggers: [ '/x' ], getResults: () => [] } ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'returns null when id is not a string', () => {
+			expect( defineMode( Object.assign( {}, VALID_MODE, { id: 42 } ) ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalled();
+		} );
+
+		it( 'returns null when triggers is missing or empty', () => {
+			expect( defineMode( Object.assign( {}, VALID_MODE, { triggers: undefined } ) ) ).toBeNull();
+			expect( defineMode( Object.assign( {}, VALID_MODE, { triggers: [] } ) ) ).toBeNull();
+			expect( defineMode( Object.assign( {}, VALID_MODE, { triggers: 'not-an-array' } ) ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'returns null when triggers contains non-strings', () => {
+			expect( defineMode( Object.assign( {}, VALID_MODE, { triggers: [ '/x', 42 ] } ) ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalled();
+		} );
+
+		it( 'returns null when triggers contains empty or whitespace-only strings', () => {
+			expect( defineMode( Object.assign( {}, VALID_MODE, { triggers: [ '/x', '' ] } ) ) ).toBeNull();
+			expect( defineMode( Object.assign( {}, VALID_MODE, { triggers: [ '/x', '   ' ] } ) ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'returns null when getResults is missing or not a function', () => {
+			expect( defineMode( Object.assign( {}, VALID_MODE, { getResults: undefined } ) ) ).toBeNull();
+			expect( defineMode( Object.assign( {}, VALID_MODE, { getResults: 'string' } ) ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'returns null when onResultSelect is present but not a function', () => {
+			expect( defineMode( Object.assign( {}, VALID_MODE, { onResultSelect: 'not-a-fn' } ) ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'soft warnings + coercion', () => {
+		it( 'warns and falls back to "list" on invalid layout', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, { layout: 'pyramid' } ) );
+
+			expect( result.layout ).toBe( 'list' );
+			expect( mw.log.warn ).toHaveBeenCalled();
+		} );
+
+		it( 'warns and coerces non-boolean compactResults', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, { compactResults: 'yes' } ) );
+
+			expect( result.compactResults ).toBe( true );
+			expect( mw.log.warn ).toHaveBeenCalled();
+		} );
+
+		it( 'warns and drops compactResults when combined with gallery layout', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, {
+				layout: 'gallery',
+				compactResults: true
+			} ) );
+
+			expect( result.layout ).toBe( 'gallery' );
+			expect( result.compactResults ).toBe( false );
+			expect( mw.log.warn ).toHaveBeenCalled();
+		} );
+
+		it( 'coerces compactResults THEN drops it when combined with gallery layout', () => {
+			// Two-step path: coerce 'yes' → true (warn), then notice the
+			// gallery pairing and drop it back to false (warn). Both warnings
+			// should fire and the final value should be false.
+			const result = defineMode( Object.assign( {}, VALID_MODE, {
+				layout: 'gallery',
+				compactResults: 'yes'
+			} ) );
+
+			expect( result.layout ).toBe( 'gallery' );
+			expect( result.compactResults ).toBe( false );
+			expect( mw.log.warn ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'warns and drops keybindings when not an array', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, { keybindings: 'oops' } ) );
+
+			expect( result.keybindings ).toBeUndefined();
+			expect( mw.log.warn ).toHaveBeenCalled();
+		} );
+
+		it( 'preserves valid keybindings as-is', () => {
+			const bindings = [ { id: 'a', zone: 'input', keys: [ 'a' ], when: () => true, handle: () => {}, hint: null } ];
+			const result = defineMode( Object.assign( {}, VALID_MODE, { keybindings: bindings } ) );
+
+			expect( result.keybindings ).toBe( bindings );
+		} );
+
+		it( 'warns and drops tokenPattern when not an object/array', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, { tokenPattern: 'oops' } ) );
+
+			expect( result.tokenPattern ).toBeUndefined();
+			expect( mw.log.warn ).toHaveBeenCalled();
+		} );
+
+		it( 'warns and drops tokenPattern when null (typeof null === "object" trap)', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, { tokenPattern: null } ) );
+
+			expect( result.tokenPattern ).toBeUndefined();
+			expect( mw.log.warn ).toHaveBeenCalled();
+		} );
+
+		it( 'warns on unknown top-level fields but keeps them', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, {
+				placholder: 'typo'
+			} ) );
+
+			expect( result ).not.toBeNull();
+			expect( result.placholder ).toBe( 'typo' );
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'placholder' )
+			);
+		} );
+
+		it( 'does not warn for known optional fields', () => {
+			defineMode( Object.assign( {}, VALID_MODE, {
+				placeholder: 'Search',
+				icon: { path: '...' },
+				emptyState: { title: 't', description: 'd', icon: {} },
+				noResults: () => ( { title: 't', description: 'd', icon: {} } ),
+				help: { description: 'foo' },
+				headerLabel: () => 'breadcrumb'
+			} ) );
+
+			expect( mw.log.warn ).not.toHaveBeenCalled();
+		} );
+	} );
+} );
+
+describe( 'defineCommand', () => {
+	beforeEach( () => {
+		mw.log.error.mockClear();
+		mw.log.warn.mockClear();
+	} );
+
+	describe( 'happy path', () => {
+		it( 'returns the config preserved (no defaults filled)', () => {
+			const result = defineCommand( VALID_COMMAND );
+
+			expect( result ).not.toBeNull();
+			expect( result.id ).toBe( 'test-cmd' );
+			// Commands don't carry layout/compactResults — those would be
+			// nonsense for an action-on-selection entry.
+			expect( result.layout ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'hard fails', () => {
+		it( 'returns null when onResultSelect is missing', () => {
+			const config = Object.assign( {}, VALID_COMMAND );
+			delete config.onResultSelect;
+
+			expect( defineCommand( config ) ).toBeNull();
+			expect( mw.log.error ).toHaveBeenCalled();
+		} );
+
+		it( 'reuses base validation (id, triggers)', () => {
+			expect( defineCommand( null ) ).toBeNull();
+			expect( defineCommand( { triggers: [ '/x' ], onResultSelect: () => {} } ) ).toBeNull();
+			expect( defineCommand( Object.assign( {}, VALID_COMMAND, { triggers: [] } ) ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'unknown field warnings', () => {
+		it( 'warns on mode-only fields appearing on a command (typo guard)', () => {
+			defineCommand( Object.assign( {}, VALID_COMMAND, {
+				layout: 'gallery',
+				getResults: () => []
+			} ) );
+
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'layout' )
+			);
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'getResults' )
+			);
+		} );
+
+		it( 'does not warn for the standard command fields', () => {
+			defineCommand( Object.assign( {}, VALID_COMMAND, {
+				label: 'Test',
+				description: 'A test',
+				help: { description: 'foo' }
+			} ) );
+
+			expect( mw.log.warn ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/tests/vitest/commandPalette/services/paletteRegistry.test.js
+++ b/tests/vitest/commandPalette/services/paletteRegistry.test.js
@@ -46,10 +46,26 @@ describe( 'createPaletteRegistry', () => {
 			expect( result ).toBe( false );
 		} );
 
-		it( 'rejects null handler', () => {
+		it( 'rejects null handler with a null-specific warning', () => {
+			mw.log.warn.mockClear();
+
 			const result = registry.register( null );
 
 			expect( result ).toBe( false );
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'null' )
+			);
+		} );
+
+		it( 'rejects non-object handler with a not-an-object warning', () => {
+			mw.log.warn.mockClear();
+
+			const result = registry.register( 'oops' );
+
+			expect( result ).toBe( false );
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'not an object' )
+			);
 		} );
 
 		it( 'overwrites existing command with same id', () => {
@@ -60,6 +76,73 @@ describe( 'createPaletteRegistry', () => {
 			registry.register( replacement );
 
 			expect( registry.getHandler( 'test' ).description ).toBe( 'Replacement' );
+		} );
+
+		it( 'warns when triggers is missing or empty', () => {
+			mw.log.warn.mockClear();
+
+			registry.register( makeHandler( { id: 'no-trig', triggers: [] } ) );
+
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'no triggers' )
+			);
+		} );
+
+		it( 'warns when a trigger collides with an already-registered one', () => {
+			registry.register( makeHandler( { id: 'first', triggers: [ '/x:' ] } ) );
+			mw.log.warn.mockClear();
+
+			registry.register( makeHandler( { id: 'second', triggers: [ '/x:' ] } ) );
+
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'collides' )
+			);
+		} );
+
+		it( 'does not warn about self-collision when overwriting same id', () => {
+			registry.register( makeHandler( { id: 'same', triggers: [ '/x:' ] } ) );
+			mw.log.warn.mockClear();
+
+			registry.register( makeHandler( { id: 'same', triggers: [ '/x:' ] } ) );
+
+			// "already registered. Overwriting" warning is fine; the
+			// trigger-collision warning would be wrong (it's the same handler).
+			const collisionWarnings = mw.log.warn.mock.calls.filter(
+				( c ) => /collides/.test( c[ 0 ] )
+			);
+			expect( collisionWarnings ).toHaveLength( 0 );
+		} );
+
+		it( 'warns when a handler has neither getResults nor onResultSelect', () => {
+			mw.log.warn.mockClear();
+
+			registry.register( makeHandler( { id: 'no-op' } ) );
+
+			expect( mw.log.warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'never produce a useful action' )
+			);
+		} );
+
+		it( 'does not warn no-op when getResults is provided', () => {
+			mw.log.warn.mockClear();
+
+			registry.register( makeHandler( { id: 'mode', getResults: () => [] } ) );
+
+			const noOpWarnings = mw.log.warn.mock.calls.filter(
+				( c ) => /never produce a useful action/.test( c[ 0 ] )
+			);
+			expect( noOpWarnings ).toHaveLength( 0 );
+		} );
+
+		it( 'does not warn no-op when onResultSelect is provided', () => {
+			mw.log.warn.mockClear();
+
+			registry.register( makeHandler( { id: 'cmd', onResultSelect: () => ( { action: 'none' } ) } ) );
+
+			const noOpWarnings = mw.log.warn.mock.calls.filter(
+				( c ) => /never produce a useful action/.test( c[ 0 ] )
+			);
+			expect( noOpWarnings ).toHaveLength( 0 );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary

- Adds `defineMode` / `defineCommand` factories that validate registry entries at registration time, fill in defaults, and warn loudly on shape mistakes — no TypeScript and no compile step.
- Hardens `paletteRegistry.register` with three defensive warnings (empty triggers, trigger collision with self-collision exclusion, no-op handlers) as a safety net for raw object literals that bypass the validators.
- Migrates all 7 built-in modes (file, history, category, user, action, namespace, help) through the new factories, and exposes both factories on the `citizen.commandPalette.register` hook payload so extension authors get the same diagnostics.

## Why

Before this branch, the palette accepted any object with an `id` and `triggers` — typos in field names rotted silently into "this mode quietly does nothing", and shape mistakes (missing `getResults`, empty `triggers`, malformed `keybindings`) only surfaced through user-visible breakage downstream. The contract makes failures loud at load time without breaking the rest of the palette when one entry is bad.

## Validator behaviour

| Severity | Cases |
| :--- | :--- |
| Hard fail (returns `null`, `mw.log.error`) | non-object config, missing/empty/non-string `id`, empty/non-string `triggers`, missing `getResults` (defineMode), missing `onResultSelect` (defineCommand) |
| Soft warn (coerce or drop) | invalid `layout` falls back to `'list'`; non-boolean `compactResults` coerced; `compactResults: true` + `layout: 'gallery'` drops `compactResults`; non-array `keybindings` dropped; non-object/null `tokenPattern` dropped; unknown top-level fields kept-with-warning |
| Defaults | `layout: 'list'`, `compactResults: false` (modes only) |

`register()` accepts `null` safely — logs a contextual warning and skips registration — so `data.register( data.defineMode( ... ) )` works without a null guard.

## Backward compatibility

No breaking changes. The registry still accepts plain object literals, with B3 register-time warnings as a lighter safety net for entries that don't go through the factories. Existing extensions keep working.

## Tests

29 new tests:
- 23 covering `defineMode` / `defineCommand` happy paths, hard fails, and soft-warn coercion (including the `compactResults` + gallery cross-field rule and the `typeof null === 'object'` trap on `tokenPattern`).
- 6 covering the new register-time warnings (empty triggers, trigger collision with self-collision exclusion, no-op handler, null vs non-object handler).

Total: 795/795 passing.

## Smoke test

A smoke test was persisted to `MediaWiki:Citizen.js` on the local dev wiki, registering a representative entry per validator behaviour. The browser console showed the expected message for each path:
- 4 soft warnings (typo field, invalid layout, compactResults+gallery, tokenPattern null)
- 2 hard-fail errors paired with 2 null-specific registry warnings
- 1 trigger-collision warning, 1 no-op-handler warning
- All happy-path entries appeared in the palette and worked as expected.

## Test plan

- [x] `npm run preflight` — 795/795 tests, 0 lint errors
- [x] Smoke test against local wiki via `MediaWiki:Citizen.js` — all 10 expected console messages fire, palette continues to function despite bad entries
- [x] Built-in modes still work end-to-end (file mode gallery, category drill-down with breadcrumb, history compact list, namespace token chips, etc.)
- [x] Console verified for warnings under `?uselang=x-xss` was not run; this branch does not change i18n message rendering, so no XSS surface area changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation and normalization helpers for command palette extensions, providing runtime diagnostics and preventing misconfigured commands.
  * Enhanced registry with defensive validation and collision detection for command triggers.

* **Documentation**
  * Updated command palette extension documentation with clarified hook payload structure and modern API examples.

* **Tests**
  * Added comprehensive test coverage for validation helpers and registry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->