### PR TITLE
fix(commandPalette): show SVG and small-bitmap thumbnails in file mode

### DIFF
--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -293,17 +293,27 @@ function adaptListItem( page ) {
 	}
 
 	const mediatype = info.mediatype || 'UNKNOWN';
-	// MW returns `thumburl` set to the original file URL when no thumb
-	// can be generated (audio, video without poster, archives, …), often
-	// with `thumbheight: -1` but sometimes with positive dimensions
-	// echoed back from the request. Real thumbnails live at /thumb/…
-	// paths distinct from the original URL — `thumburl !== info.url` is
-	// the reliable signal. Without this, native <img> would try to load
-	// the underlying media (mp3, webm, pdf) and render a broken-image
-	// glyph instead of falling back to the placeholder icon.
+	// MW returns `thumburl === info.url` in two distinct cases:
+	//   1. The file IS its own thumbnail — SVGs (DRAWING), or a bitmap
+	//      smaller than the requested `iiurlwidth`. Native <img> renders
+	//      these correctly; the URL is fine to use.
+	//   2. No thumbnail could be generated — audio, video without a
+	//      poster, archives, 3D models. The `thumburl` is echoed back as
+	//      the raw media URL, often with `thumbheight: -1` but sometimes
+	//      with positive dimensions. Native <img> would attempt to load
+	//      the raw media (mp3, webm, pdf) and render a broken glyph.
+	// Mediatype is the discriminator: typical BITMAP (PNG/JPEG/GIF/WebP)
+	// and DRAWING (SVG) URLs render directly in <img>. Non-renderable
+	// BITMAP subtypes exist (TIFF, BMP) but are protected by the other
+	// branch — when MW can produce a thumb for them, it lives at a
+	// separate /thumb/… path so `thumburl !== info.url` catches it; when
+	// it can't, `thumburl` is missing entirely and `hasThumbnail` is
+	// false. The `thumburl !== info.url` branch also covers the common
+	// case of resampled bitmaps and PDF rasterization.
+	const isInlineRenderable = mediatype === 'BITMAP' || mediatype === 'DRAWING';
 	const hasThumbnail = info.thumburl &&
-		info.thumburl !== info.url &&
-		info.thumbwidth > 0 && info.thumbheight > 0;
+		info.thumbwidth > 0 && info.thumbheight > 0 &&
+		( info.thumburl !== info.url || isInlineRenderable );
 	const thumbnail = hasThumbnail ? {
 		url: info.thumburl,
 		width: info.thumbwidth,

--- a/tests/vitest/commandPalette/modes/file.test.js
+++ b/tests/vitest/commandPalette/modes/file.test.js
@@ -320,15 +320,14 @@ describe( 'file mode', () => {
 			expect( audio ).toHaveProperty( 'thumbnailIcon' );
 		} );
 
-		it( 'sets thumbnail to null when MW echoes the original URL as thumburl (no real thumb)', async () => {
-			// For files MW cannot thumbnail (audio, webm video without
-			// poster, archives, …) the API echoes the original `url` back
-			// as `thumburl`, sometimes with -1 dimensions and sometimes
-			// with the requested width and a positive height. Real
-			// thumbnails live at /thumb/ paths distinct from `url`, so
-			// the only reliable signal is `thumburl !== url`. Without
-			// this guard, the gallery would render a broken <img> for
-			// every non-image file.
+		it( 'sets thumbnail to null for non-renderable mediatypes when MW echoes the original URL as thumburl', async () => {
+			// MW echoes `thumburl=url` when no separate thumb can be
+			// generated — audio, webm video without poster, archives, …
+			// — sometimes with -1 dimensions, sometimes with the requested
+			// width and a positive height. Native <img> would attempt to
+			// load the raw media and render a broken glyph, so we gate on
+			// mediatype: AUDIO / VIDEO / OFFICE / ARCHIVE / 3D fall back
+			// to the placeholder icon.
 			const pages = {
 				200: {
 					pageid: 200,
@@ -365,6 +364,69 @@ describe( 'file mode', () => {
 			expect( result[ 1 ].thumbnail ).toBeNull();
 			expect( result[ 0 ] ).toHaveProperty( 'thumbnailIcon' );
 			expect( result[ 1 ] ).toHaveProperty( 'thumbnailIcon' );
+		} );
+
+		it( 'sets a thumbnail for SVGs when MW echoes the original URL as thumburl', async () => {
+			// SVGs are vector — MW returns the original URL as `thumburl`
+			// because the file is its own thumbnail. Native <img> renders
+			// SVG inline, so the URL is fine to use. mediatype=DRAWING is
+			// the discriminator that distinguishes this from the
+			// non-renderable echo case (audio/video/archive).
+			const pages = {
+				300: {
+					pageid: 300,
+					ns: 6,
+					title: 'File:Logo.svg',
+					index: 1,
+					imageinfo: [ {
+						url: '/w/images/Logo.svg',
+						thumburl: '/w/images/Logo.svg',
+						thumbwidth: 512,
+						thumbheight: 512,
+						mediatype: 'DRAWING'
+					} ]
+				}
+			};
+			mockGet.mockResolvedValue( { query: { pages } } );
+
+			const result = await mode.getResults( 'logo', undefined );
+
+			expect( result[ 0 ].thumbnail ).toEqual( {
+				url: '/w/images/Logo.svg',
+				width: 512,
+				height: 512
+			} );
+		} );
+
+		it( 'sets a thumbnail for small bitmaps when MW echoes the original URL as thumburl', async () => {
+			// When the original bitmap is smaller than the requested
+			// `iiurlwidth`, MW returns the original URL as `thumburl`
+			// with the original (smaller) dimensions instead of upscaling.
+			// Native <img> renders BITMAP inline, so the URL is fine.
+			const pages = {
+				400: {
+					pageid: 400,
+					ns: 6,
+					title: 'File:Tiny.png',
+					index: 1,
+					imageinfo: [ {
+						url: '/w/images/Tiny.png',
+						thumburl: '/w/images/Tiny.png',
+						thumbwidth: 64,
+						thumbheight: 64,
+						mediatype: 'BITMAP'
+					} ]
+				}
+			};
+			mockGet.mockResolvedValue( { query: { pages } } );
+
+			const result = await mode.getResults( 'tiny', undefined );
+
+			expect( result[ 0 ].thumbnail ).toEqual( {
+				url: '/w/images/Tiny.png',
+				width: 64,
+				height: 64
+			} );
 		} );
 
 		it( 'builds a list-stage detail.header with filename + copyValue only (no description, no pairs)', async () => {


### PR DESCRIPTION
## Summary

- The file mode's gallery dropped any thumbnail where `info.thumburl === info.url`. The guard, intended to bail on audio / video / archive originals, also rejected SVGs (mediatype `DRAWING`, MW echoes the original URL because vector files are their own thumbnail) and small bitmaps (smaller than the requested `iiurlwidth`, MW echoes the original URL instead of upscaling). Both render fine in `<img>`.
- Replaces the unconditional `thumburl !== url` check with a mediatype gate: `BITMAP` and `DRAWING` URLs are inline-renderable, so allow them through when `thumburl === url`; everything else (`AUDIO` / `VIDEO` / `OFFICE` / `ARCHIVE` / `3D`) still falls back to the placeholder icon. The `thumburl !== url` branch still catches real resampled thumbnails (PDF rasterization, normal-sized bitmaps, TIFF rasterization) regardless of mediatype.
- Two new vitest cases cover the SVG and small-bitmap paths; the existing audio / video echo-rejection test is preserved.

## Test plan

- [x] `npm test -- tests/vitest/commandPalette/modes/file.test.js` — 41 / 41 pass
- [x] `npm run preflight` — 883 / 883 vitest tests pass, 0 lint errors (55 pre-existing warnings in unrelated `tableOfContents*.js`)
- [x] Browser-verified against local MW Docker dev wiki (`localhost:8080`, `$wgSVGNativeRendering = true`): uploaded `Test_logo.svg`, `Test.png`, `Test tone.mp3`. SVG tile renders the file inline, MP3 tile shows the audio placeholder icon, PNG tile renders normally. No new console errors.
- [x] API response confirmed against starcitizen.tools live data (SVG returns `thumburl === url`, `mediatype: DRAWING`, positive dims) and enwiki (SVG returns `thumburl !== url` because rsvg-convert is configured — this PR doesn't change that path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thumbnail detection for file command palette search results. SVG and small bitmap files now display thumbnails correctly in previews, enhancing the visual accuracy of file search results across various file types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1531)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->