### PR TITLE
build(deps-dev): pin eslint-plugin-mediawiki to 0.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"eslint": "8.57.1",
 				"eslint-config-wikimedia": "0.32.4",
 				"eslint-plugin-compat": "^6.2.0",
+				"eslint-plugin-mediawiki": "0.8.2",
 				"grunt-banana-checker": "0.13.0",
 				"jsdom": "^29.1.1",
 				"lefthook": "^2.1.6",
@@ -4003,9 +4004,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-mediawiki": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.8.3.tgz",
-			"integrity": "sha512-RQKZd40C1taMDk5N9+aFLEBGBB95RNG7Gc54EsJ8pHsJu8//nIdpxNFWPtQz6RNxz6pZUXBnMCxzkMOLM3Mm1w==",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.8.2.tgz",
+			"integrity": "sha512-ydYrpkzm8IVVDQA96QPF3HnFd2xjkIEh7gixD2gvOqUbUZF0p36LtpWXOFAlPWAvHLePWbNNTD5ovd3d4hEtog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"eslint": "8.57.1",
 		"eslint-config-wikimedia": "0.32.4",
 		"eslint-plugin-compat": "^6.2.0",
+		"eslint-plugin-mediawiki": "0.8.2",
 		"grunt-banana-checker": "0.13.0",
 		"jsdom": "^29.1.1",
 		"lefthook": "^2.1.6",
@@ -44,6 +45,9 @@
 		"types-mediawiki": "2.0.0",
 		"vitest": "^4.1.5",
 		"vue": "3.4.27"
+	},
+	"overrides": {
+		"eslint-plugin-mediawiki": "0.8.2"
 	},
 	"version": "3.15.1"
 }


### PR DESCRIPTION
## Summary

Pins `eslint-plugin-mediawiki` to `0.8.2` to work around an upstream regression in `0.8.3` that crashes `npm run lint:js`.

Upstream issue: wikimedia/eslint-plugin-mediawiki#133

## Background

CI lint job [run 25696148680](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/actions/runs/25696148680/job/75444804765) failed on `main` (commit 35fc85d9, the Dependabot bump of `eslint-config-wikimedia` 0.32.3 → 0.32.4) with:

```
TypeError: Cannot read properties of null (reading 'type')
    at requiresCommentList (eslint-plugin-mediawiki/src/utils.js:105)
    at CallExpression (.../rules/msg-doc.js:25)
```

[wikimedia/eslint-plugin-mediawiki#129](https://github.com/wikimedia/eslint-plugin-mediawiki/pull/129) (shipped in 0.8.3) refactored the `msg-doc` rule to only flag string concatenation but, in doing so, removed the null guard added for [issue #59](https://github.com/wikimedia/eslint-plugin-mediawiki/issues/59). When the rule walks up the AST past the top without finding an `ExpressionStatement` or `VariableDeclaration`, `checkNode` becomes `null` and the next access throws.

The trigger is dynamic message keys like `mw.message( 'literal' + key + 'literal' )` whose nearest statement ancestor is a `ReturnStatement` — in this repo, `resources/skins.citizen.commandPalette/modes/user.js:23` and `resources/skins.citizen.commandPalette.smw/init.js:17-18`.

## Implementation

- Declares `eslint-plugin-mediawiki: "0.8.2"` as a direct `devDependency` so the plugin hoists to project-root `node_modules` where ESLint's resolver finds it
- Adds `overrides.eslint-plugin-mediawiki: "0.8.2"` so any transitive request (from `eslint-config-wikimedia` for `^0.8.3`) also resolves to 0.8.2
- Revert both when an upstream release restores the null guard (tracked at wikimedia/eslint-plugin-mediawiki#133)

## Test plan

- [x] `npm run lint:js` exits 0
- [x] `npm run preflight` (lint + 913 tests) passes
- [x] Confirmed locally that with 0.8.3's `utils.js` swapped in, both `user.js:23` and `commandPalette.smw/init.js:17` reproduce the crash; with 0.8.2 restored, neither does