### PR TITLE
feat(commandPalette): show file preview in detail panel

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -239,7 +239,8 @@ module.exports = exports = defineComponent( {
 			const detail = item.detail;
 			if ( detail && (
 				( detail.pairs && detail.pairs.length ) ||
-				detail.header
+				detail.header ||
+				detail.media
 			) ) {
 				return detail;
 			}

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteDetailPanel.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteDetailPanel.vue
@@ -1,5 +1,24 @@
 <template>
 	<div class="citizen-command-palette-detail-panel" aria-live="polite">
+		<!--
+			Media preview, above the header so visual identity reads
+			before the filename. Uses `object-fit: contain` so the whole
+			image is visible — distinct from the gallery tile's `cover`
+			framing. For files with no renderable thumbnail (audio,
+			video, archive, 3D), CommandPaletteImage falls back to the
+			placeholder icon centered in the same square frame.
+		-->
+		<command-palette-image
+			v-if="detail.media"
+			class="citizen-command-palette-detail-panel__media"
+			:src="detail.media.src"
+			:width="detail.media.width"
+			:height="detail.media.height"
+			alt=""
+			aspect-ratio="3:2"
+			object-fit="contain"
+			:placeholder-icon="detail.media.placeholderIcon || null"
+		></command-palette-image>
 		<slot name="header">
 			<div
 				v-if="detail.header"
@@ -58,6 +77,7 @@
 const { defineComponent, ref, computed, watch, onBeforeUnmount } = require( 'vue' );
 const { CdxButton, CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
 const { cdxIconCopy, cdxIconCheck } = require( '../icons.json' );
+const CommandPaletteImage = require( './CommandPaletteImage.vue' );
 
 const COPY_FEEDBACK_MS = 1500;
 
@@ -66,13 +86,14 @@ module.exports = exports = defineComponent( {
 	name: 'CommandPaletteDetailPanel',
 	components: {
 		CdxButton,
-		CdxIcon
+		CdxIcon,
+		CommandPaletteImage
 	},
 	props: {
 		detail: {
 			type: Object,
 			required: true,
-			validator: ( val ) => Array.isArray( val.pairs ) || !!val.header
+			validator: ( val ) => Array.isArray( val.pairs ) || !!val.header || !!val.media
 		},
 		// Counter that increments when an external trigger (the keyboard
 		// shortcut, currently) wants the panel to copy `detail.header.copyValue`.
@@ -158,6 +179,17 @@ module.exports = exports = defineComponent( {
 .citizen-command-palette-detail-panel {
 	padding: var( --space-md ) var( --citizen-command-palette-side-padding );
 	overflow-y: auto;
+
+	// Spacing + chrome around CommandPaletteImage when it's used as the
+	// detail-panel preview. The image component owns the aspect-ratio
+	// frame and `object-fit: contain` rendering; the panel adds the
+	// border + radius so the preview reads as a contained card and
+	// drops a margin so it doesn't crowd the header.
+	&__media {
+		margin-block-end: var( --space-md );
+		border: 1px solid var( --border-color-subtle );
+		border-radius: var( --border-radius-medium );
+	}
 
 	// Inline default header. Shown when a result's `detail.header` is set
 	// and no consumer overrides the `header` slot.

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteGalleryItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteGalleryItem.vue
@@ -15,48 +15,36 @@
 		@mousedown.prevent="onMouseDown"
 		@click="onClick"
 	>
-		<span class="citizen-command-palette-gallery-item__thumbnail">
-			<!--
-				Native <img> with `loading="lazy"` and `decoding="async"`
-				so the browser schedules thumbnail fetches on its own —
-				the gallery can render up to 50 tiles at once.
-				CdxImage is the right Codex equivalent but isn't
-				available in MW 1.43; switch to it on the next LTS.
-			-->
-			<img
-				v-if="thumbnail"
-				:src="thumbnail.url"
-				:width="thumbnail.width"
-				:height="thumbnail.height"
-				loading="lazy"
-				decoding="async"
-				alt=""
-				class="citizen-command-palette-gallery-item__thumbnail-image"
-			>
-			<span
-				v-else
-				class="citizen-command-palette-gallery-item__thumbnail-placeholder"
-			>
-				<cdx-icon
-					v-if="thumbnailIcon"
-					:icon="thumbnailIcon"
-					class="cdx-thumbnail__placeholder__icon--vue"
-				></cdx-icon>
-			</span>
-		</span>
+		<!--
+			CommandPaletteImage handles src + lazy-loaded <img>, the
+			placeholder fallback, and the broken-image bail. Wraps the
+			same square aspect-ratio container the tile previously
+			built inline. Mirrors the CdxImage prop API so swapping it
+			out (when MW LTS bundles a Codex with CdxImage) is a
+			component-rename.
+		-->
+		<command-palette-image
+			class="citizen-command-palette-gallery-item__thumbnail"
+			:src="thumbnail ? thumbnail.url : ''"
+			:width="thumbnail ? thumbnail.width : null"
+			:height="thumbnail ? thumbnail.height : null"
+			aspect-ratio="1:1"
+			object-fit="cover"
+			:placeholder-icon="thumbnailIcon || null"
+		></command-palette-image>
 	</component>
 </template>
 
 <script>
 const { defineComponent, computed, ref } = require( 'vue' );
-const { CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const CommandPaletteImage = require( './CommandPaletteImage.vue' );
 const { CommandPaletteItem } = require( '../types.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
 	name: 'CommandPaletteGalleryItem',
 	components: {
-		CdxIcon
+		CommandPaletteImage
 	},
 	props: {
 		id: {
@@ -198,18 +186,12 @@ module.exports = exports = defineComponent( {
 		text-decoration: none;
 	}
 
-	// Square 1:1 tile that holds either a lazy-loaded <img> (when the
-	// file has a thumbnail) or a centred placeholder icon (audio, archive,
-	// 3D, etc.). overflow:hidden keeps the corners rounded against the
-	// image's intrinsic edges. position:relative is the containing block
-	// for the ::after focus-ring overlay.
+	// Tile chrome layered on top of CommandPaletteImage's square frame.
+	// The image component owns aspect-ratio, background, and the
+	// `<img>` / placeholder swap. The gallery item adds the border and
+	// the focus-ring overlay so only tiles get them — when the image
+	// component is reused in the detail pane, the chrome doesn't follow.
 	&__thumbnail {
-		position: relative;
-		display: block;
-		width: 100%;
-		aspect-ratio: 1 / 1;
-		overflow: hidden;
-		background-color: var( --background-color-neutral-subtle );
 		border: 1px solid var( --border-color-subtle );
 		border-radius: var( --border-radius-medium );
 
@@ -225,33 +207,6 @@ module.exports = exports = defineComponent( {
 			content: '';
 			border-radius: inherit;
 			box-shadow: inset 0 0 0 2px transparent;
-		}
-	}
-
-	&__thumbnail-image {
-		display: block;
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
-
-	&__thumbnail-placeholder {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 100%;
-		height: 100%;
-		color: var( --color-subtle );
-
-		// Codex's CdxIcon defaults to a `cdx-icon--medium` (1.25rem) size
-		// modifier — too small for a 140px tile. Override the modifier
-		// dimensions; the SVG inside fills 100% / 100% via Codex's own
-		// rule, so it scales up cleanly.
-		.cdx-icon--medium {
-			width: @size-200;
-			min-width: 0;
-			height: @size-200;
-			min-height: 0;
 		}
 	}
 

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteImage.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteImage.vue
@@ -1,0 +1,206 @@
+<template>
+	<div
+		class="citizen-command-palette-image"
+		:class="rootClasses"
+	>
+		<img
+			v-if="src && !isBroken"
+			:src="src"
+			:width="width || undefined"
+			:height="height || undefined"
+			:loading="loadingPriority"
+			:alt="alt"
+			decoding="async"
+			class="citizen-command-palette-image__image"
+			:class="imageClasses"
+			@error="onError"
+		>
+		<span
+			v-else
+			class="citizen-command-palette-image__placeholder"
+		>
+			<cdx-icon
+				v-if="placeholderIcon"
+				:icon="placeholderIcon"
+				class="citizen-command-palette-image__placeholder-icon"
+			></cdx-icon>
+		</span>
+	</div>
+</template>
+
+<script>
+const { defineComponent, computed, ref, watch } = require( 'vue' );
+const { CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+
+// Mirrors the validators in @wikimedia/codex's CdxImage so this component
+// can be swapped for CdxImage with a search-and-replace once MW LTS bundles
+// a Codex version that includes it. The aspect-ratio and object-fit values
+// come straight from Codex's `constants.ts`.
+const VALID_ASPECT_RATIOS = [ '1:1', '4:3', '3:2', '16:9' ];
+const VALID_OBJECT_FITS = [ 'fill', 'contain', 'cover', 'none', 'scale-down' ];
+const VALID_LOADING = [ 'lazy', 'eager' ];
+
+// @vue/component
+module.exports = exports = defineComponent( {
+	name: 'CommandPaletteImage',
+	components: {
+		CdxIcon
+	},
+	props: {
+		src: {
+			type: String,
+			default: ''
+		},
+		alt: {
+			type: String,
+			default: ''
+		},
+		width: {
+			type: [ String, Number ],
+			default: null
+		},
+		height: {
+			type: [ String, Number ],
+			default: null
+		},
+		aspectRatio: {
+			type: String,
+			default: null,
+			validator: ( v ) => v === null || VALID_ASPECT_RATIOS.includes( v )
+		},
+		objectFit: {
+			type: String,
+			default: 'cover',
+			validator: ( v ) => VALID_OBJECT_FITS.includes( v )
+		},
+		loadingPriority: {
+			type: String,
+			default: 'lazy',
+			validator: ( v ) => VALID_LOADING.includes( v )
+		},
+		// Codex icon shown when `src` is empty or the image fails to load.
+		// CdxImage hard-codes `cdxIconImage`; we accept any icon so file
+		// mode can route audio / video / archive / 3D to their own glyphs.
+		placeholderIcon: {
+			type: [ Object, String ],
+			default: null
+		}
+	},
+	setup( props ) {
+		const isBroken = ref( false );
+
+		// Reset the broken flag when the source changes — the same instance
+		// gets reused across rows when navigation moves the highlight, so a
+		// previous row's failure mustn't poison a fresh URL.
+		watch( () => props.src, () => {
+			isBroken.value = false;
+		} );
+
+		const onError = () => {
+			isBroken.value = true;
+		};
+
+		// Class structure mirrors CdxImage: aspect-ratio is a root-level
+		// modifier (Codex: `cdx-image--{ratio}`), object-fit is an img-level
+		// modifier (Codex: `cdx-image__image--object-fit-{value}`). Keeping
+		// the same split means the migration to CdxImage is a class-prefix
+		// rename; nothing structural changes.
+		const rootClasses = computed( () => props.aspectRatio ?
+			[ `citizen-command-palette-image--ratio-${ props.aspectRatio.replace( ':', '-' ) }` ] :
+			[]
+		);
+
+		const imageClasses = computed( () => ( {
+			[ `citizen-command-palette-image__image--fit-${ props.objectFit }` ]: true
+		} ) );
+
+		return {
+			isBroken,
+			onError,
+			rootClasses,
+			imageClasses
+		};
+	}
+} );
+</script>
+
+<style lang="less">
+@import '../../mixins.less';
+
+.citizen-command-palette-image {
+	position: relative;
+	display: block;
+	overflow: hidden;
+	background-color: var( --background-color-neutral-subtle );
+
+	// Aspect-ratio variants. The class name format mirrors Codex's
+	// `--ratio-1-1`, `--ratio-16-9` so a future swap to CdxImage is a
+	// search-and-replace on the prefix.
+	&--ratio-1-1 {
+		aspect-ratio: 1 / 1;
+	}
+
+	&--ratio-4-3 {
+		aspect-ratio: 4 / 3;
+	}
+
+	&--ratio-3-2 {
+		aspect-ratio: 3 / 2;
+	}
+
+	&--ratio-16-9 {
+		aspect-ratio: 16 / 9;
+	}
+
+	&__image {
+		display: block;
+		width: 100%;
+		height: 100%;
+
+		&--fit-fill {
+			object-fit: fill;
+		}
+
+		&--fit-contain {
+			object-fit: contain;
+		}
+
+		&--fit-cover {
+			object-fit: cover;
+		}
+
+		&--fit-none {
+			object-fit: none;
+		}
+
+		&--fit-scale-down {
+			object-fit: scale-down;
+		}
+	}
+
+	&__placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		color: var( --color-subtle );
+	}
+
+	&__placeholder-icon {
+		// CdxIcon defaults to `cdx-icon--medium` (1.25rem). Inside a
+		// constrained aspect-ratio container that's too small; size the
+		// glyph relative to the container so it scales with the tile.
+		// 25% of the container reads as a clear glyph without dominating.
+		// !important is needed to override Codex link mixin style with this selector:
+		// a:where(:not([role='button'])) .cdx-icon:not(.cdx-thumbnail__placeholder__icon--vue):last-child
+		&.cdx-icon--medium {
+			width: 25% !important;
+			min-width: @size-200 !important;
+			height: auto !important;
+			min-height: 0 !important;
+			aspect-ratio: 1 / 1;
+		}
+	}
+}
+</style>

--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -322,6 +322,19 @@ function adaptListItem( page ) {
 	const placeholderIcon = iconForMediatype( mediatype );
 	const label = stripFilePrefix( page.title );
 
+	// Detail-panel media block — same source URL as the gallery tile so
+	// the browser cache hit makes the panel render instantly on focus.
+	// Renders with `object-fit: contain` (vs. the tile's `cover`), so the
+	// full image is visible — no clipping. `placeholderIcon` doubles as
+	// the load-error fallback if the URL 404s, and as the only content
+	// when the file has no renderable thumbnail (audio, video, archive).
+	const media = {
+		src: thumbnail ? thumbnail.url : '',
+		width: thumbnail ? thumbnail.width : null,
+		height: thumbnail ? thumbnail.height : null,
+		placeholderIcon: placeholderIcon
+	};
+
 	return {
 		id: 'citizen-command-palette-item-file-' + page.pageid,
 		type: 'file',
@@ -337,6 +350,7 @@ function adaptListItem( page ) {
 		thumbnail: thumbnail,
 		thumbnailIcon: placeholderIcon,
 		detail: {
+			media: media,
 			header: {
 				label: label,
 				copyValue: label

--- a/skin.json
+++ b/skin.json
@@ -384,6 +384,7 @@
 				"resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue",
 				"resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue",
 				"resources/skins.citizen.commandPalette/components/CommandPaletteGalleryItem.vue",
+				"resources/skins.citizen.commandPalette/components/CommandPaletteImage.vue",
 				{
 					"name": "resources/skins.citizen.commandPalette/icons.json",
 					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",

--- a/tests/vitest/commandPalette/components/CommandPaletteGalleryItem.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteGalleryItem.test.js
@@ -4,6 +4,9 @@ const { mount } = require( '@vue/test-utils' );
 const mw = require( '../../mocks/mw.js' );
 globalThis.mw = mw;
 
+// CommandPaletteImage (the gallery tile's child) imports CdxIcon via
+// `mw.loader.require` at module load — stub it so the component tree
+// renders without a real Codex bundle.
 mw.loader.require = vi.fn( () => ( {
 	CdxIcon: {
 		name: 'CdxIcon',
@@ -40,7 +43,7 @@ describe( 'CommandPaletteGalleryItem', () => {
 			const thumb = { url: '/img/foo.png', width: 300, height: 200 };
 			const wrapper = mountTile( { thumbnail: thumb } );
 
-			const img = wrapper.find( 'img.citizen-command-palette-gallery-item__thumbnail-image' );
+			const img = wrapper.find( 'img.citizen-command-palette-image__image' );
 			expect( img.exists() ).toBe( true );
 			expect( img.attributes( 'src' ) ).toBe( '/img/foo.png' );
 			expect( img.attributes( 'loading' ) ).toBe( 'lazy' );
@@ -53,11 +56,22 @@ describe( 'CommandPaletteGalleryItem', () => {
 			expect( img.attributes( 'alt' ) ).toBe( '' );
 		} );
 
+		it( 'tile uses cover framing so the grid stays uniform', () => {
+			const thumb = { url: '/img/foo.png', width: 300, height: 200 };
+			const wrapper = mountTile( { thumbnail: thumb } );
+
+			// CommandPaletteImage applies the object-fit modifier to the
+			// inner <img> (matching CdxImage's class structure). Asserting
+			// the class (rather than computed style) catches accidental
+			// fit changes in either direction.
+			expect( wrapper.find( 'img.citizen-command-palette-image__image--fit-cover' ).exists() ).toBe( true );
+		} );
+
 		it( 'renders a placeholder with the cdx-icon when no thumbnail', () => {
 			const wrapper = mountTile( { thumbnailIcon: 'icon-name' } );
 
-			expect( wrapper.find( 'img.citizen-command-palette-gallery-item__thumbnail-image' ).exists() ).toBe( false );
-			const placeholder = wrapper.find( '.citizen-command-palette-gallery-item__thumbnail-placeholder' );
+			expect( wrapper.find( 'img.citizen-command-palette-image__image' ).exists() ).toBe( false );
+			const placeholder = wrapper.find( '.citizen-command-palette-image__placeholder' );
 			expect( placeholder.exists() ).toBe( true );
 			const icon = placeholder.findComponent( { name: 'CdxIcon' } );
 			expect( icon.exists() ).toBe( true );
@@ -67,7 +81,7 @@ describe( 'CommandPaletteGalleryItem', () => {
 		it( 'renders an empty placeholder (no icon) when neither thumbnail nor thumbnailIcon are set', () => {
 			const wrapper = mountTile( { thumbnailIcon: '' } );
 
-			const placeholder = wrapper.find( '.citizen-command-palette-gallery-item__thumbnail-placeholder' );
+			const placeholder = wrapper.find( '.citizen-command-palette-image__placeholder' );
 			expect( placeholder.exists() ).toBe( true );
 			expect( placeholder.findComponent( { name: 'CdxIcon' } ).exists() ).toBe( false );
 		} );

--- a/tests/vitest/commandPalette/components/CommandPaletteImage.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteImage.test.js
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+const { mount } = require( '@vue/test-utils' );
+const mw = require( '../../mocks/mw.js' );
+globalThis.mw = mw;
+
+mw.loader.require = vi.fn( () => ( {
+	CdxIcon: {
+		name: 'CdxIcon',
+		template: '<span class="cdx-icon-stub"></span>',
+		props: [ 'icon' ]
+	}
+} ) );
+
+let CommandPaletteImage;
+
+beforeAll( async () => {
+	const mod = await import(
+		'../../../../resources/skins.citizen.commandPalette/components/CommandPaletteImage.vue'
+	);
+	CommandPaletteImage = mod.default;
+} );
+
+describe( 'CommandPaletteImage', () => {
+	describe( 'renders an <img>', () => {
+		it( 'when src is provided', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/img/foo.png', width: 320, height: 240, alt: 'A cat' }
+			} );
+
+			const img = wrapper.find( 'img.citizen-command-palette-image__image' );
+			expect( img.exists() ).toBe( true );
+			expect( img.attributes( 'src' ) ).toBe( '/img/foo.png' );
+			expect( img.attributes( 'width' ) ).toBe( '320' );
+			expect( img.attributes( 'height' ) ).toBe( '240' );
+			expect( img.attributes( 'alt' ) ).toBe( 'A cat' );
+			expect( img.attributes( 'loading' ) ).toBe( 'lazy' );
+			expect( img.attributes( 'decoding' ) ).toBe( 'async' );
+		} );
+
+		it( 'with eager loading priority when set', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/img/foo.png', loadingPriority: 'eager' }
+			} );
+
+			expect( wrapper.find( 'img' ).attributes( 'loading' ) ).toBe( 'eager' );
+		} );
+	} );
+
+	describe( 'renders the placeholder', () => {
+		it( 'when src is empty', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '', placeholderIcon: 'audio-icon' }
+			} );
+
+			expect( wrapper.find( 'img' ).exists() ).toBe( false );
+			const placeholder = wrapper.find( '.citizen-command-palette-image__placeholder' );
+			expect( placeholder.exists() ).toBe( true );
+			const icon = placeholder.findComponent( { name: 'CdxIcon' } );
+			expect( icon.exists() ).toBe( true );
+			expect( icon.props( 'icon' ) ).toBe( 'audio-icon' );
+		} );
+
+		it( 'with no icon when placeholderIcon is null', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '' }
+			} );
+
+			expect( wrapper.find( '.citizen-command-palette-image__placeholder' ).exists() ).toBe( true );
+			expect( wrapper.findComponent( { name: 'CdxIcon' } ).exists() ).toBe( false );
+		} );
+
+		it( 'when the image fails to load (broken URL)', async () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/missing.png', placeholderIcon: 'fallback-icon' }
+			} );
+
+			// img is rendered initially
+			expect( wrapper.find( 'img' ).exists() ).toBe( true );
+
+			// Simulate a load failure — the component swaps to the placeholder
+			// so the user sees the mediatype icon instead of the browser's
+			// broken-image glyph.
+			await wrapper.find( 'img' ).trigger( 'error' );
+
+			expect( wrapper.find( 'img' ).exists() ).toBe( false );
+			const icon = wrapper.findComponent( { name: 'CdxIcon' } );
+			expect( icon.exists() ).toBe( true );
+			expect( icon.props( 'icon' ) ).toBe( 'fallback-icon' );
+		} );
+
+		it( 'recovers and re-attempts when src changes after a failure', async () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/missing.png', placeholderIcon: 'fallback-icon' }
+			} );
+
+			await wrapper.find( 'img' ).trigger( 'error' );
+			expect( wrapper.find( 'img' ).exists() ).toBe( false );
+
+			// Same component instance gets reused as the highlight moves
+			// across rows; resetting the broken flag on src change keeps a
+			// previous row's failure from poisoning the new URL.
+			await wrapper.setProps( { src: '/works.png' } );
+
+			const img = wrapper.find( 'img' );
+			expect( img.exists() ).toBe( true );
+			expect( img.attributes( 'src' ) ).toBe( '/works.png' );
+		} );
+	} );
+
+	describe( 'aspect ratio + object fit classes', () => {
+		it( 'maps aspectRatio="1:1" to a --ratio-1-1 class', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/img/foo.png', aspectRatio: '1:1' }
+			} );
+
+			expect( wrapper.classes() ).toContain( 'citizen-command-palette-image--ratio-1-1' );
+		} );
+
+		it( 'maps aspectRatio="16:9" to a --ratio-16-9 class', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/img/foo.png', aspectRatio: '16:9' }
+			} );
+
+			expect( wrapper.classes() ).toContain( 'citizen-command-palette-image--ratio-16-9' );
+		} );
+
+		it( 'omits the ratio class when aspectRatio is null', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/img/foo.png' }
+			} );
+
+			expect(
+				wrapper.classes().some( ( c ) => c.startsWith( 'citizen-command-palette-image--ratio-' ) )
+			).toBe( false );
+		} );
+
+		it( 'applies the object-fit class to the img element only (matches CdxImage)', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/img/foo.png', objectFit: 'contain' }
+			} );
+
+			// CdxImage puts the object-fit modifier on the inner <img>,
+			// not on the root. Mirroring that placement means the future
+			// swap is a class-prefix rename — nothing structural changes.
+			expect(
+				wrapper.classes().some( ( c ) => c.startsWith( 'citizen-command-palette-image--fit-' ) )
+			).toBe( false );
+			expect( wrapper.find( 'img' ).classes() ).toContain( 'citizen-command-palette-image__image--fit-contain' );
+		} );
+
+		it( 'defaults to cover on the img when objectFit is not provided', () => {
+			const wrapper = mount( CommandPaletteImage, {
+				props: { src: '/img/foo.png' }
+			} );
+
+			expect( wrapper.find( 'img' ).classes() ).toContain( 'citizen-command-palette-image__image--fit-cover' );
+		} );
+	} );
+} );

--- a/tests/vitest/commandPalette/modes/file.test.js
+++ b/tests/vitest/commandPalette/modes/file.test.js
@@ -443,6 +443,31 @@ describe( 'file mode', () => {
 			expect( bitmap.detail.pairs ).toBeUndefined();
 		} );
 
+		it( 'builds detail.media from the list-stage thumbnail so the panel renders without a second fetch', async () => {
+			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
+
+			const result = await mode.getResults( 'thing', undefined );
+
+			const bitmap = result.find( ( r ) => r.label === 'Diagram.png' );
+			expect( bitmap.detail.media.src ).toBe( '/thumb/diagram.png' );
+			expect( bitmap.detail.media.width ).toBe( 300 );
+			expect( bitmap.detail.media.height ).toBe( 200 );
+			// placeholderIcon is always assigned; resolved icon values come
+			// from icons.json which is a dev stub in unit tests, so just
+			// assert the field shape.
+			expect( bitmap.detail.media ).toHaveProperty( 'placeholderIcon' );
+		} );
+
+		it( 'builds detail.media with empty src for non-image files (CommandPaletteImage will render the placeholder)', async () => {
+			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
+
+			const result = await mode.getResults( 'thing', undefined );
+
+			const audio = result.find( ( r ) => r.label === 'Lecture.mp3' );
+			expect( audio.detail.media.src ).toBe( '' );
+			expect( audio.detail.media ).toHaveProperty( 'placeholderIcon' );
+		} );
+
 		it( 'sets url to the File: page URL', async () => {
 			mockGet.mockResolvedValue( { query: { pages: SAMPLE_PAGES } } );
 


### PR DESCRIPTION
## Summary

- Adds an image preview at the top of the file mode's detail panel. Reuses the thumbnail URL already loaded by the gallery, so the panel renders instantly on focus — no extra API round-trip. Renders with `object-fit: contain` (vs. the gallery tile's `cover`) so the whole image is visible. Frame is 3:2, a compromise that handles landscape screenshots well without wasting vertical space on portrait or square content. Files without a renderable thumbnail (audio, video, archive, 3D) show the mediatype's Codex placeholder icon centered.
- Extracts the lazy-loaded `<img>` + placeholder-icon pattern into a new `CommandPaletteImage` component. Used by both the gallery tile (`object-fit: cover`, square) and the detail panel preview (`object-fit: contain`, 3:2). Shaped after Codex's `CdxImage` — same prop names, same class structure — so the migration to the upstream component becomes a class-prefix rename when MW LTS bundles a Codex that includes it.
- Two commits: a refactor (extract the component, no user-visible change) and the feature (use it in the detail panel).

## Test plan

- [x] `npm run preflight` — 897 / 897 vitest tests pass, 0 lint errors. Adds 12 component smoke tests for `CommandPaletteImage`, 2 file-mode tests for `detail.media` shape; existing gallery-item tests retargeted to the new class names.
- [x] Browser-verified against the local MW dev wiki (`localhost:8080`, `\$wgSVGNativeRendering = true`, SVG enabled in `\$wgFileExtensions`):
  - PNG: gallery tile shows clipped preview (cover), detail panel shows the full image (contain). Differentiation visible.
  - SVG: same, with the SVG fix from #1531 still working.
  - MP3: gallery tile and detail panel both fall back to the audio glyph. No broken \`<img>\`.
- [x] No new console errors or warnings from the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)