### PR TITLE
refactor(commandPalette): extract useOperationLifecycle composable

### DIFF
--- a/resources/skins.citizen.commandPalette/composables/useOperationLifecycle.js
+++ b/resources/skins.citizen.commandPalette/composables/useOperationLifecycle.js
@@ -1,0 +1,120 @@
+/**
+ * Debounce + abort + pending coordination for async dispatch. Each
+ * call to `runDebouncedAbortable` cancels the prior in-flight
+ * controller, schedules the new operation after `debounceMs`, and
+ * tracks pending state on the supplied refs.
+ *
+ *  - `isPending` flips to `true` immediately and stays true until the
+ *    operation resolves, errors, or is cancelled. `showPending` flips
+ *    on after `pendingDelayMs` so brief operations don't flash a
+ *    spinner.
+ *  - The caller supplies an `isStale()` predicate. It is called both
+ *    before the operation runs (to short-circuit if the world has
+ *    moved on) and after (to decide whether to apply the result).
+ *  - Errors with `name === 'AbortError'` are swallowed silently; all
+ *    others are passed to `onError` so callers control their own log
+ *    prefix.
+ *
+ * @param {Object} options
+ * @param {import('vue').Ref<boolean>} options.isPending Reactive flag flipped to true while an operation is in flight.
+ * @param {import('vue').Ref<boolean>} options.showPending Reactive flag flipped to true after `pendingDelayMs` if the operation is still in flight (for spinner-style UI).
+ * @param {number} [options.pendingDelayMs=300] Delay before `showPending` flips on, so brief operations don't flash a spinner.
+ * @return {{ reset: Function, runDebouncedAbortable: Function }}
+ */
+function useOperationLifecycle( { isPending, showPending, pendingDelayMs = 300 } ) {
+	let debounceTimeout = null;
+	let pendingDelayTimeout = null;
+	let abortController = null;
+
+	/**
+	 * Cancel any in-flight operation and reset pending state.
+	 *
+	 * Called by the orchestrator when a navigation or mode change makes
+	 * the current operation irrelevant (e.g. enterMode, exitMode, query
+	 * cleared by Esc).
+	 */
+	function reset() {
+		clearTimeout( debounceTimeout );
+		debounceTimeout = null;
+		clearTimeout( pendingDelayTimeout );
+		pendingDelayTimeout = null;
+		isPending.value = false;
+		showPending.value = false;
+
+		if ( abortController ) {
+			abortController.abort();
+			abortController = null;
+		}
+	}
+
+	/**
+	 * Run an async operation with debounce + abort + pending coordination.
+	 *
+	 * @param {Object} task
+	 * @param {number} task.debounceMs Debounce duration in milliseconds.
+	 * @param {Function} task.isStale Predicate `() => boolean`. Called both
+	 *   before the operation runs (to short-circuit if the world has
+	 *   moved on) and after (to decide whether to apply the result).
+	 *   Implementations typically check `query.value === currentQuery
+	 *   && activeMode.value === capturedMode`.
+	 * @param {Function} task.run Async function `(signal) => Promise<*>`.
+	 *   Receives the AbortController's signal so the operation can
+	 *   cancel its own work (e.g. fetch).
+	 * @param {Function} task.onResult Called with the awaited result if
+	 *   `isStale()` is still false.
+	 * @param {Function} task.onError Called with the caught error
+	 *   (excluding AbortError, which is silently swallowed). Fires
+	 *   regardless of `isStale()` — callers must check staleness
+	 *   inside their handler before applying side effects.
+	 */
+	function runDebouncedAbortable( task ) {
+		const { debounceMs, isStale, run, onResult, onError } = task;
+
+		isPending.value = true;
+
+		clearTimeout( pendingDelayTimeout );
+		pendingDelayTimeout = setTimeout( () => {
+			if ( isPending.value && !isStale() ) {
+				showPending.value = true;
+			}
+		}, pendingDelayMs );
+
+		clearTimeout( debounceTimeout );
+
+		if ( abortController ) {
+			abortController.abort();
+		}
+		abortController = new AbortController();
+		const signal = abortController.signal;
+
+		debounceTimeout = setTimeout( async () => {
+			if ( isStale() ) {
+				isPending.value = false;
+				showPending.value = false;
+				return;
+			}
+
+			try {
+				const result = await run( signal );
+				if ( !isStale() ) {
+					onResult( result );
+				}
+			} catch ( error ) {
+				if ( error && error.name !== 'AbortError' ) {
+					onError( error );
+				}
+			} finally {
+				if ( !isStale() ) {
+					isPending.value = false;
+					showPending.value = false;
+					clearTimeout( pendingDelayTimeout );
+					pendingDelayTimeout = null;
+				}
+			}
+		}, debounceMs );
+	}
+
+	return { reset, runDebouncedAbortable };
+}
+
+module.exports = useOperationLifecycle;

--- a/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
+++ b/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
@@ -1,6 +1,8 @@
 const { ref, shallowRef, computed } = require( 'vue' );
+const useOperationLifecycle = require( './useOperationLifecycle.js' );
 
 const SHOW_PENDING_DELAY_MS = 300;
+const DEFAULT_DEBOUNCE_MS = 250;
 
 const DEFAULT_STATE_CONFIG = {
 	emptyState: {
@@ -70,26 +72,12 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		};
 	} );
 
-	let debounceTimeout = null;
-	let pendingDelayTimeout = null;
-	let abortController = null;
-
-	/**
-	 * Resets all operation state.
-	 */
-	function resetOperationState() {
-		clearTimeout( debounceTimeout );
-		debounceTimeout = null;
-		clearTimeout( pendingDelayTimeout );
-		pendingDelayTimeout = null;
-		isPending.value = false;
-		showPending.value = false;
-
-		if ( abortController ) {
-			abortController.abort();
-			abortController = null;
-		}
-	}
+	const lifecycle = useOperationLifecycle( {
+		isPending,
+		showPending,
+		pendingDelayMs: SHOW_PENDING_DELAY_MS
+	} );
+	const resetOperationState = lifecycle.reset;
 
 	/**
 	 * Applies the result decorator and updates displayedItems.
@@ -133,55 +121,21 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	 * @param {string} currentQuery The query at dispatch time.
 	 */
 	function handleAsyncProvider( provider, currentQuery ) {
-		isPending.value = true;
-
-		clearTimeout( pendingDelayTimeout );
-		pendingDelayTimeout = setTimeout( () => {
-			if ( isPending.value && query.value === currentQuery ) {
-				showPending.value = true;
-			}
-		}, SHOW_PENDING_DELAY_MS );
-
-		clearTimeout( debounceTimeout );
-
-		if ( abortController ) {
-			abortController.abort();
-		}
-		abortController = new AbortController();
-		const signal = abortController.signal;
-
-		debounceTimeout = setTimeout( async () => {
-			if ( query.value !== currentQuery ) {
-				isPending.value = false;
-				showPending.value = false;
-				return;
-			}
-
-			try {
-				const result = await provider.getResults( currentQuery, signal );
-				const items = normalizeProviderResult( result );
-				if ( query.value === currentQuery ) {
-					setResults( items );
-				}
-			} catch ( error ) {
-				if ( error.name !== 'AbortError' ) {
-					mw.log.error(
-						'[commandPalette] Async provider "' +
-						provider.id + '" failed:', error
-					);
-					if ( query.value === currentQuery ) {
-						setResults( [] );
-					}
-				}
-			} finally {
-				if ( query.value === currentQuery ) {
-					isPending.value = false;
-					showPending.value = false;
-					clearTimeout( pendingDelayTimeout );
-					pendingDelayTimeout = null;
+		const isStale = () => query.value !== currentQuery;
+		lifecycle.runDebouncedAbortable( {
+			debounceMs: provider.debounceMs || DEFAULT_DEBOUNCE_MS,
+			isStale,
+			run: ( signal ) => provider.getResults( currentQuery, signal ),
+			onResult: ( result ) => setResults( normalizeProviderResult( result ) ),
+			onError: ( error ) => {
+				mw.log.error(
+					'[commandPalette] Async provider "' + provider.id + '" failed:', error
+				);
+				if ( !isStale() ) {
+					setResults( [] );
 				}
 			}
-		}, provider.debounceMs || 250 );
+		} );
 	}
 
 	/**
@@ -257,6 +211,22 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	}
 
 	/**
+	 * Renders mode-getResults output into a single section. Both the
+	 * empty-query and debounced branches funnel through this so the
+	 * staleness check stays consistent.
+	 *
+	 * @param {Object} mode
+	 * @param {string} currentQuery
+	 * @param {Array} items
+	 */
+	function applyModeResults( mode, currentQuery, items ) {
+		if ( query.value === currentQuery && activeMode.value === mode ) {
+			displayedItems.value = items.length > 0 ?
+				[ { heading: null, items: items } ] : [];
+		}
+	}
+
+	/**
 	 * Handles a query routed through the active mode's getResults.
 	 *
 	 * @param {Object} mode The active mode object.
@@ -264,78 +234,45 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	 */
 	function handleModeQuery( mode, currentQuery ) {
 		const tokens = deps.tokens ? deps.tokens.value : [];
+
+		// Empty query: fire immediately. No debounce, no abort — modes
+		// load their root state on entry and the user expects no delay.
 		if ( !currentQuery ) {
 			isPending.value = true;
-			const clearPending = () => {
-				if ( query.value === currentQuery && activeMode.value === mode ) {
-					isPending.value = false;
-				}
-			};
-			Promise.resolve( mode.getResults( '', undefined, tokens, activeModeContext.value ) ).then( ( result ) => {
-				const items = normalizeProviderResult( result );
-				if ( query.value === currentQuery && activeMode.value === mode ) {
-					displayedItems.value = items.length > 0 ?
-						[ { heading: null, items: items } ] : [];
-				}
-				clearPending();
-			} ).catch( ( error ) => {
-				mw.log.error(
-					'[commandPalette] Mode "' + mode.id + '" failed:', error
-				);
-				clearPending();
-			} );
-			return;
-		}
-
-		isPending.value = true;
-
-		clearTimeout( pendingDelayTimeout );
-		pendingDelayTimeout = setTimeout( () => {
-			if ( isPending.value && query.value === currentQuery ) {
-				showPending.value = true;
-			}
-		}, SHOW_PENDING_DELAY_MS );
-
-		clearTimeout( debounceTimeout );
-
-		if ( abortController ) {
-			abortController.abort();
-		}
-		abortController = new AbortController();
-
-		debounceTimeout = setTimeout( async () => {
-			if ( query.value !== currentQuery || activeMode.value !== mode ) {
-				isPending.value = false;
-				showPending.value = false;
-				return;
-			}
-
-			try {
-				const signal = abortController ? abortController.signal : undefined;
-				const result = await mode.getResults( currentQuery, signal, tokens, activeModeContext.value );
-				const items = normalizeProviderResult( result );
-				if ( query.value === currentQuery && activeMode.value === mode ) {
-					displayedItems.value = items.length > 0 ?
-						[ { heading: null, items: items } ] : [];
-				}
-			} catch ( error ) {
-				if ( error.name !== 'AbortError' ) {
+			( async () => {
+				try {
+					const result = await mode.getResults(
+						'', undefined, tokens, activeModeContext.value
+					);
+					applyModeResults( mode, currentQuery, normalizeProviderResult( result ) );
+				} catch ( error ) {
 					mw.log.error(
 						'[commandPalette] Mode "' + mode.id + '" failed:', error
 					);
+				} finally {
 					if ( query.value === currentQuery && activeMode.value === mode ) {
-						displayedItems.value = [];
+						isPending.value = false;
 					}
 				}
-			} finally {
-				if ( query.value === currentQuery ) {
-					isPending.value = false;
-					showPending.value = false;
-					clearTimeout( pendingDelayTimeout );
-					pendingDelayTimeout = null;
+			} )();
+			return;
+		}
+
+		const isStale = () => query.value !== currentQuery || activeMode.value !== mode;
+		lifecycle.runDebouncedAbortable( {
+			debounceMs: mode.debounceMs ?? DEFAULT_DEBOUNCE_MS,
+			isStale,
+			run: ( signal ) => mode.getResults( currentQuery, signal, tokens, activeModeContext.value ),
+			onResult: ( result ) => applyModeResults( mode, currentQuery, normalizeProviderResult( result ) ),
+			onError: ( error ) => {
+				mw.log.error(
+					'[commandPalette] Mode "' + mode.id + '" failed:', error
+				);
+				if ( !isStale() ) {
+					displayedItems.value = [];
 				}
 			}
-		}, mode.debounceMs ?? 250 );
+		} );
 	}
 
 	/**

--- a/skin.json
+++ b/skin.json
@@ -343,6 +343,7 @@
 				"resources/skins.citizen.commandPalette/composables/useGalleryColumnCount.js",
 				"resources/skins.citizen.commandPalette/composables/useListNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useGridNavigation.js",
+				"resources/skins.citizen.commandPalette/composables/useOperationLifecycle.js",
 				"resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js",
 				"resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js",
 				"resources/skins.citizen.commandPalette/composables/useKeyboard.js",

--- a/tests/vitest/commandPalette/composables/useOperationLifecycle.test.js
+++ b/tests/vitest/commandPalette/composables/useOperationLifecycle.test.js
@@ -1,0 +1,337 @@
+// @vitest-environment jsdom
+
+const { ref } = require( 'vue' );
+
+const useOperationLifecycle = require(
+	'../../../../resources/skins.citizen.commandPalette/composables/useOperationLifecycle.js'
+);
+
+beforeEach( () => {
+	vi.useFakeTimers();
+} );
+
+afterEach( () => {
+	vi.useRealTimers();
+} );
+
+describe( 'useOperationLifecycle', () => {
+	describe( 'runDebouncedAbortable — happy path', () => {
+		it( 'sets isPending immediately and clears it on success', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			const onResult = vi.fn();
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run: () => Promise.resolve( [ { id: 1 } ] ),
+				onResult,
+				onError: vi.fn()
+			} );
+
+			expect( isPending.value ).toBe( true );
+
+			await vi.advanceTimersByTimeAsync( 100 );
+			
+
+			expect( onResult ).toHaveBeenCalledWith( [ { id: 1 } ] );
+			expect( isPending.value ).toBe( false );
+		} );
+
+		it( 'sets showPending after the configured delay if still pending', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( {
+				isPending,
+				showPending,
+				pendingDelayMs: 200
+			} );
+
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 1000,
+				isStale: () => false,
+				run: () => Promise.resolve( [] ),
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			expect( showPending.value ).toBe( false );
+			await vi.advanceTimersByTimeAsync( 200 );
+			expect( showPending.value ).toBe( true );
+
+			// Let the operation complete; showPending clears.
+			await vi.advanceTimersByTimeAsync( 1000 );
+			
+			expect( showPending.value ).toBe( false );
+		} );
+
+		it( 'does not set showPending if the operation finishes before the delay', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( {
+				isPending,
+				showPending,
+				pendingDelayMs: 500
+			} );
+
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run: () => Promise.resolve( [] ),
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			await vi.advanceTimersByTimeAsync( 100 );
+			
+
+			expect( showPending.value ).toBe( false );
+			// Even if the delay timer fires later, isPending is already false.
+			await vi.advanceTimersByTimeAsync( 500 );
+			expect( showPending.value ).toBe( false );
+		} );
+
+		it( 'passes the AbortSignal to the run function', () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			const run = vi.fn( () => Promise.resolve( [] ) );
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run,
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			vi.advanceTimersByTime( 100 );
+
+			const signal = run.mock.calls[ 0 ][ 0 ];
+			expect( signal ).toBeDefined();
+			expect( typeof signal.aborted ).toBe( 'boolean' );
+		} );
+	} );
+
+	describe( 'runDebouncedAbortable — staleness', () => {
+		it( 'short-circuits before running if isStale returns true', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			const run = vi.fn();
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => true,
+				run,
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			await vi.advanceTimersByTimeAsync( 100 );
+			
+
+			expect( run ).not.toHaveBeenCalled();
+			expect( isPending.value ).toBe( false );
+		} );
+
+		it( 'leaves isPending alone when the stale result is discarded — the spinner stays on for the operation that superseded us', async () => {
+			// Pins the contract: when isStale flips true after run resolves,
+			// the lifecycle does NOT clear isPending. The orchestrator only
+			// supersedes operations via reset() or a fresh
+			// runDebouncedAbortable, both of which manage isPending
+			// themselves. Clearing it here would flicker the spinner off
+			// between superseded and current operations.
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			let staleness = false;
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => staleness,
+				run: () => {
+					staleness = true;
+					return Promise.resolve( [] );
+				},
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			expect( isPending.value ).toBe( true );
+
+			await vi.advanceTimersByTimeAsync( 100 );
+
+			expect( isPending.value ).toBe( true );
+		} );
+
+		it( 'discards the result if isStale becomes true after run resolves', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			let staleness = false;
+			const onResult = vi.fn();
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => staleness,
+				run: () => {
+					// Simulate the world moving on while the request is in flight.
+					staleness = true;
+					return Promise.resolve( [ { id: 1 } ] );
+				},
+				onResult,
+				onError: vi.fn()
+			} );
+
+			await vi.advanceTimersByTimeAsync( 100 );
+			
+
+			expect( onResult ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'runDebouncedAbortable — abort', () => {
+		it( 'aborts a prior in-flight controller when a new operation starts', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			let firstSignal;
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run: ( signal ) => {
+					firstSignal = signal;
+					return new Promise( ( resolve ) => setTimeout( () => resolve( [] ), 1000 ) );
+				},
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			vi.advanceTimersByTime( 100 );
+			expect( firstSignal.aborted ).toBe( false );
+
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run: () => Promise.resolve( [] ),
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			expect( firstSignal.aborted ).toBe( true );
+		} );
+
+		it( 'silently swallows AbortError from the run function', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			const onError = vi.fn();
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run: () => {
+					const err = new Error( 'aborted' );
+					err.name = 'AbortError';
+					return Promise.reject( err );
+				},
+				onResult: vi.fn(),
+				onError
+			} );
+
+			await vi.advanceTimersByTimeAsync( 100 );
+			
+
+			expect( onError ).not.toHaveBeenCalled();
+		} );
+
+		it( 'invokes onError for non-AbortError exceptions', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			const onError = vi.fn();
+			const err = new Error( 'network unreachable' );
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run: () => Promise.reject( err ),
+				onResult: vi.fn(),
+				onError
+			} );
+
+			await vi.advanceTimersByTimeAsync( 100 );
+			
+
+			expect( onError ).toHaveBeenCalledWith( err );
+		} );
+	} );
+
+	describe( 'reset', () => {
+		it( 'clears pending flags and aborts the in-flight controller', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( {
+				isPending,
+				showPending,
+				pendingDelayMs: 200
+			} );
+
+			let signal;
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run: ( s ) => {
+					signal = s;
+					return new Promise( () => {} );
+				},
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			vi.advanceTimersByTime( 100 );
+			expect( isPending.value ).toBe( true );
+
+			lifecycle.reset();
+
+			expect( isPending.value ).toBe( false );
+			expect( showPending.value ).toBe( false );
+			expect( signal.aborted ).toBe( true );
+		} );
+
+		it( 'cancels a debounce timer that has not yet fired', async () => {
+			const isPending = ref( false );
+			const showPending = ref( false );
+			const lifecycle = useOperationLifecycle( { isPending, showPending } );
+
+			const run = vi.fn();
+			lifecycle.runDebouncedAbortable( {
+				debounceMs: 100,
+				isStale: () => false,
+				run,
+				onResult: vi.fn(),
+				onError: vi.fn()
+			} );
+
+			lifecycle.reset();
+			await vi.advanceTimersByTimeAsync( 200 );
+
+			expect( run ).not.toHaveBeenCalled();
+		} );
+
+		it( 'is idempotent — calling reset twice does not throw', () => {
+			const lifecycle = useOperationLifecycle( {
+				isPending: ref( false ),
+				showPending: ref( false )
+			} );
+
+			expect( () => {
+				lifecycle.reset();
+				lifecycle.reset();
+			} ).not.toThrow();
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

- Extracts the debounce + abort + pending coordination primitive from `useProviderOrchestration` into a new `useOperationLifecycle` composable.
- Eliminates ~40 lines of duplicated coordination machinery between `handleAsyncProvider` and the non-empty-query branch of `handleModeQuery`.
- Pure refactor — no behaviour changes, all dispatch semantics preserved.

## Why

`handleAsyncProvider` and `handleModeQuery` (non-empty branch) shared a copy-pasted ~40-line block that did the same thing with different argument lists: set isPending, schedule the show-pending delay, abort any prior controller, debounce-fire, check staleness, call getResults, set results if still current, swallow AbortError, log other errors, clear pending state.

This concurrency-coordination primitive is now isolated in a single unit-testable composable. Future async dispatch paths (e.g. a third subsystem with the same shape) can reuse it without re-deriving the abort/pending/staleness coordination.

## API

```js
const lifecycle = useOperationLifecycle( {
    isPending,        // ref<boolean>
    showPending,      // ref<boolean>
    pendingDelayMs    // optional, default 300
} );

lifecycle.runDebouncedAbortable( {
    debounceMs,       // delay before run() fires
    isStale,          // () => boolean
    run,              // (signal) => Promise<*>
    onResult,         // (result) => void — applied if !isStale()
    onError           // (error) => void — non-AbortError errors only
} );

lifecycle.reset();    // cancel everything, clear pending
```

The `isStale` predicate is supplied by the caller because staleness depends on the orchestrator's reactive state (`query.value`, `activeMode.value`) — the lifecycle is deliberately context-free.

## Tests

13 new tests for `useOperationLifecycle` covering:
- Happy path: isPending lifecycle, showPending delay, AbortSignal threading
- Staleness: pre-run short-circuit, post-resolve discard, isPending retention when superseded (the spinner-stays-on contract)
- Abort: prior controller aborted on new operation, AbortError swallowed, non-AbortError surfaced via onError
- reset(): cancels in-flight, clears pending, idempotent

Total: 860/860 passing, 0 lint errors. The existing `useProviderOrchestration` integration tests (`'should abort previous async request on new query'` etc.) continue to pass — the wiring at the call sites is unchanged in behaviour.

## Smoke test

Local wiki:
- Async provider dispatch: typed `main` → debounced fetch → 3 results, "Main Page" first.
- Mode dispatch: `@admin` → user mode (placeholder swap) → sub-query debounce → 1 user result.
- No new console errors.

## Test plan

- [x] `npm run preflight` — 860/860 tests, 0 lint errors
- [x] Manual smoke on local wiki — async provider + mode dispatch paths work end-to-end
- [x] `useProviderOrchestration` lines drop ~70 net (~129 lines of coordination machinery removed against ~67 lines of replacement)
- [x] No new ResourceLoader registration warnings (`useOperationLifecycle.js` registered before `useProviderOrchestration.js` in `skin.json` for load order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)