### PR TITLE
perf(commandPalette): make file mode load faster on file-heavy pages

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -225,20 +225,38 @@ module.exports = exports = defineComponent( {
 		// targets to widen the modal in gallery layouts.
 		const paletteLayout = computed( () => isGalleryLayout.value ? 'gallery' : 'list' );
 
-		const highlightedItemDetail = computed( () => {
+		const highlightedItem = computed( () => {
 			const index = listNav.highlightedIndex.value;
 			const items = orch.flatItems.value;
-			if ( index >= 0 && index < items.length ) {
-				const detail = items[ index ].detail;
-				if ( detail && (
-					( detail.pairs && detail.pairs.length ) ||
-					detail.header
-				) ) {
-					return detail;
-				}
+			return index >= 0 && index < items.length ? items[ index ] : null;
+		} );
+
+		const highlightedItemDetail = computed( () => {
+			const item = highlightedItem.value;
+			if ( !item ) {
+				return null;
+			}
+			const detail = item.detail;
+			if ( detail && (
+				( detail.pairs && detail.pairs.length ) ||
+				detail.header
+			) ) {
+				return detail;
 			}
 			return null;
 		} );
+
+		// Modes that opt in via `getItemDetail` (file mode, currently)
+		// fetch per-item detail lazily when an item is focused. The
+		// orchestration handles debounce, abort, and reactive mutation
+		// — App.vue just needs to call `requestItemDetail` whenever the
+		// highlighted item changes. `immediate: true` covers the case
+		// where the first item is auto-highlighted on initial render.
+		watch( highlightedItem, ( item ) => {
+			if ( item ) {
+				orch.requestItemDetail( item );
+			}
+		}, { immediate: true } );
 
 		// While help is open at root, the highlighted catalog row's source
 		// (e.g. "command:category") tells us which registered handler to

--- a/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
+++ b/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
@@ -4,6 +4,13 @@ const useOperationLifecycle = require( './useOperationLifecycle.js' );
 const SHOW_PENDING_DELAY_MS = 300;
 const DEFAULT_DEBOUNCE_MS = 250;
 
+// Per-item detail fetches fire on focus changes (arrow keys, hover).
+// Lower than the query debounce because the user expects detail to settle
+// faster than they expect search results, and aborts handle rapid
+// scrubbing — a settled focus of ~80ms is the threshold beyond which the
+// fetch is worth running.
+const DETAIL_DEBOUNCE_MS = 80;
+
 const DEFAULT_STATE_CONFIG = {
 	emptyState: {
 		title: mw.message( 'searchsuggest-search' ).text(),
@@ -78,6 +85,19 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		pendingDelayMs: SHOW_PENDING_DELAY_MS
 	} );
 	const resetOperationState = lifecycle.reset;
+
+	// Detail fetches run in their own abort domain so a focus change does
+	// not cancel an in-flight list fetch and a list refresh does not cancel
+	// a settled detail fetch. Pending state is internal — the UI today does
+	// not need a detail-specific spinner.
+	const detailPending = ref( false );
+	const detailShowPending = ref( false );
+	const detailLifecycle = useOperationLifecycle( {
+		isPending: detailPending,
+		showPending: detailShowPending,
+		pendingDelayMs: SHOW_PENDING_DELAY_MS
+	} );
+	const resetDetailState = detailLifecycle.reset;
 
 	/**
 	 * Applies the result decorator and updates displayedItems.
@@ -176,6 +196,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	async function clearSearch() {
 		query.value = '';
 		resetOperationState();
+		resetDetailState();
 
 		let recentItems = [];
 		if ( deps.recentItemsProvider ) {
@@ -282,6 +303,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	 */
 	function enterMode( mode ) {
 		resetOperationState();
+		resetDetailState();
 		activeMode.value = mode;
 		activeModeContext.value = [];
 		query.value = '';
@@ -297,6 +319,10 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	function exitMode() {
 		activeMode.value = null;
 		activeModeContext.value = [];
+		// clearSearch() also calls resetDetailState(), but the direct call
+		// here keeps exitMode's contract self-evident — every navigation
+		// function explicitly resets both lifecycles.
+		resetDetailState();
 		return clearSearch();
 	}
 
@@ -314,6 +340,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		}
 		activeModeContext.value = activeModeContext.value.concat( [ value ] );
 		resetOperationState();
+		resetDetailState();
 		query.value = '';
 		displayedItems.value = [];
 		handleModeQuery( activeMode.value, '' );
@@ -331,6 +358,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		}
 		activeModeContext.value = activeModeContext.value.slice( 0, -1 );
 		resetOperationState();
+		resetDetailState();
 		query.value = '';
 		displayedItems.value = [];
 		handleModeQuery( activeMode.value, '' );
@@ -344,6 +372,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	function updateQuery( newQuery ) {
 		query.value = newQuery;
 		resetOperationState();
+		resetDetailState();
 
 		// Help layers over the underlying state and owns displayedItems while
 		// visible. Skip the provider pipeline so input clears that fire after
@@ -466,6 +495,59 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	}
 
 	/**
+	 * Lazy-load detail data for a focused item. Modes that opt in by
+	 * declaring `getItemDetail` (validated by defineMode) get this hook
+	 * called when the highlighted item changes. The mode owns the API
+	 * call and any per-item caching; the orchestration provides debounce,
+	 * abort, and reactive mutation.
+	 *
+	 * On result, `item.detail.header.description` and `item.detail.pairs`
+	 * are mutated in place — Vue 3 deep reactivity propagates through
+	 * displayedItems so App.vue's highlightedItemDetail computed picks
+	 * up the new fields without explicit invalidation.
+	 *
+	 * `isStale` checks both the mode (rejects results from a mode swap)
+	 * and item identity in `flatItems` (rejects results for items that
+	 * have been replaced by a list refresh). A focus change to a new item
+	 * before this resolves aborts via the lifecycle on the next call.
+	 *
+	 * @param {Object} item Highlighted palette item.
+	 */
+	function requestItemDetail( item ) {
+		const mode = activeMode.value;
+		if ( !mode || typeof mode.getItemDetail !== 'function' || !item ) {
+			return;
+		}
+		const capturedItem = item;
+		const isStale = () => activeMode.value !== mode ||
+			!flatItems.value.includes( capturedItem );
+		detailLifecycle.runDebouncedAbortable( {
+			debounceMs: DETAIL_DEBOUNCE_MS,
+			isStale,
+			run: ( signal ) => mode.getItemDetail( capturedItem, signal ),
+			onResult: ( result ) => {
+				if ( !result || !capturedItem.detail ) {
+					return;
+				}
+				if ( !capturedItem.detail.header ) {
+					capturedItem.detail.header = {};
+				}
+				if ( result.description !== undefined ) {
+					capturedItem.detail.header.description = result.description;
+				}
+				if ( result.pairs !== undefined ) {
+					capturedItem.detail.pairs = result.pairs;
+				}
+			},
+			onError: ( error ) => {
+				mw.log.error(
+					'[commandPalette] Mode "' + mode.id + '" item detail failed:', error
+				);
+			}
+		} );
+	}
+
+	/**
 	 * Loads the registered-modes catalog into displayedItems so listNav can
 	 * navigate it. Only meaningful at root (no active mode).
 	 */
@@ -475,6 +557,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		}
 		const items = deps.getHelpCatalogItems() || [];
 		resetOperationState();
+		resetDetailState();
 		displayedItems.value = items.length > 0 ?
 			[ { heading: 'citizen-command-palette-help-section-modes', items: items } ] :
 			[];
@@ -498,6 +581,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		helpVisible.value = true;
 		if ( activeMode.value ) {
 			resetOperationState();
+			resetDetailState();
 			displayedItems.value = [];
 		} else {
 			loadHelpCatalog();
@@ -576,6 +660,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		openHelp,
 		closeHelp,
 		handleSelection,
+		requestItemDetail,
 		dismissRecentItem
 	};
 }

--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -250,12 +250,25 @@ function buildDetailPairs( info ) {
 }
 
 /**
- * Adapt one imageinfo response page to a CommandPaletteItem.
+ * Adapt one page entry to a list-stage gallery item.
+ *
+ * The list query intentionally requests only `iiprop=url|mediatype` —
+ * everything else (size, mime, extmetadata, user, timestamp) belongs to
+ * the detail panel and is fetched lazily by `getItemDetail` when the
+ * item is focused. Returning extmetadata for every file in the list
+ * costs ~80% of the response time and bandwidth, and we use exactly
+ * one field from it (LicenseShortName) — see the design doc for
+ * measurements against starcitizen.tools/Hull_B.
+ *
+ * `detail.header` is set immediately so the detail pane renders with
+ * filename + copy button as soon as the list arrives, without waiting
+ * for the per-item detail fetch. `detail.header.description` (friendly
+ * type) and `detail.pairs` are populated later by `getItemDetail`.
  *
  * @param {Object} page A page entry from `query.pages`
  * @return {Object|null} A palette item, or null when the page has no usable info
  */
-function adaptFileItem( page ) {
+function adaptListItem( page ) {
 	const info = page.imageinfo && page.imageinfo[ 0 ];
 	if ( !info ) {
 		return null;
@@ -274,21 +287,22 @@ function adaptFileItem( page ) {
 	return {
 		id: 'citizen-command-palette-item-file-' + page.pageid,
 		type: 'file',
+		// Carried so `getItemDetail` can request the focused file's
+		// detail by pageid without re-deriving it from the item id.
+		pageid: page.pageid,
+		// Carried so `getItemDetail` can build the friendly type label
+		// without re-requesting `mediatype` in the detail query — the
+		// list response already has it.
+		mediatype: mediatype,
 		label: label,
 		url: mw.util.getUrl( page.title ),
 		thumbnail: thumbnail,
 		thumbnailIcon: placeholderIcon,
-		// Drives the right pane. The header carries the filename and
-		// friendly type label (rendered as the subtitle); the pairs
-		// row carries the rest of the metadata. `copyValue` enables
-		// the detail panel's copy-filename button.
 		detail: {
 			header: {
 				label: label,
-				description: friendlyType( info.mime, mediatype ),
 				copyValue: label
-			},
-			pairs: buildDetailPairs( info )
+			}
 		}
 	};
 }
@@ -300,15 +314,40 @@ function adaptFileItem( page ) {
  * @return {Object} Mode descriptor.
  */
 function createFileMode( ApiConstructor ) {
-	const baseImageinfoParams = {
+	// List-stage params: enough to render a gallery tile (thumbnail URL,
+	// fallback icon via mediatype) and nothing else. Splitting the heavier
+	// fields out drops cold-cache response time from ~5.7 s to ~0.7 s on
+	// pages with many files.
+	const baseListImageinfoParams = {
 		action: 'query',
 		format: 'json',
 		prop: 'imageinfo',
-		iiprop: 'url|size|mime|mediatype|extmetadata|user|timestamp',
+		iiprop: 'url|mediatype',
 		iiurlwidth: THUMB_WIDTH,
 		maxage: config.wgSearchSuggestCacheExpiry,
 		smaxage: config.wgSearchSuggestCacheExpiry
 	};
+
+	// Detail-stage params: everything the right-pane renders. Filtered
+	// to LicenseShortName because that's the only extmetadata field we
+	// surface today; widening the filter is a follow-up if/when more
+	// detail-panel fields are added.
+	const detailImageinfoParams = {
+		action: 'query',
+		format: 'json',
+		prop: 'imageinfo',
+		iiprop: 'size|mime|extmetadata|user|timestamp',
+		iiextmetadatafilter: 'LicenseShortName',
+		maxage: config.wgSearchSuggestCacheExpiry,
+		smaxage: config.wgSearchSuggestCacheExpiry
+	};
+
+	// Per-pageid cache for detail data. Lives for the page lifetime
+	// (the mode factory is called once per palette init). Re-focusing a
+	// previously focused item returns the cached value synchronously
+	// rather than re-firing the API. Not persisted to mw.storage so
+	// file-overwrite / re-licensing changes show up after a reload.
+	const detailCache = new Map();
 
 	/**
 	 * Run an API query and return its `query.pages` array sorted by
@@ -335,7 +374,7 @@ function createFileMode( ApiConstructor ) {
 	}
 
 	function fetchFilesByPrefix( subQuery, signal ) {
-		return queryPages( Object.assign( {}, baseImageinfoParams, {
+		return queryPages( Object.assign( {}, baseListImageinfoParams, {
 			generator: 'prefixsearch',
 			gpssearch: subQuery,
 			gpsnamespace: FILE_NAMESPACE,
@@ -344,7 +383,7 @@ function createFileMode( ApiConstructor ) {
 	}
 
 	function fetchFilesByFullText( subQuery, signal ) {
-		return queryPages( Object.assign( {}, baseImageinfoParams, {
+		return queryPages( Object.assign( {}, baseListImageinfoParams, {
 			generator: 'search',
 			gsrsearch: subQuery,
 			gsrnamespace: FILE_NAMESPACE,
@@ -367,7 +406,7 @@ function createFileMode( ApiConstructor ) {
 			return Promise.resolve( [] );
 		}
 		const title = mw.config.get( 'wgPageName' );
-		return queryPages( Object.assign( {}, baseImageinfoParams, {
+		return queryPages( Object.assign( {}, baseListImageinfoParams, {
 			generator: 'images',
 			titles: title,
 			gimlimit: RESULT_LIMIT
@@ -377,12 +416,68 @@ function createFileMode( ApiConstructor ) {
 	function pagesToItems( pages ) {
 		const items = [];
 		pages.forEach( ( page ) => {
-			const item = adaptFileItem( page );
+			const item = adaptListItem( page );
 			if ( item ) {
 				items.push( item );
 			}
 		} );
 		return items;
+	}
+
+	/**
+	 * Lazy-load detail data for a focused file item. Called by the
+	 * orchestration when the highlighted item changes.
+	 *
+	 * Returns `{ description, pairs }` for the item's detail panel:
+	 * `description` is the friendly type label (rendered as the header
+	 * subtitle), `pairs` is the size / uploaded / license rows. The
+	 * orchestration mutates the item's `detail` reactively when this
+	 * resolves.
+	 *
+	 * Caches per pageid for the page lifetime. Aborted fetches do not
+	 * write to the cache (the rejection bypasses `cache.set`). An empty
+	 * or malformed response caches the empty default to prevent a
+	 * retry loop on a permanently broken file.
+	 *
+	 * @param {Object} item Palette item produced by `adaptListItem`.
+	 * @param {AbortSignal} [signal]
+	 * @return {Promise<{description: string, pairs: Array<Object>}>}
+	 */
+	async function getItemDetail( item, signal ) {
+		const pageid = item && item.pageid;
+		if ( !pageid ) {
+			return { description: '', pairs: [] };
+		}
+		if ( detailCache.has( pageid ) ) {
+			return detailCache.get( pageid );
+		}
+
+		const api = new ApiConstructor();
+		const data = await api.get(
+			Object.assign( {}, detailImageinfoParams, { pageids: pageid } ),
+			{ signal }
+		);
+
+		const pages = ( data && data.query && data.query.pages ) || {};
+		// Read by exact pageid only. A missing file lands under a synthetic
+		// negative key with no imageinfo — `pages[ pageid ]` returns
+		// undefined and the empty default below covers that case. A
+		// `pages` map with multiple entries is not expected for a
+		// `pageids=N` query, and falling back to `Object.values()[ 0 ]`
+		// would risk caching another file's metadata under this pageid.
+		const page = pages[ pageid ];
+		const info = page && page.imageinfo && page.imageinfo[ 0 ];
+		// `mediatype` is carried over from the list-stage item so the
+		// detail query stays narrow — re-requesting it would cost nothing
+		// over the wire but adds a field to a query that's intentionally
+		// minimal.
+		const detail = info ? {
+			description: friendlyType( info.mime, item.mediatype || 'UNKNOWN' ),
+			pairs: buildDetailPairs( info )
+		} : { description: '', pairs: [] };
+
+		detailCache.set( pageid, detail );
+		return detail;
 	}
 
 	async function getResults( subQuery, signal ) {
@@ -439,6 +534,7 @@ function createFileMode( ApiConstructor ) {
 			description: 'citizen-command-palette-mode-file-description-help'
 		},
 		getResults,
+		getItemDetail,
 		onResultSelect
 	} );
 }

--- a/resources/skins.citizen.commandPalette/services/defineMode.js
+++ b/resources/skins.citizen.commandPalette/services/defineMode.js
@@ -38,6 +38,7 @@ const MODE_FIELDS = COMMON_FIELDS.concat( [
 	'noResults',
 	'tokenPattern',
 	'getResults',
+	'getItemDetail',
 	'headerLabel'
 ] );
 
@@ -146,6 +147,13 @@ function applyOptionalFieldChecks( config ) {
 			`[commandPalette] mode "${ out.id }" \`keybindings\` must be an array. Dropping the field.`
 		);
 		delete out.keybindings;
+	}
+
+	if ( out.getItemDetail !== undefined && typeof out.getItemDetail !== 'function' ) {
+		mw.log.warn(
+			`[commandPalette] mode "${ out.id }" \`getItemDetail\` must be a function. Dropping the field.`
+		);
+		delete out.getItemDetail;
 	}
 
 	if (

--- a/tests/vitest/commandPalette/composables/useProviderOrchestration.test.js
+++ b/tests/vitest/commandPalette/composables/useProviderOrchestration.test.js
@@ -589,4 +589,218 @@ describe( 'useProviderOrchestration', () => {
 			] );
 		} );
 	} );
+
+	describe( 'requestItemDetail', () => {
+		// Build a mode with a getItemDetail mock and pre-load it as activeMode
+		// with a known list of items in displayedItems.
+		function setupModeWithItems( items, getItemDetailImpl ) {
+			const mode = {
+				id: 'file',
+				getResults: vi.fn().mockResolvedValue( items ),
+				getItemDetail: vi.fn( getItemDetailImpl )
+			};
+			const orch = useProviderOrchestration(
+				[ mockSyncProvider ], mockDecorator
+			);
+			orch.enterMode( mode );
+			return { orch, mode };
+		}
+
+		it( 'is a no-op when there is no active mode', () => {
+			const orch = useProviderOrchestration(
+				[ mockSyncProvider ], mockDecorator
+			);
+
+			expect( () => orch.requestItemDetail( { id: '1' } ) ).not.toThrow();
+		} );
+
+		it( 'is a no-op when the active mode does not declare getItemDetail', () => {
+			const mode = {
+				id: 'plain',
+				getResults: vi.fn().mockResolvedValue( [] )
+			};
+			const orch = useProviderOrchestration(
+				[ mockSyncProvider ], mockDecorator
+			);
+			orch.enterMode( mode );
+
+			expect( () => orch.requestItemDetail( { id: '1' } ) ).not.toThrow();
+		} );
+
+		it( 'is a no-op when item is null/undefined', () => {
+			const { orch, mode } = setupModeWithItems(
+				[ { id: '1', detail: { header: {} } } ],
+				() => Promise.resolve( { description: 'x', pairs: [] } )
+			);
+
+			orch.requestItemDetail( null );
+			vi.advanceTimersByTime( 100 );
+
+			expect( mode.getItemDetail ).not.toHaveBeenCalled();
+		} );
+
+		it( 'calls mode.getItemDetail after the detail debounce and mutates item.detail', async () => {
+			const { orch, mode } = setupModeWithItems(
+				[ { id: '1', detail: { header: { label: 'F' } } } ],
+				() => Promise.resolve( {
+					description: 'PNG image',
+					pairs: [ { key: 'size', label: 'Size', value: '1 KB' } ]
+				} )
+			);
+			await vi.runAllTimersAsync();
+			// App.vue passes the live (proxied) item from flatItems; doing
+			// the same here ensures the staleness identity check matches.
+			const item = orch.flatItems.value[ 0 ];
+
+			orch.requestItemDetail( item );
+			expect( mode.getItemDetail ).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime( 80 );
+			await vi.runAllTimersAsync();
+
+			expect( mode.getItemDetail ).toHaveBeenCalledTimes( 1 );
+			expect( mode.getItemDetail ).toHaveBeenCalledWith( item, expect.any( AbortSignal ) );
+			expect( item.detail.header.description ).toBe( 'PNG image' );
+			expect( item.detail.pairs ).toEqual( [
+				{ key: 'size', label: 'Size', value: '1 KB' }
+			] );
+		} );
+
+		it( 'aborts a prior in-flight detail fetch when called again with a different item', async () => {
+			const seenSignals = [];
+			const { orch, mode } = setupModeWithItems(
+				[
+					{ id: '1', detail: { header: {} } },
+					{ id: '2', detail: { header: {} } }
+				],
+				( _item, signal ) => {
+					seenSignals.push( signal );
+					// Resolve only the second call; leave the first hanging until aborted.
+					return seenSignals.length === 1 ?
+						new Promise( () => {} ) :
+						Promise.resolve( { description: 'd', pairs: [] } );
+				}
+			);
+			await vi.runAllTimersAsync();
+			const item1 = orch.flatItems.value[ 0 ];
+			const item2 = orch.flatItems.value[ 1 ];
+
+			orch.requestItemDetail( item1 );
+			vi.advanceTimersByTime( 80 );
+			await vi.runAllTimersAsync();
+
+			orch.requestItemDetail( item2 );
+			vi.advanceTimersByTime( 80 );
+			await vi.runAllTimersAsync();
+
+			expect( mode.getItemDetail ).toHaveBeenCalledTimes( 2 );
+			expect( seenSignals[ 0 ].aborted ).toBe( true );
+			expect( seenSignals[ 1 ].aborted ).toBe( false );
+		} );
+
+		it( 'drops a stale result when the item has been replaced in flatItems', async () => {
+			let resolveDetail;
+			const orch = useProviderOrchestration(
+				[ mockSyncProvider ], mockDecorator
+			);
+			const mode = {
+				id: 'file',
+				getResults: vi.fn().mockResolvedValue( [
+					{ id: 'a', detail: { header: {} } }
+				] ),
+				getItemDetail: vi.fn( () => new Promise( ( resolve ) => {
+					resolveDetail = resolve;
+				} ) )
+			};
+			orch.enterMode( mode );
+			await vi.runAllTimersAsync();
+
+			const captured = orch.flatItems.value[ 0 ];
+			orch.requestItemDetail( captured );
+			vi.advanceTimersByTime( 80 );
+			await vi.runAllTimersAsync();
+
+			// Replace the items array (simulates a list refresh from a new query).
+			mode.getResults.mockResolvedValueOnce( [
+				{ id: 'b', detail: { header: {} } }
+			] );
+			orch.updateQuery( 'b' );
+			vi.advanceTimersByTime( 250 );
+			await vi.runAllTimersAsync();
+
+			// updateQuery's resetDetailState() aborts the in-flight signal,
+			// so the lifecycle's finally block already cleared it. The
+			// resolution we trigger here arrives at a no-op onResult because
+			// isStale is true (captured no longer in flatItems).
+			resolveDetail( { description: 'late', pairs: [ { key: 'k', label: 'L', value: 'V' } ] } );
+			await vi.runAllTimersAsync();
+
+			expect( captured.detail.header.description ).toBeUndefined();
+			expect( captured.detail.pairs ).toBeUndefined();
+		} );
+
+		it( 'enterMode resets the detail lifecycle (aborts in-flight fetch)', async () => {
+			let seenSignal;
+			const { orch, mode } = setupModeWithItems(
+				[ { id: '1', detail: { header: {} } } ],
+				( _item, signal ) => {
+					seenSignal = signal;
+					return new Promise( () => {} ); // never resolves
+				}
+			);
+			await vi.runAllTimersAsync();
+			const item = orch.flatItems.value[ 0 ];
+
+			orch.requestItemDetail( item );
+			vi.advanceTimersByTime( 80 );
+			await vi.runAllTimersAsync();
+
+			expect( seenSignal.aborted ).toBe( false );
+
+			orch.enterMode( Object.assign( {}, mode, { id: 'other' } ) );
+
+			expect( seenSignal.aborted ).toBe( true );
+		} );
+
+		it( 'exitMode resets the detail lifecycle (aborts in-flight fetch)', async () => {
+			let seenSignal;
+			const { orch } = setupModeWithItems(
+				[ { id: '1', detail: { header: {} } } ],
+				( _item, signal ) => {
+					seenSignal = signal;
+					return new Promise( () => {} );
+				}
+			);
+			await vi.runAllTimersAsync();
+			const item = orch.flatItems.value[ 0 ];
+
+			orch.requestItemDetail( item );
+			vi.advanceTimersByTime( 80 );
+			await vi.runAllTimersAsync();
+
+			expect( seenSignal.aborted ).toBe( false );
+
+			orch.exitMode();
+
+			expect( seenSignal.aborted ).toBe( true );
+		} );
+
+		it( 'logs and leaves item.detail untouched when getItemDetail rejects', async () => {
+			mw.log.error.mockClear();
+			const { orch } = setupModeWithItems(
+				[ { id: '1', detail: { header: { label: 'F' } } } ],
+				() => Promise.reject( new Error( 'boom' ) )
+			);
+			await vi.runAllTimersAsync();
+			const item = orch.flatItems.value[ 0 ];
+
+			orch.requestItemDetail( item );
+			vi.advanceTimersByTime( 80 );
+			await vi.runAllTimersAsync();
+
+			expect( mw.log.error ).toHaveBeenCalled();
+			expect( item.detail.header.description ).toBeUndefined();
+			expect( item.detail.pairs ).toBeUndefined();
+		} );
+	} );
 } );

--- a/tests/vitest/commandPalette/modes/file.test.js
+++ b/tests/vitest/commandPalette/modes/file.test.js
@@ -165,7 +165,9 @@ describe( 'file mode', () => {
 			expect( params.gpsnamespace ).toBe( 6 );
 			expect( params.gpslimit ).toBe( 50 );
 			expect( params.prop ).toBe( 'imageinfo' );
-			expect( params.iiprop ).toBe( 'url|size|mime|mediatype|extmetadata|user|timestamp' );
+			// The list-stage iiprop is intentionally minimal — heavier fields
+			// (extmetadata, size, mime, user, timestamp) move to getItemDetail.
+			expect( params.iiprop ).toBe( 'url|mediatype' );
 			expect( params.iiurlwidth ).toBe( 300 );
 		} );
 
@@ -230,6 +232,22 @@ describe( 'file mode', () => {
 			expect( result.every( ( r ) => r.type === 'file' ) ).toBe( true );
 		} );
 
+		it( 'carries pageid on each item so getItemDetail can request it', async () => {
+			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
+
+			const result = await mode.getResults( 'thing', undefined );
+
+			expect( result.map( ( r ) => r.pageid ) ).toEqual( [ 100, 101, 102 ] );
+		} );
+
+		it( 'carries mediatype on each item so getItemDetail can derive friendly type', async () => {
+			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
+
+			const result = await mode.getResults( 'thing', undefined );
+
+			expect( result.map( ( r ) => r.mediatype ) ).toEqual( [ 'BITMAP', 'AUDIO', 'OFFICE' ] );
+		} );
+
 		it( 'strips the File: prefix from the displayed label', async () => {
 			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
 
@@ -263,122 +281,18 @@ describe( 'file mode', () => {
 			expect( audio ).toHaveProperty( 'thumbnailIcon' );
 		} );
 
-		it( 'builds detail.pairs for size, uploaded, license (type lives in the header)', async () => {
-			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
-
-			const [ first ] = await mode.getResults( 'thing', undefined );
-
-			const keys = first.detail.pairs.map( ( p ) => p.key );
-			expect( keys ).not.toContain( 'type' );
-			expect( keys ).toContain( 'size' );
-			expect( keys ).toContain( 'uploaded' );
-			expect( keys ).toContain( 'license' );
-		} );
-
-		it( 'builds detail.header with filename, friendly type, and copyValue', async () => {
+		it( 'builds a list-stage detail.header with filename + copyValue only (no description, no pairs)', async () => {
 			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
 
 			const result = await mode.getResults( 'thing', undefined );
 
 			const bitmap = result.find( ( r ) => r.label === 'Diagram.png' );
-			const audio = result.find( ( r ) => r.label === 'Lecture.mp3' );
 
 			expect( bitmap.detail.header.label ).toBe( 'Diagram.png' );
-			expect( bitmap.detail.header.description ).toBe( 'PNG image' );
 			expect( bitmap.detail.header.copyValue ).toBe( 'Diagram.png' );
-
-			expect( audio.detail.header.label ).toBe( 'Lecture.mp3' );
-			expect( audio.detail.header.description ).toBe( 'MPEG audio' );
-			expect( audio.detail.header.copyValue ).toBe( 'Lecture.mp3' );
-		} );
-
-		it( 'formats size as "<dim> × <dim>, <bytes>" for visual files', async () => {
-			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
-
-			const [ first ] = await mode.getResults( 'thing', undefined );
-
-			const sizePair = first.detail.pairs.find( ( p ) => p.key === 'size' );
-			expect( sizePair.value ).toContain( '1280 × 960' );
-			expect( sizePair.value ).toMatch( /KB|MB/ );
-		} );
-
-		it( 'formats size as bytes-only for non-visual files', async () => {
-			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
-
-			const result = await mode.getResults( 'thing', undefined );
-
-			const audio = result.find( ( r ) => r.label === 'Lecture.mp3' );
-			const sizePair = audio.detail.pairs.find( ( p ) => p.key === 'size' );
-			expect( sizePair.value ).not.toContain( '×' );
-			expect( sizePair.value ).toMatch( /MB$/ );
-		} );
-
-		it( 'omits the license pair when extmetadata.LicenseShortName is missing', async () => {
-			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
-
-			const result = await mode.getResults( 'thing', undefined );
-
-			const audio = result.find( ( r ) => r.label === 'Lecture.mp3' );
-			const licensePair = audio.detail.pairs.find( ( p ) => p.key === 'license' );
-			expect( licensePair ).toBeUndefined();
-		} );
-
-		it( 'derives a friendly type label from mime + mediatype (rendered as header subtitle)', async () => {
-			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
-
-			const result = await mode.getResults( 'thing', undefined );
-
-			const bitmap = result.find( ( r ) => r.label === 'Diagram.png' );
-			const audio = result.find( ( r ) => r.label === 'Lecture.mp3' );
-			const office = result.find( ( r ) => r.label === 'Manual.pdf' );
-
-			expect( bitmap.detail.header.description ).toBe( 'PNG image' );
-			expect( audio.detail.header.description ).toBe( 'MPEG audio' );
-			expect( office.detail.header.description ).toBe( 'PDF document' );
-		} );
-
-		it( 'preserves brand casing for WebM and WebP subtypes', async () => {
-			const pages = {
-				1: {
-					pageid: 1,
-					ns: 6,
-					title: 'File:Demo.webm',
-					index: 1,
-					imageinfo: [ {
-						url: '/wiki/File:Demo.webm',
-						size: 25000,
-						width: 320,
-						height: 240,
-						mime: 'video/webm',
-						mediatype: 'VIDEO',
-						extmetadata: {}
-					} ]
-				},
-				2: {
-					pageid: 2,
-					ns: 6,
-					title: 'File:Photo.webp',
-					index: 2,
-					imageinfo: [ {
-						url: '/wiki/File:Photo.webp',
-						thumburl: '/thumb/Photo.webp',
-						thumbwidth: 300, thumbheight: 200,
-						size: 50000,
-						width: 1024, height: 768,
-						mime: 'image/webp',
-						mediatype: 'BITMAP',
-						extmetadata: {}
-					} ]
-				}
-			};
-			mockGet.mockResolvedValue( { query: { pages } } );
-
-			const result = await mode.getResults( 'demo', undefined );
-
-			const webm = result.find( ( r ) => r.label === 'Demo.webm' );
-			const webp = result.find( ( r ) => r.label === 'Photo.webp' );
-			expect( webm.detail.header.description ).toBe( 'WebM video' );
-			expect( webp.detail.header.description ).toBe( 'WebP image' );
+			// Description and pairs are populated lazily by getItemDetail.
+			expect( bitmap.detail.header.description ).toBeUndefined();
+			expect( bitmap.detail.pairs ).toBeUndefined();
 		} );
 
 		it( 'sets url to the File: page URL', async () => {
@@ -399,6 +313,157 @@ describe( 'file mode', () => {
 			const result = await mode.getResults( 'thing', undefined );
 
 			expect( result ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'getItemDetail', () => {
+		// Mirrors what `adaptListItem` produces from the list query: pageid
+		// plus mediatype carried over so the detail query doesn't need to
+		// re-request `mediatype`.
+		const ITEM_100 = { pageid: 100, mediatype: 'BITMAP' };
+		const ITEM_101 = { pageid: 101, mediatype: 'AUDIO' };
+		const ITEM_102 = { pageid: 102, mediatype: 'OFFICE' };
+
+		it( 'requests imageinfo by pageid with the heavy fields and a license filter', async () => {
+			mockGet.mockResolvedValue( { query: { pages: { 100: SAMPLE_PAGES[ 100 ] } } } );
+
+			await mode.getItemDetail( ITEM_100, undefined );
+
+			expect( mockGet ).toHaveBeenCalledTimes( 1 );
+			const params = mockGet.mock.calls[ 0 ][ 0 ];
+			expect( params.action ).toBe( 'query' );
+			expect( params.prop ).toBe( 'imageinfo' );
+			expect( params.pageids ).toBe( 100 );
+			expect( params.iiprop ).toBe( 'size|mime|extmetadata|user|timestamp' );
+			expect( params.iiextmetadatafilter ).toBe( 'LicenseShortName' );
+		} );
+
+		it( 'returns description (friendly type) and pairs (size, uploaded, license)', async () => {
+			mockGet.mockResolvedValue( { query: { pages: { 100: SAMPLE_PAGES[ 100 ] } } } );
+
+			const detail = await mode.getItemDetail( ITEM_100, undefined );
+
+			expect( detail.description ).toBe( 'PNG image' );
+			const keys = detail.pairs.map( ( p ) => p.key );
+			expect( keys ).toEqual( [ 'size', 'uploaded', 'license' ] );
+		} );
+
+		it( 'formats the size pair as "<dim> × <dim>, <bytes>" for visual files', async () => {
+			mockGet.mockResolvedValue( { query: { pages: { 100: SAMPLE_PAGES[ 100 ] } } } );
+
+			const detail = await mode.getItemDetail( ITEM_100, undefined );
+
+			const sizePair = detail.pairs.find( ( p ) => p.key === 'size' );
+			expect( sizePair.value ).toContain( '1280 × 960' );
+			expect( sizePair.value ).toMatch( /KB|MB/ );
+		} );
+
+		it( 'formats the size pair as bytes-only for non-visual files', async () => {
+			mockGet.mockResolvedValue( { query: { pages: { 101: SAMPLE_PAGES[ 101 ] } } } );
+
+			const detail = await mode.getItemDetail( ITEM_101, undefined );
+
+			const sizePair = detail.pairs.find( ( p ) => p.key === 'size' );
+			expect( sizePair.value ).not.toContain( '×' );
+			expect( sizePair.value ).toMatch( /MB$/ );
+		} );
+
+		it( 'omits the license pair when extmetadata.LicenseShortName is missing', async () => {
+			mockGet.mockResolvedValue( { query: { pages: { 101: SAMPLE_PAGES[ 101 ] } } } );
+
+			const detail = await mode.getItemDetail( ITEM_101, undefined );
+
+			expect( detail.pairs.find( ( p ) => p.key === 'license' ) ).toBeUndefined();
+		} );
+
+		it( 'derives the friendly type label from mime + mediatype', async () => {
+			mockGet.mockResolvedValueOnce( { query: { pages: { 101: SAMPLE_PAGES[ 101 ] } } } );
+			const audio = await mode.getItemDetail( ITEM_101, undefined );
+			expect( audio.description ).toBe( 'MPEG audio' );
+
+			mockGet.mockResolvedValueOnce( { query: { pages: { 102: SAMPLE_PAGES[ 102 ] } } } );
+			const office = await mode.getItemDetail( ITEM_102, undefined );
+			expect( office.description ).toBe( 'PDF document' );
+		} );
+
+		it( 'preserves brand casing for WebM and WebP subtypes', async () => {
+			const webmPage = {
+				pageid: 1,
+				title: 'File:Demo.webm',
+				imageinfo: [ {
+					size: 25000, width: 320, height: 240,
+					mime: 'video/webm', mediatype: 'VIDEO', extmetadata: {}
+				} ]
+			};
+			const webpPage = {
+				pageid: 2,
+				title: 'File:Photo.webp',
+				imageinfo: [ {
+					size: 50000, width: 1024, height: 768,
+					mime: 'image/webp', mediatype: 'BITMAP', extmetadata: {}
+				} ]
+			};
+			mockGet.mockResolvedValueOnce( { query: { pages: { 1: webmPage } } } );
+			mockGet.mockResolvedValueOnce( { query: { pages: { 2: webpPage } } } );
+
+			const webm = await mode.getItemDetail( { pageid: 1, mediatype: 'VIDEO' }, undefined );
+			const webp = await mode.getItemDetail( { pageid: 2, mediatype: 'BITMAP' }, undefined );
+
+			expect( webm.description ).toBe( 'WebM video' );
+			expect( webp.description ).toBe( 'WebP image' );
+		} );
+
+		it( 'caches by pageid: a second call for the same item does not hit the API', async () => {
+			mockGet.mockResolvedValue( { query: { pages: { 100: SAMPLE_PAGES[ 100 ] } } } );
+
+			const first = await mode.getItemDetail( ITEM_100, undefined );
+			const second = await mode.getItemDetail( ITEM_100, undefined );
+
+			expect( mockGet ).toHaveBeenCalledTimes( 1 );
+			expect( second ).toBe( first );
+		} );
+
+		it( 'caches an empty default when the response has no imageinfo (prevents retry loops)', async () => {
+			mockGet.mockResolvedValueOnce( { query: { pages: {} } } );
+
+			const detail = await mode.getItemDetail( ITEM_100, undefined );
+			expect( detail ).toEqual( { description: '', pairs: [] } );
+
+			mockGet.mockClear();
+			const cached = await mode.getItemDetail( ITEM_100, undefined );
+			expect( mockGet ).not.toHaveBeenCalled();
+			expect( cached ).toEqual( { description: '', pairs: [] } );
+		} );
+
+		it( 'returns the empty default and skips the API when item has no pageid', async () => {
+			const detail = await mode.getItemDetail( {}, undefined );
+
+			expect( detail ).toEqual( { description: '', pairs: [] } );
+			expect( mockGet ).not.toHaveBeenCalled();
+		} );
+
+		it( 'propagates AbortError without writing to the cache', async () => {
+			const abortErr = new Error( 'aborted' );
+			abortErr.name = 'AbortError';
+			mockGet.mockRejectedValueOnce( abortErr );
+
+			await expect( mode.getItemDetail( ITEM_100, undefined ) ).rejects.toBe( abortErr );
+
+			// A subsequent call still hits the API — the abort did not poison the cache.
+			mockGet.mockResolvedValueOnce( { query: { pages: { 100: SAMPLE_PAGES[ 100 ] } } } );
+			const detail = await mode.getItemDetail( ITEM_100, undefined );
+			expect( detail.description ).toBe( 'PNG image' );
+			expect( mockGet ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'threads the abort signal through to the API call', async () => {
+			mockGet.mockResolvedValue( { query: { pages: { 100: SAMPLE_PAGES[ 100 ] } } } );
+			const signal = new AbortController().signal;
+
+			await mode.getItemDetail( ITEM_100, signal );
+
+			const options = mockGet.mock.calls[ 0 ][ 1 ];
+			expect( options.signal ).toBe( signal );
 		} );
 	} );
 

--- a/tests/vitest/commandPalette/services/defineMode.test.js
+++ b/tests/vitest/commandPalette/services/defineMode.test.js
@@ -156,6 +156,20 @@ describe( 'defineMode', () => {
 			expect( result.keybindings ).toBe( bindings );
 		} );
 
+		it( 'warns and drops getItemDetail when not a function', () => {
+			const result = defineMode( Object.assign( {}, VALID_MODE, { getItemDetail: 'oops' } ) );
+
+			expect( result.getItemDetail ).toBeUndefined();
+			expect( mw.log.warn ).toHaveBeenCalled();
+		} );
+
+		it( 'preserves valid getItemDetail as-is', () => {
+			const fn = async () => ( { description: '', pairs: [] } );
+			const result = defineMode( Object.assign( {}, VALID_MODE, { getItemDetail: fn } ) );
+
+			expect( result.getItemDetail ).toBe( fn );
+		} );
+
 		it( 'warns and drops tokenPattern when not an object/array', () => {
 			const result = defineMode( Object.assign( {}, VALID_MODE, { tokenPattern: 'oops' } ) );
 


### PR DESCRIPTION
## Summary

- File mode's list query is slimmed from `iiprop=url|size|mime|mediatype|extmetadata|user|timestamp` to `iiprop=url|mediatype` — only what the gallery tile needs. The `extmetadata` bag dominates the response time and we use exactly one field from it (`LicenseShortName`).
- Per-item detail (size, mime, license, uploader, timestamp) is fetched lazily for the focused item via a new optional mode capability, `getItemDetail( item, signal )`. Re-focusing a previously focused item is a cache hit, no network request.
- Measured against `https://starcitizen.tools/Hull_B` (50 files, hits the `gimlimit`):
  - Cold cache: **5.71 s → ~0.7 s** (~8×), payload **124 KB → ~46 KB**.
  - Warm CF edge cache: same TTFB, but the 60% smaller list payload still helps on slow connections.

## How it fits together

- `defineMode` learns an optional `getItemDetail` field with the standard validate-or-warn-and-drop treatment.
- `useProviderOrchestration` gains a second `useOperationLifecycle` instance dedicated to detail fetches (separate abort domain from the list lifecycle), plus a `requestItemDetail( item )` method. The detail lifecycle is reset alongside the main lifecycle in every navigation function (`enterMode`, `exitMode`, `pushModeContext`, `popModeContext`, `updateQuery`, `clearSearch`, `loadHelpCatalog`, `openHelp`).
- `App.vue` watches the highlighted item identity and calls `orch.requestItemDetail` whenever the focused item changes, including on initial mount when the first item auto-highlights.
- The file mode keeps a `Map<pageid, detail>` so re-focusing returns synchronously.

## Out of scope (separate PRs)

- Widening the detail query to surface more `extmetadata` fields (description, artist, attribution).
- `gimlimit` reduction.
- Image-side optimisations (`loading=\"lazy\"`, DPR-aware thumbnail width).
- Mitigations for `Vary: Cookie` browser-cache fragmentation.

## Test plan

- [x] `npm run preflight` passes (879/879 tests, 0 lint errors).
- [x] Unit tests cover the new contract: `defineMode` validation, `file` mode list-query slim + `getItemDetail` (request shape, parse, cache hit, abort propagation, empty/missing response, signal threading), orchestration `requestItemDetail` (no-op paths, debounce, mutation, abort, stale result, mode-swap reset, exitMode reset).
- [x] Smoke-tested on a local content page with 4 files: list query fires with `iiprop=url|mediatype`, detail fetch fires for the auto-highlighted first item, arrowing through items triggers per-item detail fetches, re-focusing hits the cache, detail panel shows correct friendly type labels (`JPEG image` / `WebP image` / `MPEG audio`).
- [x] No new console warnings/errors.
- [x] No `v-html` introduced in the rendering path; all i18n and API-derived strings flow through Vue `{{ }}` interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command palette now loads item details on-demand as you navigate through results, improving responsiveness and reducing initial load times.
  * File search results appear faster with full metadata available after selecting or focusing on an item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->