### PR TITLE
refactor(commandPalette): decompose App.vue into focused composables

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -105,6 +105,7 @@
 
 <script>
 const { defineComponent, ref, nextTick, computed, watch, inject, onBeforeUnmount } = require( 'vue' );
+const useActionNavigation = require( '../composables/useActionNavigation.js' );
 const useListNavigation = require( '../composables/useListNavigation.js' );
 const useGridNavigation = require( '../composables/useGridNavigation.js' );
 const useKeyboard = require( '../composables/useKeyboard.js' );
@@ -355,58 +356,11 @@ module.exports = exports = defineComponent( {
 			return items.every( ( it ) => it.type === firstType );
 		} );
 
-		// Action navigation adapter (managed at App level)
-		const actionFocusedIndex = ref( -1 );
-		const actionIsActive = computed( () => actionFocusedIndex.value >= 0 );
-
-		function getHighlightedItemComponent() {
-			return itemRefs.value.get( listNav.highlightedIndex.value );
-		}
-
-		const actionNav = {
-			isActive: actionIsActive,
-			focusedIndex: actionFocusedIndex,
-			focusFirst() {
-				const item = getHighlightedItemComponent();
-				if ( item && item.focusFirstButton ) {
-					item.focusFirstButton();
-					actionFocusedIndex.value = 0;
-				}
-			},
-			focusNext() {
-				const highlightedIdx = listNav.highlightedIndex.value;
-				const items = orch.flatItems.value;
-				const actions = ( highlightedIdx >= 0 && items[ highlightedIdx ] ) ?
-					items[ highlightedIdx ].actions || [] : [];
-				if ( actionFocusedIndex.value < actions.length - 1 ) {
-					actionFocusedIndex.value++;
-					const item = getHighlightedItemComponent();
-					if ( item && item.focusButtonAtIndex ) {
-						item.focusButtonAtIndex( actionFocusedIndex.value );
-					}
-				}
-			},
-			focusPrevious() {
-				if ( actionFocusedIndex.value <= 0 ) {
-					actionFocusedIndex.value = -1;
-				} else {
-					actionFocusedIndex.value--;
-					const item = getHighlightedItemComponent();
-					if ( item && item.focusButtonAtIndex ) {
-						item.focusButtonAtIndex( actionFocusedIndex.value );
-					}
-				}
-			},
-			deactivate() {
-				actionFocusedIndex.value = -1;
-			},
-			clickFocused() {
-				const item = getHighlightedItemComponent();
-				if ( item && item.clickButtonAtIndex ) {
-					item.clickButtonAtIndex( actionFocusedIndex.value );
-				}
-			}
-		};
+		const actionNav = useActionNavigation( {
+			items: orch.flatItems,
+			highlightedIndex: listNav.highlightedIndex,
+			itemRefs
+		} );
 
 		const close = () => {
 			if ( !isOpen.value ) {

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -112,6 +112,7 @@ const useListNavigation = require( '../composables/useListNavigation.js' );
 const useGridNavigation = require( '../composables/useGridNavigation.js' );
 const useKeyboard = require( '../composables/useKeyboard.js' );
 const useProviderOrchestration = require( '../composables/useProviderOrchestration.js' );
+const useResultRouter = require( '../composables/useResultRouter.js' );
 const useTokenizedInput = require( '../composables/useTokenizedInput.js' );
 const CommandPaletteList = require( './CommandPaletteList.vue' );
 const CommandPaletteGallery = require( './CommandPaletteGallery.vue' );
@@ -309,112 +310,13 @@ module.exports = exports = defineComponent( {
 			searchHeader.value?.focus();
 		};
 
-		/**
-		 * Handles the selection of a result item.
-		 *
-		 * @param {Object} result The selected item
-		 */
-		const selectResult = async ( result ) => {
-			const wasHelpVisible = orch.helpVisible.value;
-			const selectionAction = await orch.handleSelection( result );
-
-			switch ( selectionAction.action ) {
-				case 'navigate':
-					if ( selectionAction.payload ) {
-						// Previewable result with an in-place preview handler
-						// available: keep the palette open so the user can
-						// dismiss the preview and pick another row. Plain
-						// mouse clicks are already intercepted by the
-						// handler; keyboard activation synthesizes a click
-						// on the highlighted row's anchor so the handler
-						// can take over. Modifier or non-primary clicks
-						// (Ctrl, Cmd, Alt, Shift, middle) fall through to
-						// the existing navigate+close path so users keep
-						// their browser-level escape hatches.
-						if (
-							result.previewable &&
-							instantDiffs.isAvailable() &&
-							!result.modifierClick
-						) {
-							if ( !result.isMouseClick && paletteRoot.value ) {
-								const anchor = paletteRoot.value.querySelector(
-									'.citizen-command-palette-list-item--highlighted a'
-								);
-								if ( anchor ) {
-									instantDiffs.triggerForAnchor( anchor );
-								}
-							}
-							break;
-						}
-
-						// <a> tags are handled by the browser on mouse click, so we don't need to navigate.
-						if ( !result.isMouseClick ) {
-							window.location.href = selectionAction.payload;
-						}
-						close();
-					}
-					break;
-				case 'exitWithQuery':
-					if ( orch.activeMode.value ) {
-						// From within a mode: exit and add token
-						orch.exitMode();
-						tokenInput.setFreeText( selectionAction.payload );
-					} else {
-						// From root: try to enter a matching mode
-						const match = findModeByQuery( selectionAction.payload );
-						if ( match ) {
-							tokenInput.clear();
-							// Closing help before entering the mode keeps openHelp's
-							// catalog from being preserved across the enterMode reset.
-							if ( wasHelpVisible ) {
-								orch.closeHelp();
-							}
-							orch.enterMode( match.mode );
-						}
-					}
-					nextTick( focusInput );
-					break;
-				case 'updateQuery':
-					tokenInput.setFreeText( selectionAction.payload );
-					nextTick( focusInput );
-					break;
-				case 'addToken':
-					tokenInput.addToken( selectionAction.payload );
-					tokenInput.setFreeText( '' );
-					// Force re-query: adding a token while clearing freeText
-					// produces the same fullQuery string, so the watcher won't fire.
-					// TODO: A generation counter on useTokenizedInput could replace
-					// this workaround by making the watcher always see a new value.
-					orch.updateQuery( tokenInput.fullQuery.value );
-					nextTick( focusInput );
-					break;
-				case 'pushModeContext':
-					orch.pushModeContext( selectionAction.payload );
-					tokenInput.clear();
-					nextTick( focusInput );
-					break;
-				case 'toggleHelp':
-					orch.toggleHelp();
-					tokenInput.clear();
-					nextTick( focusInput );
-					break;
-				case 'none':
-				default:
-					break;
-			}
-
-			// Auto-dismiss help after any non-toggle selection from inside the
-			// help overlay. Skipped for 'navigate' (the palette closes) and
-			// 'exitWithQuery' (which already closed help before entering mode).
-			if (
-				wasHelpVisible &&
-				selectionAction.action !== 'toggleHelp' &&
-				selectionAction.action !== 'navigate' &&
-				selectionAction.action !== 'exitWithQuery'
-			) {
-				orch.closeHelp();
-			}
-		};
+		const { selectResult, handleAction } = useResultRouter( {
+			orchestrator: orch,
+			tokenInput,
+			navigation: { findModeByQuery },
+			control: { focusInput, close, paletteRoot },
+			preview: instantDiffs
+		} );
 
 		const handleRemoveToken = ( index ) => {
 			const token = tokenInput.tokens.value[ index ];
@@ -485,35 +387,6 @@ module.exports = exports = defineComponent( {
 		const handleHover = ( newIndex ) => {
 			if ( newIndex !== listNav.highlightedIndex.value ) {
 				listNav.highlightedIndex.value = newIndex;
-			}
-		};
-
-		/**
-		 * Handles custom actions triggered by buttons within list items.
-		 *
-		 * @param {Object} action The action event payload.
-		 */
-		const handleAction = ( action ) => {
-			switch ( action.type ) {
-				case 'dismiss':
-					if ( action.itemId !== undefined ) {
-						orch.dismissRecentItem( action.itemId );
-					} else {
-						mw.log.warn( '[CommandPalette] Dismiss action missing itemId:', action );
-					}
-					break;
-				case 'navigate':
-					if ( action.url ) {
-						window.location.href = action.url;
-						close();
-					} else {
-						mw.log.warn( '[CommandPalette] Navigate action missing url:', action );
-					}
-					break;
-				case 'event':
-					break;
-				default:
-					mw.log.warn( '[CommandPalette] Unknown or missing action type received:', action );
 			}
 		};
 

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -104,9 +104,10 @@
 </template>
 
 <script>
-const { defineComponent, ref, nextTick, computed, watch, inject, onBeforeUnmount } = require( 'vue' );
+const { defineComponent, ref, nextTick, computed, watch, inject } = require( 'vue' );
 const useActionNavigation = require( '../composables/useActionNavigation.js' );
 const useBodyHeightAnimation = require( '../composables/useBodyHeightAnimation.js' );
+const useGalleryColumnCount = require( '../composables/useGalleryColumnCount.js' );
 const useListNavigation = require( '../composables/useListNavigation.js' );
 const useGridNavigation = require( '../composables/useGridNavigation.js' );
 const useKeyboard = require( '../composables/useKeyboard.js' );
@@ -162,40 +163,13 @@ module.exports = exports = defineComponent( {
 		const bodyContainer = ref( null );
 		const bodyViewport = ref( null );
 		const galleryRef = ref( null );
-		// Column count drives 2D grid navigation. Updated via ResizeObserver
-		// when the gallery is mounted. Defaults to 1 (list-equivalent) so
-		// the grid composable behaves correctly even before measurement.
-		const galleryColumnCount = ref( 1 );
-		let galleryResizeObserver = null;
-		// Mirror of the gallery template ref's `repeat( auto-fill, minmax( 140px, 1fr ) )`.
-		// Keep this in sync with the value in CommandPaletteGallery.vue's stylesheet.
-		const GALLERY_MIN_TILE_WIDTH = 140;
 
 		const { setupResizeObserver, teardownResizeObserver } = useBodyHeightAnimation( {
 			bodyContainer,
 			bodyViewport
 		} );
 
-		const updateGalleryColumnCount = ( element ) => {
-			if ( !element ) {
-				return;
-			}
-			const width = element.clientWidth;
-			galleryColumnCount.value = Math.max(
-				1, Math.floor( width / GALLERY_MIN_TILE_WIDTH )
-			);
-		};
-
-		const teardownGalleryResizeObserver = () => {
-			if ( galleryResizeObserver ) {
-				galleryResizeObserver.disconnect();
-				galleryResizeObserver = null;
-			}
-		};
-
-		onBeforeUnmount( () => {
-			teardownGalleryResizeObserver();
-		} );
+		const galleryColumnCount = useGalleryColumnCount( { galleryRef } );
 
 		// Provider orchestration (replaces Pinia searchStore)
 		const orchDeps = {
@@ -247,23 +221,6 @@ module.exports = exports = defineComponent( {
 		// String form for the [data-palette-layout] attribute, which CSS
 		// targets to widen the modal in gallery layouts.
 		const paletteLayout = computed( () => isGalleryLayout.value ? 'gallery' : 'list' );
-
-		// Attach a ResizeObserver to the gallery container only while it is
-		// mounted. Vue sets `galleryRef` to the component proxy when the
-		// gallery enters the DOM and back to `null` when it leaves.
-		watch( galleryRef, ( newInstance, oldInstance ) => {
-			if ( oldInstance ) {
-				teardownGalleryResizeObserver();
-			}
-			if ( newInstance && newInstance.$el ) {
-				const element = newInstance.$el;
-				updateGalleryColumnCount( element );
-				galleryResizeObserver = new ResizeObserver(
-					() => updateGalleryColumnCount( element )
-				);
-				galleryResizeObserver.observe( element );
-			}
-		} );
 
 		const highlightedItemDetail = computed( () => {
 			const index = listNav.highlightedIndex.value;

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -106,6 +106,7 @@
 <script>
 const { defineComponent, ref, nextTick, computed, watch, inject, onBeforeUnmount } = require( 'vue' );
 const useActionNavigation = require( '../composables/useActionNavigation.js' );
+const useBodyHeightAnimation = require( '../composables/useBodyHeightAnimation.js' );
 const useListNavigation = require( '../composables/useListNavigation.js' );
 const useGridNavigation = require( '../composables/useGridNavigation.js' );
 const useKeyboard = require( '../composables/useKeyboard.js' );
@@ -165,39 +166,15 @@ module.exports = exports = defineComponent( {
 		// when the gallery is mounted. Defaults to 1 (list-equivalent) so
 		// the grid composable behaves correctly even before measurement.
 		const galleryColumnCount = ref( 1 );
-		let resizeObserver = null;
 		let galleryResizeObserver = null;
 		// Mirror of the gallery template ref's `repeat( auto-fill, minmax( 140px, 1fr ) )`.
 		// Keep this in sync with the value in CommandPaletteGallery.vue's stylesheet.
 		const GALLERY_MIN_TILE_WIDTH = 140;
 
-		/**
-		 * Sync the body container's height CSS variable to the viewport's
-		 * rendered height. The CSS transition on the body handles animation.
-		 */
-		const updateBodyHeight = () => {
-			const container = bodyContainer.value;
-			const viewport = bodyViewport.value;
-			if ( container && viewport ) {
-				container.style.height = viewport.clientHeight + 'px';
-			}
-		};
-
-		const setupResizeObserver = () => {
-			if ( !bodyViewport.value ) {
-				return;
-			}
-			updateBodyHeight();
-			resizeObserver = new ResizeObserver( updateBodyHeight );
-			resizeObserver.observe( bodyViewport.value );
-		};
-
-		const teardownResizeObserver = () => {
-			if ( resizeObserver ) {
-				resizeObserver.disconnect();
-				resizeObserver = null;
-			}
-		};
+		const { setupResizeObserver, teardownResizeObserver } = useBodyHeightAnimation( {
+			bodyContainer,
+			bodyViewport
+		} );
 
 		const updateGalleryColumnCount = ( element ) => {
 			if ( !element ) {
@@ -217,7 +194,6 @@ module.exports = exports = defineComponent( {
 		};
 
 		onBeforeUnmount( () => {
-			teardownResizeObserver();
 			teardownGalleryResizeObserver();
 		} );
 

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -121,7 +121,6 @@ const CommandPaletteFooter = require( './CommandPaletteFooter.vue' );
 const CommandPaletteHeader = require( './CommandPaletteHeader.vue' );
 const CommandPaletteDetailPanel = require( './CommandPaletteDetailPanel.vue' );
 const CommandPaletteHelpView = require( './CommandPaletteHelpView.vue' );
-const instantDiffs = require( '../services/instantDiffs.js' );
 const { cdxIconArticleNotFound, cdxIconArticlesSearch } = require( '../icons.json' );
 
 // @vue/component
@@ -152,6 +151,9 @@ module.exports = exports = defineComponent( {
 		const getTokenPatterns = inject( 'getTokenPatterns' );
 		const getHelpCatalogItems = inject( 'getHelpCatalogItems', null );
 		const getHandler = inject( 'getHandler', null );
+		// Duck-typed { isAvailable, processContext, triggerForAnchor, onReady }
+		// service — today the InstantDiffs gadget bridge, swappable via init.js.
+		const previewService = inject( 'previewService' );
 		// Provided by commandPalette.js so the trigger orchestrator can hide
 		// its overlay wrapper after the palette closes from inside (Esc, backdrop).
 		const paletteExternalClose = inject( 'paletteExternalClose', null );
@@ -315,7 +317,7 @@ module.exports = exports = defineComponent( {
 			tokenInput,
 			navigation: { findModeByQuery },
 			control: { focusInput, close, paletteRoot },
-			preview: instantDiffs
+			preview: previewService
 		} );
 
 		const handleRemoveToken = ( index ) => {
@@ -436,16 +438,16 @@ module.exports = exports = defineComponent( {
 			// its click listeners. The watcher's `flush: 'post'` already
 			// runs us after DOM updates from the items mutation.
 			if ( paletteRoot.value ) {
-				instantDiffs.processContext( paletteRoot.value );
+				previewService.processContext( paletteRoot.value );
 			}
 		}, { flush: 'post' } );
 
 		// Late-load handler: if the preview handler initializes after the
 		// palette is already open, re-process whatever is currently
 		// rendered so the existing anchors get wired up.
-		instantDiffs.onReady( () => {
+		previewService.onReady( () => {
 			if ( paletteRoot.value ) {
-				instantDiffs.processContext( paletteRoot.value );
+				previewService.processContext( paletteRoot.value );
 			}
 		} );
 

--- a/resources/skins.citizen.commandPalette/composables/useActionNavigation.js
+++ b/resources/skins.citizen.commandPalette/composables/useActionNavigation.js
@@ -1,0 +1,81 @@
+const { ref, computed } = require( 'vue' );
+
+/**
+ * Composable for managing focus across the action buttons of the
+ * currently highlighted result row. Exposes the same surface the
+ * keyboard composable expects (`isActive`, `focusedIndex`, plus the
+ * five focus/click helpers) and delegates to the row component's
+ * `focusFirstButton`, `focusButtonAtIndex`, and `clickButtonAtIndex`
+ * methods.
+ *
+ * @param {Object} options
+ * @param {import('vue').Ref<Array<{actions?: Array}>>} options.items Reactive list of result items.
+ * @param {import('vue').Ref<number>} options.highlightedIndex Index of the highlighted row.
+ * @param {import('vue').Ref<Map<number, Object>>} options.itemRefs Map of row index → row component instance.
+ * @return {Object} Action-navigation API.
+ */
+function useActionNavigation( { items, highlightedIndex, itemRefs } ) {
+	const focusedIndex = ref( -1 );
+	const isActive = computed( () => focusedIndex.value >= 0 );
+
+	function getHighlightedComponent() {
+		return itemRefs.value.get( highlightedIndex.value );
+	}
+
+	function focusFirst() {
+		const item = getHighlightedComponent();
+		if ( item && item.focusFirstButton ) {
+			item.focusFirstButton();
+			focusedIndex.value = 0;
+		}
+	}
+
+	function focusNext() {
+		const idx = highlightedIndex.value;
+		const list = items.value;
+		const actions = ( idx >= 0 && list[ idx ] ) ?
+			list[ idx ].actions || [] : [];
+		if ( focusedIndex.value < actions.length - 1 ) {
+			focusedIndex.value++;
+			const item = getHighlightedComponent();
+			if ( item && item.focusButtonAtIndex ) {
+				item.focusButtonAtIndex( focusedIndex.value );
+			}
+		}
+	}
+
+	function focusPrevious() {
+		if ( focusedIndex.value <= 0 ) {
+			focusedIndex.value = -1;
+		} else {
+			focusedIndex.value--;
+			const item = getHighlightedComponent();
+			if ( item && item.focusButtonAtIndex ) {
+				item.focusButtonAtIndex( focusedIndex.value );
+			}
+		}
+	}
+
+	function deactivate() {
+		focusedIndex.value = -1;
+	}
+
+	function clickFocused() {
+		const item = getHighlightedComponent();
+		if ( item && item.clickButtonAtIndex ) {
+			item.clickButtonAtIndex( focusedIndex.value );
+		}
+	}
+
+	return {
+		isActive,
+		focusedIndex,
+		focusFirst,
+		focusNext,
+		focusPrevious,
+		deactivate,
+		clickFocused
+	};
+}
+
+module.exports = useActionNavigation;

--- a/resources/skins.citizen.commandPalette/composables/useBodyHeightAnimation.js
+++ b/resources/skins.citizen.commandPalette/composables/useBodyHeightAnimation.js
@@ -1,0 +1,53 @@
+const { onBeforeUnmount } = require( 'vue' );
+
+/**
+ * Composable for the palette body's animated-height transition.
+ *
+ * Owns a ResizeObserver that watches the inner viewport's rendered
+ * height and writes it as a CSS pixel value on the outer container's
+ * inline style. The container's CSS transition handles the animation.
+ *
+ * Setup is invoked from the palette's enter-transition `@after-enter`
+ * hook so the observer attaches once the modal has finished mounting;
+ * teardown runs from `@after-leave` to release the observer when the
+ * palette closes. As a safety net the composable also disconnects on
+ * component unmount, in case the leave-transition is interrupted.
+ *
+ * @param {Object} options
+ * @param {import('vue').Ref<HTMLElement|null>} options.bodyContainer Outer container ref.
+ * @param {import('vue').Ref<HTMLElement|null>} options.bodyViewport Inner viewport ref measured by the observer.
+ * @return {{ setupResizeObserver: () => void, teardownResizeObserver: () => void }}
+ */
+function useBodyHeightAnimation( { bodyContainer, bodyViewport } ) {
+	let observer = null;
+
+	function updateBodyHeight() {
+		const container = bodyContainer.value;
+		const viewport = bodyViewport.value;
+		if ( container && viewport ) {
+			container.style.height = viewport.clientHeight + 'px';
+		}
+	}
+
+	function setupResizeObserver() {
+		if ( !bodyViewport.value ) {
+			return;
+		}
+		updateBodyHeight();
+		observer = new ResizeObserver( updateBodyHeight );
+		observer.observe( bodyViewport.value );
+	}
+
+	function teardownResizeObserver() {
+		if ( observer ) {
+			observer.disconnect();
+			observer = null;
+		}
+	}
+
+	onBeforeUnmount( teardownResizeObserver );
+
+	return { setupResizeObserver, teardownResizeObserver };
+}
+
+module.exports = useBodyHeightAnimation;

--- a/resources/skins.citizen.commandPalette/composables/useGalleryColumnCount.js
+++ b/resources/skins.citizen.commandPalette/composables/useGalleryColumnCount.js
@@ -1,0 +1,55 @@
+const { ref, watch, onBeforeUnmount } = require( 'vue' );
+
+/**
+ * Composable that tracks the gallery's rendered column count for use
+ * by 2D grid navigation. Watches the gallery component's template ref
+ * and attaches a ResizeObserver to the underlying element while it is
+ * mounted, deriving the column count from the element's width and the
+ * configured minimum tile width.
+ *
+ * The composable returns a `Ref<number>` initialized at 1 so grid
+ * consumers can rely on a sensible default before the first
+ * measurement.
+ *
+ * @param {Object} options
+ * @param {import('vue').Ref<Object|null>} options.galleryRef Vue template ref for the gallery component instance.
+ * @param {number} [options.minTileWidth=140] Minimum tile width in CSS pixels. Must mirror the gallery stylesheet's `minmax( ..., 1fr )` floor.
+ * @return {import('vue').Ref<number>} Reactive column count, default 1.
+ */
+function useGalleryColumnCount( { galleryRef, minTileWidth = 140 } ) {
+	const columnCount = ref( 1 );
+	let observer = null;
+
+	function update( element ) {
+		if ( !element ) {
+			return;
+		}
+		const width = element.clientWidth;
+		columnCount.value = Math.max( 1, Math.floor( width / minTileWidth ) );
+	}
+
+	function disconnect() {
+		if ( observer ) {
+			observer.disconnect();
+			observer = null;
+		}
+	}
+
+	watch( galleryRef, ( newInstance, oldInstance ) => {
+		if ( oldInstance ) {
+			disconnect();
+		}
+		if ( newInstance && newInstance.$el ) {
+			const element = newInstance.$el;
+			update( element );
+			observer = new ResizeObserver( () => update( element ) );
+			observer.observe( element );
+		}
+	} );
+
+	onBeforeUnmount( disconnect );
+
+	return columnCount;
+}
+
+module.exports = useGalleryColumnCount;

--- a/resources/skins.citizen.commandPalette/composables/useResultRouter.js
+++ b/resources/skins.citizen.commandPalette/composables/useResultRouter.js
@@ -1,0 +1,194 @@
+const { nextTick } = require( 'vue' );
+
+/**
+ * Composable that owns the palette's result-action dispatch.
+ *
+ * Two functions are returned: `selectResult` for row activations, and
+ * `handleAction` for action-button events emitted by row components.
+ * Both are switch-based dispatchers; the action sets are intentionally
+ * closed (the palette's contract enumerates them).
+ *
+ * The composable does not own state — it reads from and mutates the
+ * passed-in orchestrator and tokenInput. The grouped-interface options
+ * bag keeps the caller's wiring explicit:
+ *  - `orchestrator` and `tokenInput` are passed through opaquely; the
+ *    composable consumes their public surfaces as documented in the
+ *    design (handleSelection, enterMode, addToken, setFreeText, etc.).
+ *  - `navigation` exposes cross-mode lookups (currently
+ *    `findModeByQuery`).
+ *  - `control` carries the DOM and lifecycle handles
+ *    (`focusInput`, `close`, `paletteRoot`).
+ *  - `preview` is the injected preview-handler service; the duck-typed
+ *    contract is `{ isAvailable, triggerForAnchor }`. Other consumers
+ *    of the service (palette-level processContext / onReady wiring)
+ *    live in App.vue.
+ *
+ * @param {Object} options
+ * @param {Object} options.orchestrator
+ * @param {Object} options.tokenInput
+ * @param {Object} options.navigation
+ * @param {Function} options.navigation.findModeByQuery
+ * @param {Object} options.control
+ * @param {Function} options.control.focusInput
+ * @param {Function} options.control.close
+ * @param {import('vue').Ref<HTMLElement|null>} options.control.paletteRoot
+ * @param {Object} options.preview
+ * @param {Function} options.preview.isAvailable
+ * @param {Function} options.preview.triggerForAnchor
+ * @return {{ selectResult: Function, handleAction: Function }}
+ */
+function useResultRouter( {
+	orchestrator,
+	tokenInput,
+	navigation,
+	control,
+	preview
+} ) {
+	const { findModeByQuery } = navigation;
+	const { focusInput, close, paletteRoot } = control;
+
+	/**
+	 * Dispatch a row activation. The orchestrator decides what action
+	 * the row produced (via `handleSelection`); this function carries
+	 * out the side effects.
+	 *
+	 * @param {Object} result The selected item.
+	 */
+	async function selectResult( result ) {
+		const wasHelpVisible = orchestrator.helpVisible.value;
+		const action = await orchestrator.handleSelection( result );
+
+		switch ( action.action ) {
+			case 'navigate':
+				if ( action.payload ) {
+					// Previewable result with a preview handler available:
+					// keep the palette open so the user can dismiss the
+					// preview and pick another row. Plain mouse clicks are
+					// intercepted by the handler; keyboard activation
+					// synthesizes a click on the highlighted row's anchor
+					// so the handler can take over. Modifier or non-primary
+					// clicks (Ctrl, Cmd, Alt, Shift, middle) fall through
+					// to the navigate+close path so users keep their
+					// browser-level escape hatches.
+					if (
+						result.previewable &&
+						preview.isAvailable() &&
+						!result.modifierClick
+					) {
+						if ( !result.isMouseClick && paletteRoot.value ) {
+							const anchor = paletteRoot.value.querySelector(
+								'.citizen-command-palette-list-item--highlighted a'
+							);
+							if ( anchor ) {
+								preview.triggerForAnchor( anchor );
+							}
+						}
+						break;
+					}
+
+					// <a> tags are handled by the browser on mouse click,
+					// so we don't need to navigate.
+					if ( !result.isMouseClick ) {
+						window.location.href = action.payload;
+					}
+					close();
+				}
+				break;
+			case 'exitWithQuery':
+				if ( orchestrator.activeMode.value ) {
+					// From within a mode: exit and seed the freeText.
+					orchestrator.exitMode();
+					tokenInput.setFreeText( action.payload );
+				} else {
+					// From root: try to enter a matching mode.
+					const match = findModeByQuery( action.payload );
+					if ( match ) {
+						tokenInput.clear();
+						// Closing help before entering the mode keeps openHelp's
+						// catalog from being preserved across the enterMode reset.
+						if ( wasHelpVisible ) {
+							orchestrator.closeHelp();
+						}
+						orchestrator.enterMode( match.mode );
+					}
+				}
+				nextTick( focusInput );
+				break;
+			case 'updateQuery':
+				tokenInput.setFreeText( action.payload );
+				nextTick( focusInput );
+				break;
+			case 'addToken':
+				tokenInput.addToken( action.payload );
+				tokenInput.setFreeText( '' );
+				// Force re-query: adding a token while clearing freeText
+				// produces the same fullQuery string, so the watcher won't
+				// fire. Push the value through explicitly.
+				// TODO: A generation counter on useTokenizedInput could
+				// replace this workaround by making the watcher always
+				// see a new value.
+				orchestrator.updateQuery( tokenInput.fullQuery.value );
+				nextTick( focusInput );
+				break;
+			case 'pushModeContext':
+				orchestrator.pushModeContext( action.payload );
+				tokenInput.clear();
+				nextTick( focusInput );
+				break;
+			case 'toggleHelp':
+				orchestrator.toggleHelp();
+				tokenInput.clear();
+				nextTick( focusInput );
+				break;
+			case 'none':
+			default:
+				break;
+		}
+
+		// Auto-dismiss help after any non-toggle selection from inside
+		// the help overlay. Skipped for 'navigate' (the palette closes)
+		// and 'exitWithQuery' (which already closed help before
+		// entering mode).
+		if (
+			wasHelpVisible &&
+			action.action !== 'toggleHelp' &&
+			action.action !== 'navigate' &&
+			action.action !== 'exitWithQuery'
+		) {
+			orchestrator.closeHelp();
+		}
+	}
+
+	/**
+	 * Dispatch a row-button action (dismiss, navigate, event).
+	 *
+	 * @param {Object} action
+	 */
+	function handleAction( action ) {
+		switch ( action.type ) {
+			case 'dismiss':
+				if ( action.itemId !== undefined ) {
+					orchestrator.dismissRecentItem( action.itemId );
+				} else {
+					mw.log.warn( '[CommandPalette] Dismiss action missing itemId:', action );
+				}
+				break;
+			case 'navigate':
+				if ( action.url ) {
+					window.location.href = action.url;
+					close();
+				} else {
+					mw.log.warn( '[CommandPalette] Navigate action missing url:', action );
+				}
+				break;
+			case 'event':
+				break;
+			default:
+				mw.log.warn( '[CommandPalette] Unknown or missing action type received:', action );
+		}
+	}
+
+	return { selectResult, handleAction };
+}
+
+module.exports = useResultRouter;

--- a/resources/skins.citizen.commandPalette/init.js
+++ b/resources/skins.citizen.commandPalette/init.js
@@ -7,6 +7,7 @@ const createRecentItems = require( './services/recentItems.js' );
 const createRestSearchClient = require( './services/searchClient.js' );
 const createPaletteRegistry = require( './services/paletteRegistry.js' );
 const { defineMode, defineCommand } = require( './services/defineMode.js' );
+const previewService = require( './services/instantDiffs.js' );
 
 // Provider factories
 const createSearchProvider = require( './providers/SearchProvider.js' );
@@ -107,6 +108,13 @@ function initApp( overlayEl, options ) {
 	app.provide( 'getHandler', paletteRegistry.getHandler );
 	app.provide( 'getHelpCatalogItems', () => paletteRegistry.getCommandListItems()
 		.filter( ( item ) => item.source !== 'command:help' ) );
+	// Preview-handler service — currently the InstantDiffs gadget bridge,
+	// but the consumer (useResultRouter + the App-level processContext /
+	// onReady wiring) only depends on the duck-typed
+	// `{ isAvailable, processContext, triggerForAnchor, onReady }` shape.
+	// Future preview integrations become a swap of this provider, not a
+	// code change in the dispatcher.
+	app.provide( 'previewService', previewService );
 	// Called from App.vue's close() so the orchestrator can hide its
 	// overlay wrapper and reset the trigger's `<details>` open state when
 	// the palette is dismissed from inside (Esc, backdrop click). Falls

--- a/skin.json
+++ b/skin.json
@@ -346,6 +346,7 @@
 				"resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js",
 				"resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js",
 				"resources/skins.citizen.commandPalette/composables/useKeyboard.js",
+				"resources/skins.citizen.commandPalette/composables/useResultRouter.js",
 				"resources/skins.citizen.commandPalette/composables/useTokenizedInput.js",
 				"resources/skins.citizen.commandPalette/utils/fetch.js",
 				"resources/skins.citizen.commandPalette/utils/providerActions.js",

--- a/skin.json
+++ b/skin.json
@@ -339,6 +339,7 @@
 				"resources/skins.citizen.commandPalette/init.js",
 				"resources/skins.citizen.commandPalette/types.js",
 				"resources/skins.citizen.commandPalette/composables/useActionNavigation.js",
+				"resources/skins.citizen.commandPalette/composables/useBodyHeightAnimation.js",
 				"resources/skins.citizen.commandPalette/composables/useListNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useGridNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js",

--- a/skin.json
+++ b/skin.json
@@ -338,6 +338,7 @@
 			"packageFiles": [
 				"resources/skins.citizen.commandPalette/init.js",
 				"resources/skins.citizen.commandPalette/types.js",
+				"resources/skins.citizen.commandPalette/composables/useActionNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useListNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useGridNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js",

--- a/skin.json
+++ b/skin.json
@@ -340,6 +340,7 @@
 				"resources/skins.citizen.commandPalette/types.js",
 				"resources/skins.citizen.commandPalette/composables/useActionNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useBodyHeightAnimation.js",
+				"resources/skins.citizen.commandPalette/composables/useGalleryColumnCount.js",
 				"resources/skins.citizen.commandPalette/composables/useListNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useGridNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js",

--- a/tests/vitest/commandPalette/composables/useActionNavigation.test.js
+++ b/tests/vitest/commandPalette/composables/useActionNavigation.test.js
@@ -1,0 +1,184 @@
+const { ref } = require( 'vue' );
+
+const useActionNavigation = require(
+	'../../../../resources/skins.citizen.commandPalette/composables/useActionNavigation.js'
+);
+
+function makeRowComponent() {
+	return {
+		focusFirstButton: vi.fn(),
+		focusButtonAtIndex: vi.fn(),
+		clickButtonAtIndex: vi.fn()
+	};
+}
+
+function setup( { items = [], highlighted = -1, refs = new Map() } = {} ) {
+	const itemsRef = ref( items );
+	const highlightedIndex = ref( highlighted );
+	const itemRefs = ref( refs );
+	const nav = useActionNavigation( { items: itemsRef, highlightedIndex, itemRefs } );
+
+	return { nav, itemsRef, highlightedIndex, itemRefs };
+}
+
+describe( 'useActionNavigation', () => {
+	it( 'starts inactive with focusedIndex -1', () => {
+		const { nav } = setup();
+
+		expect( nav.focusedIndex.value ).toBe( -1 );
+		expect( nav.isActive.value ).toBe( false );
+	} );
+
+	describe( 'focusFirst', () => {
+		it( 'calls focusFirstButton on the highlighted row and moves focusedIndex to 0', () => {
+			const row = makeRowComponent();
+			const { nav } = setup( {
+				items: [ { actions: [ {}, {} ] } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, row ] ] )
+			} );
+
+			nav.focusFirst();
+
+			expect( row.focusFirstButton ).toHaveBeenCalledOnce();
+			expect( nav.focusedIndex.value ).toBe( 0 );
+			expect( nav.isActive.value ).toBe( true );
+		} );
+
+		it( 'is a no-op when no row component is available', () => {
+			const { nav } = setup( { highlighted: 0 } );
+
+			nav.focusFirst();
+
+			expect( nav.focusedIndex.value ).toBe( -1 );
+		} );
+
+		it( 'is a no-op when the row component lacks focusFirstButton', () => {
+			const incomplete = { /* no focusFirstButton */ };
+			const { nav } = setup( {
+				items: [ { actions: [ {} ] } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, incomplete ] ] )
+			} );
+
+			nav.focusFirst();
+
+			expect( nav.focusedIndex.value ).toBe( -1 );
+		} );
+	} );
+
+	describe( 'focusNext', () => {
+		it( 'moves to the next button and calls focusButtonAtIndex', () => {
+			const row = makeRowComponent();
+			const { nav } = setup( {
+				items: [ { actions: [ {}, {}, {} ] } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, row ] ] )
+			} );
+			nav.focusedIndex.value = 0;
+
+			nav.focusNext();
+
+			expect( nav.focusedIndex.value ).toBe( 1 );
+			expect( row.focusButtonAtIndex ).toHaveBeenCalledWith( 1 );
+		} );
+
+		it( 'does not advance past the last action', () => {
+			const row = makeRowComponent();
+			const { nav } = setup( {
+				items: [ { actions: [ {}, {} ] } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, row ] ] )
+			} );
+			nav.focusedIndex.value = 1;
+
+			nav.focusNext();
+
+			expect( nav.focusedIndex.value ).toBe( 1 );
+			expect( row.focusButtonAtIndex ).not.toHaveBeenCalled();
+		} );
+
+		it( 'treats a row without an actions array as zero actions', () => {
+			const row = makeRowComponent();
+			const { nav } = setup( {
+				items: [ { /* no actions */ } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, row ] ] )
+			} );
+
+			nav.focusNext();
+
+			expect( nav.focusedIndex.value ).toBe( -1 );
+		} );
+	} );
+
+	describe( 'focusPrevious', () => {
+		it( 'decrements focusedIndex and calls focusButtonAtIndex', () => {
+			const row = makeRowComponent();
+			const { nav } = setup( {
+				items: [ { actions: [ {}, {}, {} ] } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, row ] ] )
+			} );
+			nav.focusedIndex.value = 2;
+
+			nav.focusPrevious();
+
+			expect( nav.focusedIndex.value ).toBe( 1 );
+			expect( row.focusButtonAtIndex ).toHaveBeenCalledWith( 1 );
+		} );
+
+		it( 'snaps to -1 (deactivates) when called from index 0', () => {
+			const row = makeRowComponent();
+			const { nav } = setup( {
+				items: [ { actions: [ {}, {} ] } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, row ] ] )
+			} );
+			nav.focusedIndex.value = 0;
+
+			nav.focusPrevious();
+
+			expect( nav.focusedIndex.value ).toBe( -1 );
+			expect( row.focusButtonAtIndex ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'deactivate', () => {
+		it( 'resets focusedIndex to -1', () => {
+			const { nav } = setup();
+			nav.focusedIndex.value = 2;
+
+			nav.deactivate();
+
+			expect( nav.focusedIndex.value ).toBe( -1 );
+			expect( nav.isActive.value ).toBe( false );
+		} );
+	} );
+
+	describe( 'clickFocused', () => {
+		it( 'dispatches a click on the row at focusedIndex', () => {
+			const row = makeRowComponent();
+			const { nav } = setup( {
+				items: [ { actions: [ {}, {} ] } ],
+				highlighted: 0,
+				refs: new Map( [ [ 0, row ] ] )
+			} );
+			nav.focusedIndex.value = 1;
+
+			nav.clickFocused();
+
+			expect( row.clickButtonAtIndex ).toHaveBeenCalledWith( 1 );
+		} );
+
+		it( 'is a no-op when no row component is available', () => {
+			const { nav } = setup( { highlighted: 0 } );
+			nav.focusedIndex.value = 0;
+
+			nav.clickFocused();
+
+			// Nothing to assert; the no-op should not throw.
+			expect( nav.focusedIndex.value ).toBe( 0 );
+		} );
+	} );
+} );

--- a/tests/vitest/commandPalette/composables/useBodyHeightAnimation.test.js
+++ b/tests/vitest/commandPalette/composables/useBodyHeightAnimation.test.js
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+const { mount } = require( '@vue/test-utils' );
+const { defineComponent, ref } = require( 'vue' );
+
+const useBodyHeightAnimation = require(
+	'../../../../resources/skins.citizen.commandPalette/composables/useBodyHeightAnimation.js'
+);
+
+// Stub ResizeObserver so we can capture the constructor and the callback
+// without depending on jsdom's (missing) implementation.
+let observerInstance = null;
+
+class StubResizeObserver {
+	constructor( callback ) {
+		this.callback = callback;
+		this.observed = [];
+		this.disconnected = false;
+		// Most recent instance is the one the test asserts against.
+		observerInstance = this;
+	}
+	observe( target ) {
+		this.observed.push( target );
+	}
+	disconnect() {
+		this.disconnected = true;
+	}
+}
+
+beforeEach( () => {
+	observerInstance = null;
+	globalThis.ResizeObserver = StubResizeObserver;
+} );
+
+afterEach( () => {
+	delete globalThis.ResizeObserver;
+} );
+
+/**
+ * Mount a wrapper that calls useBodyHeightAnimation against the given
+ * container/viewport refs. Returns the wrapper plus the setup/teardown
+ * functions on the wrapper's `vm` so tests can drive them directly.
+ *
+ * @param {Object} refs
+ * @return {Object}
+ */
+function mountWith( refs ) {
+	const Wrapper = defineComponent( {
+		template: '<div></div>',
+		setup() {
+			return useBodyHeightAnimation( refs );
+		}
+	} );
+	return mount( Wrapper );
+}
+
+describe( 'useBodyHeightAnimation', () => {
+	describe( 'setupResizeObserver', () => {
+		it( 'observes the viewport ref and writes its clientHeight to the container', () => {
+			const container = document.createElement( 'div' );
+			const viewport = document.createElement( 'div' );
+			Object.defineProperty( viewport, 'clientHeight', { value: 320 } );
+
+			const wrapper = mountWith( {
+				bodyContainer: ref( container ),
+				bodyViewport: ref( viewport )
+			} );
+
+			wrapper.vm.setupResizeObserver();
+
+			expect( observerInstance ).not.toBeNull();
+			expect( observerInstance.observed ).toEqual( [ viewport ] );
+			expect( container.style.height ).toBe( '320px' );
+		} );
+
+		it( 'is a no-op when the viewport ref is null', () => {
+			const wrapper = mountWith( {
+				bodyContainer: ref( null ),
+				bodyViewport: ref( null )
+			} );
+
+			wrapper.vm.setupResizeObserver();
+
+			expect( observerInstance ).toBeNull();
+		} );
+
+		it( 'updates the container height again when the observer callback fires', () => {
+			const container = document.createElement( 'div' );
+			const viewport = document.createElement( 'div' );
+			Object.defineProperty( viewport, 'clientHeight', {
+				configurable: true,
+				value: 200
+			} );
+
+			const wrapper = mountWith( {
+				bodyContainer: ref( container ),
+				bodyViewport: ref( viewport )
+			} );
+
+			wrapper.vm.setupResizeObserver();
+			expect( container.style.height ).toBe( '200px' );
+
+			Object.defineProperty( viewport, 'clientHeight', {
+				configurable: true,
+				value: 480
+			} );
+			observerInstance.callback();
+
+			expect( container.style.height ).toBe( '480px' );
+		} );
+	} );
+
+	describe( 'teardownResizeObserver', () => {
+		it( 'disconnects the active observer', () => {
+			const container = document.createElement( 'div' );
+			const viewport = document.createElement( 'div' );
+			Object.defineProperty( viewport, 'clientHeight', { value: 100 } );
+
+			const wrapper = mountWith( {
+				bodyContainer: ref( container ),
+				bodyViewport: ref( viewport )
+			} );
+			wrapper.vm.setupResizeObserver();
+			const created = observerInstance;
+
+			wrapper.vm.teardownResizeObserver();
+
+			expect( created.disconnected ).toBe( true );
+		} );
+
+		it( 'is a no-op when no observer is active', () => {
+			const wrapper = mountWith( {
+				bodyContainer: ref( null ),
+				bodyViewport: ref( null )
+			} );
+
+			expect( () => wrapper.vm.teardownResizeObserver() ).not.toThrow();
+		} );
+	} );
+
+	describe( 'unmount', () => {
+		it( 'disconnects an active observer when the component unmounts', () => {
+			const container = document.createElement( 'div' );
+			const viewport = document.createElement( 'div' );
+			Object.defineProperty( viewport, 'clientHeight', { value: 100 } );
+
+			const wrapper = mountWith( {
+				bodyContainer: ref( container ),
+				bodyViewport: ref( viewport )
+			} );
+			wrapper.vm.setupResizeObserver();
+			const created = observerInstance;
+
+			wrapper.unmount();
+
+			expect( created.disconnected ).toBe( true );
+		} );
+	} );
+} );

--- a/tests/vitest/commandPalette/composables/useGalleryColumnCount.test.js
+++ b/tests/vitest/commandPalette/composables/useGalleryColumnCount.test.js
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+const { mount, flushPromises } = require( '@vue/test-utils' );
+const { defineComponent, ref } = require( 'vue' );
+
+const useGalleryColumnCount = require(
+	'../../../../resources/skins.citizen.commandPalette/composables/useGalleryColumnCount.js'
+);
+
+let observerInstance = null;
+
+class StubResizeObserver {
+	constructor( callback ) {
+		this.callback = callback;
+		this.observed = [];
+		this.disconnected = false;
+		observerInstance = this;
+	}
+	observe( target ) {
+		this.observed.push( target );
+	}
+	disconnect() {
+		this.disconnected = true;
+	}
+}
+
+beforeEach( () => {
+	observerInstance = null;
+	globalThis.ResizeObserver = StubResizeObserver;
+} );
+
+afterEach( () => {
+	delete globalThis.ResizeObserver;
+} );
+
+/**
+ * Build a fake gallery component instance with an `$el` whose
+ * clientWidth can be configured up front.
+ *
+ * @param {number} width
+ * @return {Object}
+ */
+function fakeGallery( width ) {
+	const el = document.createElement( 'div' );
+	Object.defineProperty( el, 'clientWidth', {
+		configurable: true,
+		value: width
+	} );
+	return { $el: el };
+}
+
+/**
+ * Mount a wrapper that runs the composable against a galleryRef and
+ * exposes the returned columnCount ref + the galleryRef so tests can
+ * mutate it.
+ *
+ * @param {Object} options
+ * @return {Object}
+ */
+function mountWith( { galleryRef, minTileWidth } = {} ) {
+	const ref$ = galleryRef || ref( null );
+	const Wrapper = defineComponent( {
+		template: '<div></div>',
+		setup() {
+			const columnCount = useGalleryColumnCount( {
+				galleryRef: ref$,
+				minTileWidth
+			} );
+			return { columnCount };
+		}
+	} );
+	const wrapper = mount( Wrapper );
+	return { wrapper, galleryRef: ref$ };
+}
+
+describe( 'useGalleryColumnCount', () => {
+	it( 'starts at 1 with no gallery mounted', () => {
+		const { wrapper } = mountWith();
+
+		expect( wrapper.vm.columnCount ).toBe( 1 );
+	} );
+
+	it( 'attaches an observer and computes columns when galleryRef binds', async () => {
+		const { wrapper, galleryRef } = mountWith();
+
+		galleryRef.value = fakeGallery( 700 );
+		await flushPromises();
+
+		expect( observerInstance ).not.toBeNull();
+		expect( observerInstance.observed ).toHaveLength( 1 );
+		// 700 / 140 = 5
+		expect( wrapper.vm.columnCount ).toBe( 5 );
+	} );
+
+	it( 'recomputes columns when the observer callback fires', async () => {
+		const gallery = fakeGallery( 280 );
+		const { wrapper, galleryRef } = mountWith();
+
+		galleryRef.value = gallery;
+		await flushPromises();
+		expect( wrapper.vm.columnCount ).toBe( 2 );
+
+		Object.defineProperty( gallery.$el, 'clientWidth', {
+			configurable: true,
+			value: 560
+		} );
+		observerInstance.callback();
+
+		expect( wrapper.vm.columnCount ).toBe( 4 );
+	} );
+
+	it( 'clamps to a minimum of 1 column for narrow gallery widths', async () => {
+		const { wrapper, galleryRef } = mountWith();
+
+		galleryRef.value = fakeGallery( 80 );
+		await flushPromises();
+
+		expect( wrapper.vm.columnCount ).toBe( 1 );
+	} );
+
+	it( 'disconnects the previous observer when galleryRef swaps to a new instance', async () => {
+		const { galleryRef } = mountWith();
+
+		galleryRef.value = fakeGallery( 280 );
+		await flushPromises();
+		const first = observerInstance;
+
+		galleryRef.value = fakeGallery( 560 );
+		await flushPromises();
+		const second = observerInstance;
+
+		expect( first.disconnected ).toBe( true );
+		expect( second ).not.toBe( first );
+	} );
+
+	it( 'disconnects when galleryRef becomes null', async () => {
+		const { galleryRef } = mountWith();
+
+		galleryRef.value = fakeGallery( 280 );
+		await flushPromises();
+		const created = observerInstance;
+
+		galleryRef.value = null;
+		await flushPromises();
+
+		expect( created.disconnected ).toBe( true );
+	} );
+
+	it( 'disconnects on component unmount', async () => {
+		const { wrapper, galleryRef } = mountWith();
+
+		galleryRef.value = fakeGallery( 280 );
+		await flushPromises();
+		const created = observerInstance;
+
+		wrapper.unmount();
+
+		expect( created.disconnected ).toBe( true );
+	} );
+
+	it( 'honors a custom minTileWidth', async () => {
+		const { wrapper, galleryRef } = mountWith( { minTileWidth: 200 } );
+
+		galleryRef.value = fakeGallery( 700 );
+		await flushPromises();
+
+		// 700 / 200 = 3 (floored)
+		expect( wrapper.vm.columnCount ).toBe( 3 );
+	} );
+} );

--- a/tests/vitest/commandPalette/composables/useResultRouter.test.js
+++ b/tests/vitest/commandPalette/composables/useResultRouter.test.js
@@ -1,0 +1,476 @@
+// @vitest-environment jsdom
+
+const mw = require( '../../mocks/mw.js' );
+globalThis.mw = mw;
+
+const { ref } = require( 'vue' );
+
+const useResultRouter = require(
+	'../../../../resources/skins.citizen.commandPalette/composables/useResultRouter.js'
+);
+
+/**
+ * Build a minimal but realistic dependency bundle. Each test overrides
+ * the bits it cares about and leaves the rest at the defaults.
+ *
+ * @param {Object} overrides
+ * @return {Object}
+ */
+function makeDeps( overrides = {} ) {
+	const orchestrator = {
+		activeMode: ref( null ),
+		helpVisible: ref( false ),
+		query: ref( '' ),
+		handleSelection: vi.fn().mockResolvedValue( { action: 'none' } ),
+		enterMode: vi.fn(),
+		exitMode: vi.fn(),
+		pushModeContext: vi.fn(),
+		closeHelp: vi.fn(),
+		toggleHelp: vi.fn(),
+		dismissRecentItem: vi.fn(),
+		updateQuery: vi.fn(),
+		...( overrides.orchestrator || {} )
+	};
+	const tokenInput = {
+		tokens: ref( [] ),
+		freeText: ref( '' ),
+		fullQuery: ref( '' ),
+		setFreeText: vi.fn(),
+		clear: vi.fn(),
+		addToken: vi.fn(),
+		removeToken: vi.fn(),
+		...( overrides.tokenInput || {} )
+	};
+	const navigation = {
+		findModeByQuery: vi.fn(),
+		...( overrides.navigation || {} )
+	};
+	const control = {
+		focusInput: vi.fn(),
+		close: vi.fn(),
+		paletteRoot: ref( null ),
+		...( overrides.control || {} )
+	};
+	const preview = {
+		isAvailable: vi.fn().mockReturnValue( false ),
+		triggerForAnchor: vi.fn(),
+		...( overrides.preview || {} )
+	};
+	return { orchestrator, tokenInput, navigation, control, preview };
+}
+
+beforeEach( () => {
+	mw.log.warn.mockClear();
+} );
+
+describe( 'useResultRouter — selectResult', () => {
+	it( 'calls handleSelection with the result', async () => {
+		const deps = makeDeps();
+		const { selectResult } = useResultRouter( deps );
+
+		await selectResult( { id: 'foo' } );
+
+		expect( deps.orchestrator.handleSelection ).toHaveBeenCalledWith( { id: 'foo' } );
+	} );
+
+	describe( 'navigate', () => {
+		it( 'sets window.location.href and closes the palette for keyboard activation', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				}
+			} );
+			const setLocation = vi.fn();
+			Object.defineProperty( window, 'location', {
+				configurable: true,
+				value: { set href( v ) { setLocation( v ); } }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { id: 'foo' } );
+
+			expect( setLocation ).toHaveBeenCalledWith( '/wiki/Foo' );
+			expect( deps.control.close ).toHaveBeenCalled();
+		} );
+
+		it( 'does not set window.location for mouse clicks (browser already handled the <a>)', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				}
+			} );
+			const setLocation = vi.fn();
+			Object.defineProperty( window, 'location', {
+				configurable: true,
+				value: { set href( v ) { setLocation( v ); } }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { id: 'foo', isMouseClick: true } );
+
+			expect( setLocation ).not.toHaveBeenCalled();
+			expect( deps.control.close ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'navigate with preview', () => {
+		it( 'triggers the preview anchor for keyboard activation when available + previewable + non-modifier', async () => {
+			const root = document.createElement( 'div' );
+			const anchor = document.createElement( 'a' );
+			anchor.classList.add( 'citizen-command-palette-list-item--highlighted' );
+			const inner = document.createElement( 'a' );
+			anchor.appendChild( inner );
+			root.appendChild( anchor );
+
+			const deps = makeDeps( {
+				orchestrator: {
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				},
+				control: { paletteRoot: ref( root ), focusInput: vi.fn(), close: vi.fn() },
+				preview: { isAvailable: vi.fn().mockReturnValue( true ), triggerForAnchor: vi.fn() }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { previewable: true } );
+
+			expect( deps.preview.triggerForAnchor ).toHaveBeenCalledWith( inner );
+			expect( deps.control.close ).not.toHaveBeenCalled();
+		} );
+
+		it( 'falls through to navigate when modifierClick is set', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				},
+				preview: { isAvailable: vi.fn().mockReturnValue( true ), triggerForAnchor: vi.fn() }
+			} );
+			const setLocation = vi.fn();
+			Object.defineProperty( window, 'location', {
+				configurable: true,
+				value: { set href( v ) { setLocation( v ); } }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { previewable: true, modifierClick: true } );
+
+			expect( deps.preview.triggerForAnchor ).not.toHaveBeenCalled();
+			expect( setLocation ).toHaveBeenCalledWith( '/wiki/Foo' );
+		} );
+
+		it( 'does not call triggerForAnchor on mouse click (browser already fired one)', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				},
+				control: { paletteRoot: ref( null ), focusInput: vi.fn(), close: vi.fn() },
+				preview: { isAvailable: vi.fn().mockReturnValue( true ), triggerForAnchor: vi.fn() }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { previewable: true, isMouseClick: true } );
+
+			expect( deps.preview.triggerForAnchor ).not.toHaveBeenCalled();
+			expect( deps.control.close ).not.toHaveBeenCalled();
+		} );
+
+		it( 'keeps the palette open without error when no anchor is found in the DOM', async () => {
+			// Pin the no-anchor branch: if the highlighted-row CSS class is
+			// renamed in the future, this test catches the silent no-op.
+			const root = document.createElement( 'div' );
+			const deps = makeDeps( {
+				orchestrator: {
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				},
+				control: { paletteRoot: ref( root ), focusInput: vi.fn(), close: vi.fn() },
+				preview: { isAvailable: vi.fn().mockReturnValue( true ), triggerForAnchor: vi.fn() }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { previewable: true } );
+
+			expect( deps.preview.triggerForAnchor ).not.toHaveBeenCalled();
+			expect( deps.control.close ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'exitWithQuery', () => {
+		it( 'inside a mode, exits and seeds freeText', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					activeMode: ref( { id: 'cat' } ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'exitWithQuery', payload: 'Foo:' } ),
+					exitMode: vi.fn(),
+					helpVisible: ref( false ),
+					closeHelp: vi.fn()
+				}
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			expect( deps.orchestrator.exitMode ).toHaveBeenCalled();
+			expect( deps.tokenInput.setFreeText ).toHaveBeenCalledWith( 'Foo:' );
+		} );
+
+		it( 'at root, enters a matching mode if found', async () => {
+			const matchedMode = { id: 'smw' };
+			const deps = makeDeps( {
+				orchestrator: {
+					activeMode: ref( null ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'exitWithQuery', payload: '/smw:' } )
+				},
+				navigation: { findModeByQuery: vi.fn().mockReturnValue( { mode: matchedMode } ) }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			expect( deps.tokenInput.clear ).toHaveBeenCalled();
+			expect( deps.orchestrator.enterMode ).toHaveBeenCalledWith( matchedMode );
+		} );
+
+		it( 'at root, closes help before entering mode if help was visible', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					activeMode: ref( null ),
+					helpVisible: ref( true ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'exitWithQuery', payload: '/smw:' } )
+				},
+				navigation: { findModeByQuery: vi.fn().mockReturnValue( { mode: { id: 'smw' } } ) }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			expect( deps.orchestrator.closeHelp ).toHaveBeenCalled();
+		} );
+
+		it( 'at root, no-ops if no matching mode is found', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					activeMode: ref( null ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'exitWithQuery', payload: 'random' } )
+				},
+				navigation: { findModeByQuery: vi.fn().mockReturnValue( null ) }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			expect( deps.orchestrator.enterMode ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	it( 'updateQuery sets freeText', async () => {
+		const deps = makeDeps( {
+			orchestrator: {
+				handleSelection: vi.fn().mockResolvedValue( { action: 'updateQuery', payload: 'foo' } )
+			}
+		} );
+
+		const { selectResult } = useResultRouter( deps );
+		await selectResult( {} );
+
+		expect( deps.tokenInput.setFreeText ).toHaveBeenCalledWith( 'foo' );
+	} );
+
+	it( 'addToken adds the token, clears freeText, and forces a query refresh', async () => {
+		const deps = makeDeps( {
+			orchestrator: {
+				handleSelection: vi.fn().mockResolvedValue( { action: 'addToken', payload: { raw: 'Cat:' } } )
+			},
+			tokenInput: {
+				fullQuery: ref( 'Cat: anything' ),
+				addToken: vi.fn(),
+				setFreeText: vi.fn(),
+				clear: vi.fn()
+			}
+		} );
+
+		const { selectResult } = useResultRouter( deps );
+		await selectResult( {} );
+
+		expect( deps.tokenInput.addToken ).toHaveBeenCalledWith( { raw: 'Cat:' } );
+		expect( deps.tokenInput.setFreeText ).toHaveBeenCalledWith( '' );
+		expect( deps.orchestrator.updateQuery ).toHaveBeenCalledWith( 'Cat: anything' );
+	} );
+
+	it( 'pushModeContext pushes and clears tokens', async () => {
+		const deps = makeDeps( {
+			orchestrator: {
+				handleSelection: vi.fn().mockResolvedValue( { action: 'pushModeContext', payload: { title: 'Mammals' } } )
+			}
+		} );
+
+		const { selectResult } = useResultRouter( deps );
+		await selectResult( {} );
+
+		expect( deps.orchestrator.pushModeContext ).toHaveBeenCalledWith( { title: 'Mammals' } );
+		expect( deps.tokenInput.clear ).toHaveBeenCalled();
+	} );
+
+	it( 'toggleHelp toggles and clears tokens', async () => {
+		const deps = makeDeps( {
+			orchestrator: {
+				handleSelection: vi.fn().mockResolvedValue( { action: 'toggleHelp' } )
+			}
+		} );
+
+		const { selectResult } = useResultRouter( deps );
+		await selectResult( {} );
+
+		expect( deps.orchestrator.toggleHelp ).toHaveBeenCalled();
+		expect( deps.tokenInput.clear ).toHaveBeenCalled();
+	} );
+
+	it( 'none and unknown actions no-op', async () => {
+		const deps = makeDeps( {
+			orchestrator: {
+				handleSelection: vi.fn().mockResolvedValue( { action: 'none' } )
+			}
+		} );
+
+		const { selectResult } = useResultRouter( deps );
+		await selectResult( {} );
+
+		expect( deps.control.close ).not.toHaveBeenCalled();
+		expect( deps.tokenInput.setFreeText ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'help auto-dismiss', () => {
+		it( 'closes help after a non-toggle/non-navigate/non-exit action when help was visible', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					helpVisible: ref( true ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'updateQuery', payload: 'foo' } )
+				}
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			expect( deps.orchestrator.closeHelp ).toHaveBeenCalled();
+		} );
+
+		it( 'does NOT close help on toggleHelp (the toggle handles it)', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					helpVisible: ref( true ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'toggleHelp' } )
+				}
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			expect( deps.orchestrator.closeHelp ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does NOT close help on navigate (the palette closes anyway)', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					helpVisible: ref( true ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				}
+			} );
+			Object.defineProperty( window, 'location', {
+				configurable: true,
+				value: { set href( _v ) {} }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			expect( deps.orchestrator.closeHelp ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does NOT close help on exitWithQuery (it closed it explicitly before entering mode)', async () => {
+			const deps = makeDeps( {
+				orchestrator: {
+					activeMode: ref( null ),
+					helpVisible: ref( true ),
+					handleSelection: vi.fn().mockResolvedValue( { action: 'exitWithQuery', payload: '/smw:' } )
+				},
+				navigation: { findModeByQuery: vi.fn().mockReturnValue( { mode: { id: 'smw' } } ) }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( {} );
+
+			// Closed exactly once (the explicit closeHelp before enterMode), not the auto-dismiss path.
+			expect( deps.orchestrator.closeHelp ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );
+
+describe( 'useResultRouter — handleAction', () => {
+	it( 'dismiss with itemId calls dismissRecentItem', () => {
+		const deps = makeDeps();
+		const { handleAction } = useResultRouter( deps );
+
+		handleAction( { type: 'dismiss', itemId: 42 } );
+
+		expect( deps.orchestrator.dismissRecentItem ).toHaveBeenCalledWith( 42 );
+	} );
+
+	it( 'dismiss without itemId logs a warning', () => {
+		const deps = makeDeps();
+		const { handleAction } = useResultRouter( deps );
+
+		handleAction( { type: 'dismiss' } );
+
+		expect( mw.log.warn ).toHaveBeenCalledWith(
+			expect.stringContaining( 'Dismiss action missing itemId' ),
+			expect.any( Object )
+		);
+		expect( deps.orchestrator.dismissRecentItem ).not.toHaveBeenCalled();
+	} );
+
+	it( 'navigate with url sets location and closes', () => {
+		const deps = makeDeps();
+		const setLocation = vi.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: { set href( v ) { setLocation( v ); } }
+		} );
+		const { handleAction } = useResultRouter( deps );
+
+		handleAction( { type: 'navigate', url: '/wiki/Foo' } );
+
+		expect( setLocation ).toHaveBeenCalledWith( '/wiki/Foo' );
+		expect( deps.control.close ).toHaveBeenCalled();
+	} );
+
+	it( 'navigate without url logs a warning', () => {
+		const deps = makeDeps();
+		const { handleAction } = useResultRouter( deps );
+
+		handleAction( { type: 'navigate' } );
+
+		expect( mw.log.warn ).toHaveBeenCalledWith(
+			expect.stringContaining( 'Navigate action missing url' ),
+			expect.any( Object )
+		);
+	} );
+
+	it( 'event no-ops', () => {
+		const deps = makeDeps();
+		const { handleAction } = useResultRouter( deps );
+
+		handleAction( { type: 'event' } );
+
+		expect( mw.log.warn ).not.toHaveBeenCalled();
+	} );
+
+	it( 'unknown type logs a warning', () => {
+		const deps = makeDeps();
+		const { handleAction } = useResultRouter( deps );
+
+		handleAction( { type: 'unknown' } );
+
+		expect( mw.log.warn ).toHaveBeenCalledWith(
+			expect.stringContaining( 'Unknown or missing action type' ),
+			expect.any( Object )
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary

- Decomposes `App.vue` (formerly 942 lines, now 704) by extracting four focused composables, each unit-testable in isolation.
- Inverts `instantDiffs` from a hard import to a Vue-injected `previewService`, removing the dispatcher's coupling to a specific preview implementation.
- Establishes a grouped-interface options-bag pattern in the new composables (`{ orchestrator, tokenInput, navigation, control, preview }`) — sets the convention for a future `useKeyboard` ISP refactor.

## Why

`App.vue`'s 620-line `setup()` mixed several concerns: composable wiring, DOM measurement (two ResizeObservers), action-button focus management, and a 120-line action dispatcher. Of those, `selectResult` was the largest readability and testability cost — the 6-action switch was reachable only by mounting the full component, with a hard reference to the `instantDiffs` preview service hard-wired into the navigate branch.

This is direction A from a wider command-palette architecture brainstorm. Direction B (the mode contract) shipped in #1523. The `useKeyboard` ISP follow-up is intentionally out of scope here — see "Non-goals" below.

## What changed

| Composable | Lines | Owns |
| :--- | :--- | :--- |
| `useResultRouter` | 194 | `selectResult` (6-action dispatch + InstantDiffs preview branch + help auto-dismiss) and `handleAction` (3-action dispatch). |
| `useGalleryColumnCount` | 55 | ResizeObserver lifecycle for the gallery's column count. Watches the gallery template ref; attaches/detaches as the ref binds, swaps, or unbinds. |
| `useActionNavigation` | 81 | Focus adapter for action buttons on the highlighted row. Tracks `focusedIndex`, exposes 5 methods that delegate to row-component refs. |
| `useBodyHeightAnimation` | 53 | ResizeObserver lifecycle that animates the palette body's height to track the rendered viewport. |

**DIP**: `init.js` now provides `previewService`. App.vue and `useResultRouter` consume it via `inject('previewService')`. The duck-typed contract is `{ isAvailable, processContext, triggerForAnchor, onReady }` — today the InstantDiffs gadget bridge, swappable in `init.js` for any service that satisfies the shape.

## Non-goals

- **ISP refactor of `useKeyboard`**'s 25-field options bag is intentionally a separate follow-up. The grouped-interface pattern is established here in the new composables; that PR will apply the same pattern to `useKeyboard.js` so reviewers can evaluate it on its own merits.
- **Splitting `useProviderOrchestration`** further.
- **No template, child-component, or mode changes.** Pure refactor.

## Tests

51 new tests in `tests/vitest/commandPalette/composables/`:

- `useActionNavigation.test.js` — 12 tests covering all 5 methods, bounds checks, and missing-component guards.
- `useBodyHeightAnimation.test.js` — 6 tests covering setup, teardown, observer-callback updates, and unmount-time disconnect.
- `useGalleryColumnCount.test.js` — 8 tests covering initial state, observer attachment, callback recompute, ref-swap disconnect, ref-clear disconnect, unmount disconnect, and the configurable `minTileWidth`.
- `useResultRouter.test.js` — 25 tests: every selectResult action type, the InstantDiffs preview branch (available + previewable + non-modifier-click → triggers preview; modifier-click and mouse-click fall through correctly), the no-anchor branch, the help auto-dismiss with all 3 exclusion paths, and every handleAction case.

Total: 847/847 passing, 0 lint errors.

## Smoke test

Manual verification on the local wiki against `MediaWiki:Citizen.js` (the smoke test from #1523 still in place):
- Palette opens, recents render.
- `/file:` enters gallery mode (data-palette-layout swap, useGalleryColumnCount attaches).
- `/cat:` from root auto-enters category mode (useResultRouter exitWithQuery + auto-enter pipeline).
- All 10 mode-contract validators from #1523 still fire as expected — the dispatch path didn't drift.
- No new console errors.

## Test plan

- [x] `npm run preflight` — 847/847 tests, 0 lint errors
- [x] Manual smoke test on local wiki — built-in modes work, keyboard navigation works, InstantDiffs preview path still wired
- [x] Verified the InstantDiffs late-load path (`onReady` callback) routes through the injected service rather than the previous hard import
- [x] Each commit independently passes preflight (one composable extracted per commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the command palette's architecture by extracting result routing, action navigation, and preview handling logic into dedicated composables for improved maintainability.
  * Improved preview anchor processing and gallery/list resizing behavior.

* **Tests**
  * Added comprehensive test coverage for new composables and routing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->