### PR TITLE
perf(commandPalette): lazy-load gallery thumbnails and size them by DPR

### DIFF
--- a/resources/skins.citizen.commandPalette/components/CommandPaletteGalleryItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteGalleryItem.vue
@@ -15,24 +15,48 @@
 		@mousedown.prevent="onMouseDown"
 		@click="onClick"
 	>
-		<cdx-thumbnail
-			:thumbnail="thumbnail"
-			:placeholder-icon="thumbnailIcon || undefined"
-			class="citizen-command-palette-gallery-item__thumbnail"
-		></cdx-thumbnail>
+		<span class="citizen-command-palette-gallery-item__thumbnail">
+			<!--
+				Native <img> with `loading="lazy"` and `decoding="async"`
+				so the browser schedules thumbnail fetches on its own —
+				the gallery can render up to 50 tiles at once.
+				CdxImage is the right Codex equivalent but isn't
+				available in MW 1.43; switch to it on the next LTS.
+			-->
+			<img
+				v-if="thumbnail"
+				:src="thumbnail.url"
+				:width="thumbnail.width"
+				:height="thumbnail.height"
+				loading="lazy"
+				decoding="async"
+				alt=""
+				class="citizen-command-palette-gallery-item__thumbnail-image"
+			>
+			<span
+				v-else
+				class="citizen-command-palette-gallery-item__thumbnail-placeholder"
+			>
+				<cdx-icon
+					v-if="thumbnailIcon"
+					:icon="thumbnailIcon"
+					class="cdx-thumbnail__placeholder__icon--vue"
+				></cdx-icon>
+			</span>
+		</span>
 	</component>
 </template>
 
 <script>
 const { defineComponent, computed, ref } = require( 'vue' );
-const { CdxThumbnail } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
 const { CommandPaletteItem } = require( '../types.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
 	name: 'CommandPaletteGalleryItem',
 	components: {
-		CdxThumbnail
+		CdxIcon
 	},
 	props: {
 		id: {
@@ -174,59 +198,79 @@ module.exports = exports = defineComponent( {
 		text-decoration: none;
 	}
 
-	// CdxThumbnail at gallery scale: fill the tile, square aspect ratio,
-	// and scale the placeholder icon up from its 1.25rem default so it
-	// stays readable inside a ~140px tile. CdxThumbnail defaults to
-	// `display: inline-flex`, which leaves a line-box descender below
-	// the tile — switching to block removes that gap.
-	&__thumbnail.cdx-thumbnail {
+	// Square 1:1 tile that holds either a lazy-loaded <img> (when the
+	// file has a thumbnail) or a centred placeholder icon (audio, archive,
+	// 3D, etc.). overflow:hidden keeps the corners rounded against the
+	// image's intrinsic edges. position:relative is the containing block
+	// for the ::after focus-ring overlay.
+	&__thumbnail {
+		position: relative;
 		display: block;
 		width: 100%;
-		height: auto;
 		aspect-ratio: 1 / 1;
+		overflow: hidden;
+		background-color: var( --background-color-neutral-subtle );
+		border: 1px solid var( --border-color-subtle );
 		border-radius: var( --border-radius-medium );
 
-		.cdx-thumbnail__image,
-		.cdx-thumbnail__placeholder {
-			width: 100%;
-			min-width: 0;
-			height: 100%;
-			min-height: 0;
-			border-color: var( --border-color-subtle );
+		// Focus/active ring overlay. `box-shadow: inset` on the tile
+		// itself paints between the parent's border and its content area
+		// — behind the child <img>, which is opaque and covers the
+		// shadow. A transparent pseudo-element layered on top is the
+		// reliable way to render the ring above image content.
+		&::after {
+			position: absolute;
+			inset: 0;
+			pointer-events: none;
+			content: '';
 			border-radius: inherit;
+			box-shadow: inset 0 0 0 2px transparent;
 		}
+	}
 
-		// __image stretches to cover; __placeholder must keep its
-		// flex centering so the icon stays in the middle of the tile.
-		.cdx-thumbnail__image {
-			display: block;
-		}
+	&__thumbnail-image {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
 
-		.cdx-thumbnail__placeholder__icon {
-			width: 3.5rem;
+	&__thumbnail-placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		color: var( --color-subtle );
+
+		// Codex's CdxIcon defaults to a `cdx-icon--medium` (1.25rem) size
+		// modifier — too small for a 140px tile. Override the modifier
+		// dimensions; the SVG inside fills 100% / 100% via Codex's own
+		// rule, so it scales up cleanly.
+		.cdx-icon--medium {
+			width: @size-200;
 			min-width: 0;
-			height: 3.5rem;
+			height: @size-200;
 			min-height: 0;
-			-webkit-mask-size: 3.5rem;
-			mask-size: 3.5rem;
 		}
 	}
 
 	// Focus ring matches Codex's interactive-focus pattern (inset 2px
 	// progressive border) — visible against any thumbnail content
-	// without enlarging the tile or pushing siblings around.
-	&--highlighted &__thumbnail.cdx-thumbnail {
-		.cdx-thumbnail__image,
-		.cdx-thumbnail__placeholder {
-			border-color: var( --border-color-progressive );
+	// without enlarging the tile or pushing siblings around. The ring
+	// is drawn on the ::after overlay so it sits above the <img>.
+	&--highlighted &__thumbnail {
+		border-color: var( --border-color-progressive );
+
+		&::after {
 			box-shadow: inset 0 0 0 2px var( --border-color-progressive );
 		}
 	}
 
-	&--active &__thumbnail.cdx-thumbnail {
-		.cdx-thumbnail__image,
-		.cdx-thumbnail__placeholder {
-			border-color: var( --border-color-progressive--active );
+	&--active &__thumbnail {
+		border-color: var( --border-color-progressive--active );
+
+		&::after {
 			box-shadow: inset 0 0 0 2px var( --border-color-progressive--active );
 		}
 	}

--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -275,11 +275,21 @@ function adaptListItem( page ) {
 	}
 
 	const mediatype = info.mediatype || 'UNKNOWN';
-	const thumbUrl = info.thumburl || '';
-	const thumbnail = thumbUrl ? {
-		url: thumbUrl,
-		width: info.thumbwidth || THUMB_WIDTH,
-		height: info.thumbheight || THUMB_WIDTH
+	// MW returns `thumburl` set to the original file URL when no thumb
+	// can be generated (audio, video without poster, archives, …), often
+	// with `thumbheight: -1` but sometimes with positive dimensions
+	// echoed back from the request. Real thumbnails live at /thumb/…
+	// paths distinct from the original URL — `thumburl !== info.url` is
+	// the reliable signal. Without this, native <img> would try to load
+	// the underlying media (mp3, webm, pdf) and render a broken-image
+	// glyph instead of falling back to the placeholder icon.
+	const hasThumbnail = info.thumburl &&
+		info.thumburl !== info.url &&
+		info.thumbwidth > 0 && info.thumbheight > 0;
+	const thumbnail = hasThumbnail ? {
+		url: info.thumburl,
+		width: info.thumbwidth,
+		height: info.thumbheight
 	} : null;
 	const placeholderIcon = iconForMediatype( mediatype );
 	const label = stripFilePrefix( page.title );

--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -29,7 +29,25 @@ const { defineMode } = require( '../services/defineMode.js' );
 
 const FILE_NAMESPACE = 6;
 const RESULT_LIMIT = 50;
-const THUMB_WIDTH = 300;
+
+// Gallery tiles render in a `minmax(140px, 1fr)` grid; the average
+// rendered tile width is roughly BASE_TILE_WIDTH. The MW server resamples
+// to whatever `iiurlwidth` we request, so picking a width that matches
+// the user's DPR avoids over-fetching on 1× displays and prevents the
+// browser from upscaling on retina-class (2×, 3×) displays. Capped at
+// MAX_THUMB_WIDTH to avoid runaway values from unusual ratios. Computed
+// per request rather than at module load so a window dragged between a
+// 1× and a 2× display picks up the new ratio on the next list refresh.
+const BASE_TILE_WIDTH = 160;
+const MAX_THUMB_WIDTH = 400;
+
+function computeThumbWidth() {
+	const dpr = ( typeof window !== 'undefined' && window.devicePixelRatio ) || 1;
+	return Math.min(
+		MAX_THUMB_WIDTH,
+		Math.ceil( BASE_TILE_WIDTH * Math.max( 1, dpr ) )
+	);
+}
 
 const KB = 1024;
 const MB = KB * 1024;
@@ -333,10 +351,15 @@ function createFileMode( ApiConstructor ) {
 		format: 'json',
 		prop: 'imageinfo',
 		iiprop: 'url|mediatype',
-		iiurlwidth: THUMB_WIDTH,
 		maxage: config.wgSearchSuggestCacheExpiry,
 		smaxage: config.wgSearchSuggestCacheExpiry
 	};
+
+	function listParams( extra ) {
+		return Object.assign(
+			{}, baseListImageinfoParams, { iiurlwidth: computeThumbWidth() }, extra
+		);
+	}
 
 	// Detail-stage params: everything the right-pane renders. Filtered
 	// to LicenseShortName because that's the only extmetadata field we
@@ -384,7 +407,7 @@ function createFileMode( ApiConstructor ) {
 	}
 
 	function fetchFilesByPrefix( subQuery, signal ) {
-		return queryPages( Object.assign( {}, baseListImageinfoParams, {
+		return queryPages( listParams( {
 			generator: 'prefixsearch',
 			gpssearch: subQuery,
 			gpsnamespace: FILE_NAMESPACE,
@@ -393,7 +416,7 @@ function createFileMode( ApiConstructor ) {
 	}
 
 	function fetchFilesByFullText( subQuery, signal ) {
-		return queryPages( Object.assign( {}, baseListImageinfoParams, {
+		return queryPages( listParams( {
 			generator: 'search',
 			gsrsearch: subQuery,
 			gsrnamespace: FILE_NAMESPACE,
@@ -416,7 +439,7 @@ function createFileMode( ApiConstructor ) {
 			return Promise.resolve( [] );
 		}
 		const title = mw.config.get( 'wgPageName' );
-		return queryPages( Object.assign( {}, baseListImageinfoParams, {
+		return queryPages( listParams( {
 			generator: 'images',
 			titles: title,
 			gimlimit: RESULT_LIMIT

--- a/tests/vitest/commandPalette/components/CommandPaletteGalleryItem.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteGalleryItem.test.js
@@ -5,10 +5,10 @@ const mw = require( '../../mocks/mw.js' );
 globalThis.mw = mw;
 
 mw.loader.require = vi.fn( () => ( {
-	CdxThumbnail: {
-		name: 'CdxThumbnail',
-		template: '<div class="cdx-thumbnail-stub"></div>',
-		props: [ 'thumbnail', 'placeholderIcon' ]
+	CdxIcon: {
+		name: 'CdxIcon',
+		template: '<span class="cdx-icon-stub"></span>',
+		props: [ 'icon' ]
 	}
 } ) );
 
@@ -36,29 +36,40 @@ beforeAll( async () => {
 
 describe( 'CommandPaletteGalleryItem', () => {
 	describe( 'thumbnail rendering', () => {
-		it( 'forwards the thumbnail object to CdxThumbnail', () => {
+		it( 'renders a native <img loading="lazy"> when thumbnail is set', () => {
 			const thumb = { url: '/img/foo.png', width: 300, height: 200 };
 			const wrapper = mountTile( { thumbnail: thumb } );
 
-			const cdxThumb = wrapper.findComponent( { name: 'CdxThumbnail' } );
-			expect( cdxThumb.exists() ).toBe( true );
-			expect( cdxThumb.props( 'thumbnail' ) ).toEqual( thumb );
+			const img = wrapper.find( 'img.citizen-command-palette-gallery-item__thumbnail-image' );
+			expect( img.exists() ).toBe( true );
+			expect( img.attributes( 'src' ) ).toBe( '/img/foo.png' );
+			expect( img.attributes( 'loading' ) ).toBe( 'lazy' );
+			expect( img.attributes( 'decoding' ) ).toBe( 'async' );
+			expect( img.attributes( 'width' ) ).toBe( '300' );
+			expect( img.attributes( 'height' ) ).toBe( '200' );
+			// Empty alt because the filename is already in the title attribute
+			// and surrounding label — a duplicated alt would just add noise
+			// for screen readers.
+			expect( img.attributes( 'alt' ) ).toBe( '' );
 		} );
 
-		it( 'forwards the placeholder icon to CdxThumbnail', () => {
+		it( 'renders a placeholder with the cdx-icon when no thumbnail', () => {
 			const wrapper = mountTile( { thumbnailIcon: 'icon-name' } );
 
-			const cdxThumb = wrapper.findComponent( { name: 'CdxThumbnail' } );
-			expect( cdxThumb.exists() ).toBe( true );
-			expect( cdxThumb.props( 'placeholderIcon' ) ).toBe( 'icon-name' );
+			expect( wrapper.find( 'img.citizen-command-palette-gallery-item__thumbnail-image' ).exists() ).toBe( false );
+			const placeholder = wrapper.find( '.citizen-command-palette-gallery-item__thumbnail-placeholder' );
+			expect( placeholder.exists() ).toBe( true );
+			const icon = placeholder.findComponent( { name: 'CdxIcon' } );
+			expect( icon.exists() ).toBe( true );
+			expect( icon.props( 'icon' ) ).toBe( 'icon-name' );
 		} );
 
-		it( 'omits the placeholder icon prop when thumbnailIcon is empty', () => {
+		it( 'renders an empty placeholder (no icon) when neither thumbnail nor thumbnailIcon are set', () => {
 			const wrapper = mountTile( { thumbnailIcon: '' } );
 
-			const cdxThumb = wrapper.findComponent( { name: 'CdxThumbnail' } );
-			// Empty string maps to undefined so CdxThumbnail uses its default.
-			expect( cdxThumb.props( 'placeholderIcon' ) ).toBeUndefined();
+			const placeholder = wrapper.find( '.citizen-command-palette-gallery-item__thumbnail-placeholder' );
+			expect( placeholder.exists() ).toBe( true );
+			expect( placeholder.findComponent( { name: 'CdxIcon' } ).exists() ).toBe( false );
 		} );
 	} );
 

--- a/tests/vitest/commandPalette/modes/file.test.js
+++ b/tests/vitest/commandPalette/modes/file.test.js
@@ -275,10 +275,57 @@ describe( 'file mode', () => {
 
 			const audio = result.find( ( r ) => r.label === 'Lecture.mp3' );
 			expect( audio.thumbnail ).toBeNull();
-			// thumbnailIcon is always assigned by adaptFileItem; the actual
+			// thumbnailIcon is always assigned by adaptListItem; the actual
 			// icon glyph is wired up by MediaWiki's ResourceLoader at runtime
 			// (icons.json is a stub in unit tests). Just check the field exists.
 			expect( audio ).toHaveProperty( 'thumbnailIcon' );
+		} );
+
+		it( 'sets thumbnail to null when MW echoes the original URL as thumburl (no real thumb)', async () => {
+			// For files MW cannot thumbnail (audio, webm video without
+			// poster, archives, …) the API echoes the original `url` back
+			// as `thumburl`, sometimes with -1 dimensions and sometimes
+			// with the requested width and a positive height. Real
+			// thumbnails live at /thumb/ paths distinct from `url`, so
+			// the only reliable signal is `thumburl !== url`. Without
+			// this guard, the gallery would render a broken <img> for
+			// every non-image file.
+			const pages = {
+				200: {
+					pageid: 200,
+					ns: 6,
+					title: 'File:Demo.webm',
+					index: 1,
+					imageinfo: [ {
+						url: '/w/images/Demo.webm',
+						thumburl: '/w/images/Demo.webm',
+						thumbwidth: 300,
+						thumbheight: 225,
+						mediatype: 'VIDEO'
+					} ]
+				},
+				201: {
+					pageid: 201,
+					ns: 6,
+					title: 'File:Audio.mp3',
+					index: 2,
+					imageinfo: [ {
+						url: '/w/images/Audio.mp3',
+						thumburl: '/w/images/Audio.mp3',
+						thumbwidth: 300,
+						thumbheight: -1,
+						mediatype: 'AUDIO'
+					} ]
+				}
+			};
+			mockGet.mockResolvedValue( { query: { pages } } );
+
+			const result = await mode.getResults( 'media', undefined );
+
+			expect( result[ 0 ].thumbnail ).toBeNull();
+			expect( result[ 1 ].thumbnail ).toBeNull();
+			expect( result[ 0 ] ).toHaveProperty( 'thumbnailIcon' );
+			expect( result[ 1 ] ).toHaveProperty( 'thumbnailIcon' );
 		} );
 
 		it( 'builds a list-stage detail.header with filename + copyValue only (no description, no pairs)', async () => {

--- a/tests/vitest/commandPalette/modes/file.test.js
+++ b/tests/vitest/commandPalette/modes/file.test.js
@@ -168,7 +168,46 @@ describe( 'file mode', () => {
 			// The list-stage iiprop is intentionally minimal — heavier fields
 			// (extmetadata, size, mime, user, timestamp) move to getItemDetail.
 			expect( params.iiprop ).toBe( 'url|mediatype' );
-			expect( params.iiurlwidth ).toBe( 300 );
+			// jsdom's window.devicePixelRatio defaults to 1, so the DPR-aware
+			// thumb width resolves to BASE_TILE_WIDTH (160). Verify it's a
+			// positive integer rather than the exact value so a future tweak
+			// to the tile-width constant doesn't crash this test.
+			expect( params.iiurlwidth ).toBeGreaterThan( 0 );
+			expect( Number.isInteger( params.iiurlwidth ) ).toBe( true );
+		} );
+
+		it( 'computes iiurlwidth per request from devicePixelRatio, capped at the documented max', async () => {
+			const originalDpr = window.devicePixelRatio;
+			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
+
+			Object.defineProperty( window, 'devicePixelRatio', {
+				value: 1, configurable: true
+			} );
+			await mode.getResults( 'a', undefined );
+			const dpr1 = mockGet.mock.calls.at( -1 )[ 0 ].iiurlwidth;
+
+			Object.defineProperty( window, 'devicePixelRatio', {
+				value: 2, configurable: true
+			} );
+			await mode.getResults( 'b', undefined );
+			const dpr2 = mockGet.mock.calls.at( -1 )[ 0 ].iiurlwidth;
+
+			Object.defineProperty( window, 'devicePixelRatio', {
+				value: 4, configurable: true
+			} );
+			await mode.getResults( 'c', undefined );
+			const dpr4 = mockGet.mock.calls.at( -1 )[ 0 ].iiurlwidth;
+
+			Object.defineProperty( window, 'devicePixelRatio', {
+				value: originalDpr, configurable: true
+			} );
+
+			expect( dpr2 ).toBeGreaterThan( dpr1 );
+			// At DPR 4 the requested width (640) exceeds MAX_THUMB_WIDTH
+			// (400), so the cap is hit and widening stops. Asserting the
+			// exact cap value catches a regression that removes the cap
+			// or raises it without updating the documented intent.
+			expect( dpr4 ).toBe( 400 );
 		} );
 
 		it( 'falls back to full-text search when prefix returns no results', async () => {


### PR DESCRIPTION
## Summary

- The command palette's file gallery shows up to 50 thumbnails simultaneously. CdxThumbnail uses a CSS `background-image` and eagerly preloads via `new Image()` on mount, so opening file mode fires 50 parallel HTTP requests for thumbnails the user may never scroll into view. Replace it with a native `<img loading=\"lazy\" decoding=\"async\">` in the gallery tile so the browser defers offscreen thumbnails and decoding stays off the main thread.
- The list query's `iiurlwidth` was hard-coded at 300 — too small for retina (2×, 3×) displays where the browser has to upscale, and too big for 1× displays where ~140 px of pixels go to waste on a ~160 px tile. Compute it per request from `window.devicePixelRatio` (160 px × max(1, dpr), capped at 400 px). Per-request rather than at module load so a window dragged between displays picks up the new ratio on the next list refresh.

## Subtle bug surfaced by the lazy-load switch

For files MW can't thumbnail (audio, webm without poster, archives, …), the imageinfo API echoes the original `url` back as the `thumburl`, sometimes with `thumbheight: -1` and sometimes with positive dimensions reflecting the requested width. CdxThumbnail used to mask both shapes by failing to load via `new Image()` and falling back to its placeholder. Native `<img>` doesn't have that auto-fallback — it would render a broken-image glyph for every non-image file.

Real thumbnails always live at `/thumb/` paths distinct from the file URL, so `thumburl !== info.url` is the reliable signal. The adapter now treats both shapes (\"thumburl=url with -1\" and \"thumburl=url with positive dims\") as 'no real thumbnail' and renders the placeholder icon instead.

## Test plan

- [x] `npm run preflight` passes (880 → unchanged + lazy/DPR tests; existing tests unaffected).
- [x] Updated `CommandPaletteGalleryItem.test.js`: now asserts `<img loading=\"lazy\" decoding=\"async\">` for thumbnail items and a `cdx-icon` placeholder for non-thumbable items.
- [x] Updated `file.test.js`: explicit fixture covering MW's `thumburl===url` shapes (webm with positive dims, mp3 with -1) ensures both fall back to the placeholder icon.
- [x] DPR test toggles `window.devicePixelRatio` across 1, 2, 4 and verifies `iiurlwidth` widens and caps at 400.
- [x] Smoke-tested locally: gallery tile renders sharp images on a real page, audio/webm fall back to the right placeholder icon (was the regression caught during review of the predecessor PR), arrowing through items still works, no console warnings.

## Predecessor

Builds on https://github.com/StarCitizenTools/mediawiki-skins-Citizen/pull/1529 (merged) which set up the list/detail split and the per-pageid detail cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)