### PR TITLE
Feature page content pass for release

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
 	themeConfig: {
 		docsVersion: process.env.DOCS_VERSION ?? "main",
 		logo: "/img/layout.svg",
+		outline: [2, 3],
 		nav: [
 			{
 				text: "Guide",

--- a/docs/src/features/command-palette.md
+++ b/docs/src/features/command-palette.md
@@ -5,14 +5,14 @@ description: A keyboard-driven palette for jumping to pages, running actions, an
 
 # Command palette
 
-The command palette lets you search for articles quickly and efficiently. Press `/` to see all available entries, or type to start searching right away.
+The command palette is a keyboard-driven launcher for the wiki. Press `/` to see all available entries, or just start typing to search.
 
 ## How it works
 
-The palette supports two kinds of entries:
+The palette has two kinds of entries:
 
-- **Modes** switch the palette into a different search context. When you enter a mode, the header updates with the mode's icon and placeholder, and a back button appears. Type a query to search within that mode.
-- **Commands** execute an action immediately when selected — no additional input needed.
+- **Modes** change the palette's search context. The header shows the mode's icon and placeholder, and a back button appears. Type to search within the mode.
+- **Commands** run their action when you pick them. No input needed.
 
 ### Built-in entries
 
@@ -28,11 +28,13 @@ The palette supports two kinds of entries:
 | `/smw:` | - | Mode | Query pages with Semantic MediaWiki Ask syntax. Only available when SMW is installed. |
 | `/help` | `?` | Command | Open the help overlay to browse every available mode. |
 
-Single-character aliases like `@`, `>`, `:`, `#`, `!`, `~`, and `?` can be typed directly to enter the mode or trigger the command instantly, without needing the `/` prefix.
+You can type the single-character aliases (`@`, `>`, `:`, `#`, `!`, `~`, `?`) directly — no `/` prefix needed.
 
 ### Help overlay
 
-Press `?` at an empty input to open the help overlay. The footer surfaces the same `?` shortcut as a contextual hint whenever pressing it would do something. While help is open, the header swaps to a help indicator with a back button, and <kbd>Esc</kbd> closes help before any other action. Help is a transient layer: opening it preserves your active mode, query, and any drilled-in mode context, so you can peek and bounce back to where you were.
+Press `?` at an empty input to open the help overlay. The footer shows the `?` shortcut as a hint whenever it's available. While help is open, the header swaps to a help indicator with a back button, and <kbd>Esc</kbd> closes help before any other action.
+
+Help is an overlay — opening it preserves your active mode, query, and any drill-down position, so you can peek and return to where you were.
 
 What you see depends on where you are:
 
@@ -72,11 +74,11 @@ The category mode helps you find a category and see what's inside it. Open it wi
 
 #### Revision history
 
-The history mode lists recent edits to the current page so you can scan who changed what and jump to a revision. Open it with `/hist:` or `!`.
+The history mode lists recent edits to the current page so you can scan who changed what and jump to a diff. Open it with `/hist:` or `!`.
 
 - **An empty input** shows the last 50 revisions, newest first.
 - **Type to filter** by editor name or any text in the edit summary — either field can match.
-- **Press <kbd>↵</kbd>** on a revision to view the page as it existed at that point.
+- **Press <kbd>↵</kbd>** on a revision to open the diff against the previous revision. The page's first edit has no previous revision, so it opens that revision directly.
 - **Open a wiki page first.** On a special page (or anywhere without a real article), the mode shows an empty state.
 
 ::: tip Pair with the Instant Diffs gadget
@@ -90,7 +92,7 @@ The file mode finds images, PDFs, audio, video, and other files on the wiki and 
 - **An empty input on a content page** shows the files used on the current page — a quick way to grab the filename of an image you're looking at without leaving the article. Off-article (or on pages with no file usage) the mode shows its idle empty state.
 - **Type a query** to search the wiki's media library. Results appear as tiles with a thumbnail (or a fallback icon for non-visual files like audio or archives).
 - **Arrow keys move 2D**: <kbd>←</kbd>/<kbd>→</kbd> step within a row, <kbd>↑</kbd>/<kbd>↓</kbd> jump between rows.
-- **The detail panel** on the right shows the highlighted file's type, dimensions, byte size, uploader, upload age, and license short-name (when available). A copy-to-clipboard button next to the filename — or <kbd>⌘C</kbd> / <kbd>Ctrl</kbd>+<kbd>C</kbd> — copies the filename for use in wikitext.
+- **The detail panel** on the right shows the file's type, size (dimensions and byte count), upload info (timestamp and uploader), and the license short-name when available. A copy-to-clipboard button next to the filename — or <kbd>⌘C</kbd> / <kbd>Ctrl</kbd>+<kbd>C</kbd> — copies the filename for use in wikitext.
 - **Press <kbd>↵</kbd>** to open the file's `File:` description page.
 
 The mode matches file titles by prefix first, so typing the start of a filename works on every wiki regardless of search backend. If nothing matches by prefix, it falls back to a full-text search — which surfaces deeper hits when [CirrusSearch](https://www.mediawiki.org/wiki/Extension:CirrusSearch) is installed.
@@ -157,16 +159,19 @@ Every entry must have at minimum an `id`, `triggers`, and `description`. If the 
 | `id` | `string` | Yes | Unique identifier. |
 | `triggers` | `string[]` | Yes | Prefixes that activate this entry. Triggers ending with `:` accept a sub-query. |
 | `description` | `string` | Yes | Short explanation shown in the command list. |
-| `placeholder` | `string` | No | Input placeholder when mode is active (e.g., "Search users"). Modes only. |
-| `icon` | `Object` | No | Codex icon for the header when mode is active. Modes only. |
-| `compactResults` | `boolean` | No | Render results in a denser layout — a small icon instead of a thumbnail and the description inline beside the label. Use this for command-style modes whose items don't have real thumbnail images. Modes only. |
+| `label` | `string` | No | Display label shown for the entry in command lists. Falls back to a humanised form of `id` when omitted. |
+| `placeholder` | `string` | No | Input placeholder when the mode is active (e.g., "Search users"). Modes only. |
+| `icon` | `Object` | No | Codex icon for the header when the mode is active. Modes only. |
+| `compactResults` | `boolean` | No | Render results in a denser layout — a small icon instead of a thumbnail and the description inline beside the label. Use this for command-style modes whose items don't have real thumbnail images. Ignored in gallery layout. Modes only. |
 | `layout` | `'list' \| 'gallery'` | No | Result layout. `'list'` (default) renders a vertical list. `'gallery'` renders a tiled grid for thumbnail-driven content like media browsers, and widens the palette to fit. Modes only. |
 | `getResults` | `function` | No | `(subQuery, signal?, tokens?, modeContext?) => Promise<Array>` — if provided, this entry is a mode. The optional fourth argument is the current [mode context](#mode-context) stack. |
+| `getItemDetail` | `function` | No | `(item, signal?) => Promise<Object>` — lazy detail-pane data for the highlighted item. Use this when the detail is too heavy to compute for every item upfront (the file mode uses it for image metadata and licensing). Modes only. |
 | `onResultSelect` | `function` | No | `(item) => { action, payload }` — handles selection of a result item. |
 | `headerLabel` | `function` | No | `(modeContext) => string \| null` — replaces the input placeholder with a custom label. Return `null` to fall back to the regular placeholder — useful for showing a breadcrumb only when the mode is drilled in. Typically used with [mode context](#mode-context). Modes only. |
 | `emptyState` | `Object` | No | `{ title, description, icon }` — content shown when the mode is active with no query. Falls back to default search messaging. Modes only. |
 | `noResults` | `function` | No | `(query, tokens?) => { title, description, icon }` — returns content shown when a query produces no results. Falls back to default no-results messaging. Modes only. |
-| `tokenPattern` | `Object` | No | Token detection pattern for auto-tokenization. See [token patterns](#token-patterns). Modes only. |
+| `tokenPattern` | `Object \| Object[]` | No | Token detection pattern (or array of patterns) for auto-tokenization. See [token patterns](#token-patterns). Modes only. |
+| `keybindings` | `KeyBinding[]` | No | Mode-contributed keyboard bindings, active while the mode is active. See [keybindings](#keybindings). Modes only. |
 | `help` | `Object` | No | Content surfaced by the help overlay when this entry is active. See [help content](#help-content). |
 
 ### Action results
@@ -179,6 +184,7 @@ Every entry must have at minimum an `id`, `triggers`, and `description`. If the 
 | `{ action: 'navigate', payload: url }` | URL string | Close the palette and navigate to the URL. |
 | `{ action: 'exitWithQuery', payload: query }` | Query string | Exit the current mode and set the query string. |
 | `{ action: 'updateQuery', payload: query }` | Query string | Update the query within the current mode without exiting. |
+| `{ action: 'addToken', payload: token }` | Token object | Append a token chip to the input and clear the free text. Use this when picking a result should add a structured condition to the query — like the SMW mode appending `[[Property::]]` after you pick a property. |
 | `{ action: 'pushModeContext', payload: any }` | Any | Step the active mode into a new level. Appends to the [mode context](#mode-context) stack and clears the input. |
 | `{ action: 'toggleHelp' }` | - | Toggle the help overlay. |
 
@@ -192,8 +198,12 @@ Modes can declare a `tokenPattern` to enable auto-tokenization — when the user
 | `position` | `'prefix' \| 'any'` | Where tokens can appear — `prefix` means only at the start, `any` means anywhere in the input. |
 | `activeIn` | `string` | Which mode context this pattern is active in (`'root'` for default search, or a mode id like `'smw'`). |
 | `match` | `function` | `(text) => { label, raw } \| null` — tests whether the text starts with a tokenizable pattern. Returns `label` (display text) and `raw` (the original text) on match, or `null`. |
+| `eagerMatch` | `function` | Optional lenient matcher used after the standard `match` pass has produced at least one token (useful for paste handling). Allows end-of-string as a valid terminator. Same signature as `match`. |
+| `variant` | `string` | Optional visual variant for the chip — e.g. `'outlined'` for chips that should look different from the default solid style. |
 
 Tokens are passed to `getResults` and `noResults` so modes can incorporate them into queries. For example, the SMW mode reconstructs the full Ask query from its token chips plus any free text.
+
+Modes that need multiple tokenization rules — like SMW, which tokenizes both `[[…]]` conditions and printout selectors — can declare `tokenPattern` as an array of pattern objects instead of a single one.
 
 ### Help content
 
@@ -219,7 +229,7 @@ Some modes need to step *into* a result rather than navigate away from it — th
 
 It's opt-in. Modes that don't need it can ignore it entirely.
 
-- The stack is empty when a mode is entered, and is cleared when the mode exits or the palette closes.
+- The stack is empty when a mode is entered, and is cleared when the mode exits.
 - `{ action: 'pushModeContext', payload }` appends the payload and clears the input, so the user starts fresh at the new level.
 - `getResults` gets the current stack as its fourth argument and decides what to show per level.
 - `headerLabel( modeContext )` renders a breadcrumb in the header so the user can always tell where they are. Returning `null` falls back to the regular placeholder, so the breadcrumb only shows when there's actually a path to display.
@@ -256,6 +266,49 @@ const myDrillMode = {
     }
 };
 ```
+
+### Keybindings
+
+Modes can contribute their own keyboard bindings via the `keybindings` array. Each binding declares when it fires, what it does, and (optionally) what hint to show in the palette footer.
+
+```js
+keybindings: [
+    {
+        id: 'mydrill.refresh',
+        zone: 'input',
+        keys: [ 'r' ],
+        when: ( state ) => state.modifierKey,
+        handle: ( state, event ) => {
+            event.preventDefault();
+            refreshResults();
+        },
+        hint: {
+            msgKey: 'my-extension-mode-refresh-hint',
+            kbd: '⌘R'
+        }
+    }
+]
+```
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `id` | `string` | Unique binding identifier (used for debugging). |
+| `zone` | `'input' \| 'action'` | Which focus zone the binding applies to. |
+| `keys` | `string[]` | Event `key` values that fire `handle`. An empty array marks the binding as hint-only. |
+| `when` | `function` | `(state) => boolean` — predicate over the dispatch state. False suppresses both the handler and the hint. |
+| `handle` | `function` | `(state, event) => void` — called when a `keys` entry matches and `when` passes. Call `event.preventDefault()` to claim the keystroke. |
+| `worksDuringHelp` | `boolean` | When true, the binding fires even with the help overlay open. Defaults to false. |
+| `hint` | `Object \| null` | Footer hint to surface, or `null` to omit one. |
+
+Hint shape:
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `msgKey` | `string` | i18n message key for the hint label. |
+| `kbd` | `string` | Keyboard glyph shown next to the label (e.g. `↵`, `↑↓`, `⌘C`). |
+| `order` | `number` | Sort order within the footer (lower = leftmost). |
+
+Mode keybindings are prepended to the core bindings while the mode is active, so a mode binding wins on key collisions within its own focus zone. Footer hints derive from the same list, so a hint is visible iff its handler will fire — no risk of stale hints.
 
 ### Example: simple command
 

--- a/docs/src/features/command-palette.md
+++ b/docs/src/features/command-palette.md
@@ -1,13 +1,13 @@
 ---
 title: Command palette
-description: Citizen's search feature and command palette
+description: A keyboard-driven palette for jumping to pages, running actions, and searching the wiki.
 ---
 
 # Command palette
 
 The command palette lets you search for articles quickly and efficiently. Press `/` to see all available entries, or type to start searching right away.
 
-## Modes and commands
+## How it works
 
 The palette supports two kinds of entries:
 
@@ -56,11 +56,11 @@ Some modes turn parts of your query into tags. For example, typing `Talk:` in de
 
 To change a tag, press <kbd>Backspace</kbd> on an empty input. The first press highlights the last tag (footer hint: **Select tag**). A second press turns it back into editable text (footer hint: **Edit tag**), so you can fix a typo without retyping the whole thing. Keep pressing to delete the text character by character.
 
-## Built-in modes
+### Built-in modes
 
 Most built-in modes (namespace, action, user) work as straightforward search — type a query, get results. The modes below have additional behavior worth knowing about.
 
-### Categories
+#### Categories
 
 The category mode helps you find a category and see what's inside it. Open it with `/cat:` or `#`.
 
@@ -70,7 +70,7 @@ The category mode helps you find a category and see what's inside it. Open it wi
 - **<kbd>Backspace</kbd> on an empty input** backs out one level. At the top, <kbd>Backspace</kbd> closes the mode.
 - **Each result has action buttons** on the right — focus them with <kbd>→</kbd>. Categories offer **View** (the actual `Category:` page) and **Edit**; pages offer **Edit**.
 
-### Revision history
+#### Revision history
 
 The history mode lists recent edits to the current page so you can scan who changed what and jump to a revision. Open it with `/hist:` or `!`.
 
@@ -83,7 +83,7 @@ The history mode lists recent edits to the current page so you can scan who chan
 If users have the [Instant Diffs](https://www.mediawiki.org/wiki/Instant_Diffs) gadget enabled, activating a revision opens the gadget's preview dialog above the still-mounted palette, so they can dismiss it and pick another revision without losing their place. See [Extensions and gadgets](../config/extensions.md#gadget-enhancements) for details.
 :::
 
-### Files and media
+#### Files and media
 
 The file mode finds images, PDFs, audio, video, and other files on the wiki and renders them as a gallery of thumbnails. Open it with `/file:` or `~`.
 
@@ -95,7 +95,7 @@ The file mode finds images, PDFs, audio, video, and other files on the wiki and 
 
 The mode matches file titles by prefix first, so typing the start of a filename works on every wiki regardless of search backend. If nothing matches by prefix, it falls back to a full-text search — which surfaces deeper hits when [CirrusSearch](https://www.mediawiki.org/wiki/Extension:CirrusSearch) is installed.
 
-### Semantic MediaWiki
+#### Semantic MediaWiki
 
 When [Semantic MediaWiki](https://www.semantic-mediawiki.org/) is installed, the `/smw:` mode lets you run Ask queries interactively. Type conditions like `[[Category:City]]` or `[[Located in::Germany]]` — each completed `[[...]]` condition becomes a token chip, and matching pages appear as results.
 
@@ -344,7 +344,7 @@ mw.hook( 'citizen.commandPalette.register' ).add( function ( data ) {
 
 :::
 
-## Migration from previous API
+### Migration from previous API
 
 ::: warning Breaking change
 If you have custom commands registered with the previous API, you'll need to update them:

--- a/docs/src/features/performance-mode.md
+++ b/docs/src/features/performance-mode.md
@@ -9,17 +9,18 @@ Performance mode dials back animations and visual effects so the skin feels fast
 
 ## How it works
 
-When performance mode is on, Citizen:
+With performance mode on, Citizen:
 
-- Turns off CSS animations and transitions
-- Drops frosted glass backdrop effects
-- Replaces the blurred mobile header with a solid background
+- Turns off transitions and animations across the whole skin (every element, not just ones using Citizen's transition tokens)
+- Disables smooth scrolling
+- Drops frosted-glass backdrop effects
+- Skips the frosted overlay on the mobile header, leaving the default solid background
 
 ::: tip Relationship with `prefers-reduced-motion`
 MediaWiki core handles the OS-level `prefers-reduced-motion` media query on its own. Performance mode is a skin-level toggle that goes further — it also strips out frosted glass and other visual flourishes that reduced motion doesn't cover.
 :::
 
-Performance mode starts **on by default**. On the first page load, Citizen checks for WebGL support and quietly turns it off if the device has GPU acceleration. Without a GPU, it stays on. The result is saved in the browser, so the check only runs once. Users can always flip it in their preferences.
+Performance mode is on by default. On the first page load, Citizen probes the browser for WebGL support — if the device can render WebGL, performance mode turns off; otherwise it stays on. The result is saved in the browser, so the check only runs once. Users can flip the toggle in their preferences at any time.
 
 ## Extending performance mode
 
@@ -62,7 +63,7 @@ Use these to gate heavy effects, swap in lighter alternatives, or simplify layou
 
 #### Animation readiness
 
-Citizen also prevents transitions from firing during initial page load. The `.citizen-animations-ready` class is added to the root element once the skin's JavaScript has loaded — transition tokens like `--transition-hover` and `--transition-menu` are only defined under this class.
+Citizen also prevents transitions from firing during initial page load. The `.citizen-animations-ready` class is added to the root element after the skin finishes its deferred startup tasks (scheduled via `requestIdleCallback`) — transition tokens like `--transition-duration-base`, `--transition-hover`, and `--transition-menu` are only defined under this class.
 
 Gate your own transitions the same way to avoid jank on first paint:
 
@@ -80,3 +81,5 @@ Performance mode overrides these custom properties, so anything that references 
 | :--- | :--- | :--- |
 | `--backdrop-filter-frosted-glass` | `blur(…)` | `none` |
 | `--opacity-glass` | `<0–1>` | `1` |
+
+On top of that, performance mode applies `transition-duration: 0ms !important` and `animation-duration: 0.01ms !important` to every element via the universal selector, so transitions and animations are flattened even when your styles don't reference Citizen's tokens.

--- a/docs/src/features/performance-mode.md
+++ b/docs/src/features/performance-mode.md
@@ -1,13 +1,13 @@
 ---
 title: Performance mode
-description: How Citizen adapts to low-end hardware and how to hook into it in custom styles
+description: A lightweight mode that strips animations and visual effects for fast page loads.
 ---
 
 # Performance mode
 
 Performance mode dials back animations and visual effects so the skin feels fast on any device.
 
-## What it does
+## How it works
 
 When performance mode is on, Citizen:
 
@@ -19,11 +19,11 @@ When performance mode is on, Citizen:
 MediaWiki core handles the OS-level `prefers-reduced-motion` media query on its own. Performance mode is a skin-level toggle that goes further — it also strips out frosted glass and other visual flourishes that reduced motion doesn't cover.
 :::
 
-## Automatic detection
-
 Performance mode starts **on by default**. On the first page load, Citizen checks for WebGL support and quietly turns it off if the device has GPU acceleration. Without a GPU, it stays on. The result is saved in the browser, so the check only runs once. Users can always flip it in their preferences.
 
-## Admin controls
+## Extending performance mode
+
+### On-wiki JSON
 
 You can hide the performance mode toggle or lock it to a specific value through [preference overrides](./preferences#removing-a-built-in-preference). To remove it from the preferences panel entirely:
 
@@ -37,7 +37,7 @@ You can hide the performance mode toggle or lock it to a specific value through 
 
 Place this on `MediaWiki:Citizen-preferences.json`.
 
-## Hooking into performance mode
+### Custom styles
 
 Citizen sets a class on the root element that you can target in your own styles:
 
@@ -60,7 +60,7 @@ Use these to gate heavy effects, swap in lighter alternatives, or simplify layou
 }
 ```
 
-### Animation readiness
+#### Animation readiness
 
 Citizen also prevents transitions from firing during initial page load. The `.citizen-animations-ready` class is added to the root element once the skin's JavaScript has loaded — transition tokens like `--transition-hover` and `--transition-menu` are only defined under this class.
 
@@ -72,7 +72,7 @@ Gate your own transitions the same way to avoid jank on first paint:
 }
 ```
 
-### Affected custom properties
+#### Affected custom properties
 
 Performance mode overrides these custom properties, so anything that references them adapts without extra work:
 

--- a/docs/src/features/preferences.md
+++ b/docs/src/features/preferences.md
@@ -5,7 +5,7 @@ description: A panel for personalizing the skin, extensible with on-wiki JSON or
 
 # Preferences
 
-Citizen's preferences panel lets readers personalize the skin — theme, font size, page width, and any other toggles your wiki adds. The panel is extensible: you can add, modify, or remove preferences through two paths, both using the same configuration schema.
+Citizen's preferences panel lets readers personalize the skin — theme, font size, page width, and any toggles your wiki adds. You extend the panel through two paths, both using the same configuration schema.
 
 <LinkGrid>
     <LinkCard title="On-wiki JSON" href="#on-wiki-json" target="_self">
@@ -18,18 +18,18 @@ Citizen's preferences panel lets readers personalize the skin — theme, font si
 
 ## How it works
 
-Citizen ships with a set of built-in preferences, grouped into two sections:
+Citizen ships with two built-in sections:
 
 | Section | Preferences |
 | :--- | :--- |
-| `appearance` | Theme, font size, page width, pure black |
+| `appearance` | Theme, font size, page width, pure black, image dimming |
 | `behavior` | Auto-hide navigation, performance mode |
 
-The panel is lazy-loaded, so it doesn't ship in the initial page bundle. Changes to preference configuration — whether through on-wiki JSON or the JavaScript API — take effect the next time a user opens the panel, with no cache purge required.
+The panel is lazy-loaded, so it doesn't ship in the initial page bundle. Changes to preference configuration — through on-wiki JSON or the JavaScript API — take effect the next time a user opens the panel, with no cache purge required.
 
 ## Extending preferences
 
-Admins can override any built-in preference, or add entirely new ones, through two paths. Gadgets and user scripts can do the same thing via the JavaScript API. Both paths share the same configuration schema.
+Admins can override any built-in preference, or add entirely new ones, through `MediaWiki:Citizen-preferences.json`. Gadgets and user scripts can do the same thing via the JavaScript API. Both paths share the same configuration schema.
 
 ### Configuration schema
 
@@ -86,31 +86,32 @@ Each preference is keyed by its feature name.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `section` | string | Which section this preference belongs to. |
-| `type` | string | `"switch"`, `"select"`, or `"radio"`. Auto-detected if omitted (2 options = switch, 3+ = select). |
-| `options` | array | Short form `["0", "1"]` or long form `[{"value": "0", "labelMsg": "..."}]`. |
+| `type` | string | `"switch"`, `"select"`, or `"radio"`. Switch and select are auto-detected from the option count (2 options = switch, 3+ = select); `"radio"` must be set explicitly. |
+| `options` | array | Short form `["0", "1"]` or long form `[{"value": "0", "labelMsg": "..."}]`. Long-form options also accept `"label"` for literal text instead of an i18n key. |
 | `labelMsg` / `label` | string | i18n message key or literal text for the preference name. |
 | `descriptionMsg` / `description` | string | i18n message key or literal text for the description. |
 | `columns` | number | For radio type, number of columns (default: 2). |
+| `visibilityCondition` | string | Optional gate on when the preference appears: `"always"` (default), `"dark-theme"` (visible only in dark theme), `"tablet-viewport"` (visible only at tablet width or above). |
 
 ### `label` vs `labelMsg`
 
 Both sections and preferences support two ways to set their display text:
 
-- **`labelMsg`** (and `descriptionMsg`): References an i18n message key. The message must be loadable via the MediaWiki API. Use this for multilingual wikis so that labels are translated automatically.
-- **`label`** (and `description`): A literal string used as-is. Use this for single-language wikis or quick prototyping.
+- **`labelMsg`** (and `descriptionMsg`) references an i18n message key. The message must be loadable via the MediaWiki API. Use this for multilingual wikis so labels are translated automatically.
+- **`label`** (and `description`) is a literal string used as-is. Use this for single-language wikis or quick prototyping.
 
 The same pattern applies to `descriptionMsg` / `description`.
 
 ### On-wiki JSON
 
-This is the simplest way to manage preferences — just create a JSON page on your wiki at `MediaWiki:Citizen-preferences.json`.
+The simplest way to manage preferences — create a JSON page on your wiki at `MediaWiki:Citizen-preferences.json`.
 
 #### Merge behavior
 
-When you create `MediaWiki:Citizen-preferences.json`, your configuration is merged with the built-in defaults:
+Your configuration is merged with the built-in defaults:
 
-- **Omitting** a built-in preference keeps its default.
-- Setting a preference to **`null`** removes it from the panel.
+- **Omitting** a built-in preference or section keeps its default.
+- Setting a preference to **`null`** removes it from the panel. Sections with no remaining preferences are dropped automatically.
 - **Overriding** specific fields of a built-in preference merges them — unspecified fields keep their default values.
 - **Options arrays** are replaced wholesale, not merged element-by-element. If you override `options`, provide the full list.
 
@@ -167,7 +168,7 @@ This removes the "auto" option from the theme preference, leaving only day and n
 
 ### JavaScript API
 
-Gadgets and user scripts can register preferences at runtime using `mw.hook`. This is useful when you want a gadget to ship its own preference toggle without requiring an admin to edit the on-wiki JSON.
+Gadgets and user scripts can register preferences at runtime via `mw.hook`. Use this when a gadget needs to ship its own preference toggle without requiring an admin to edit the on-wiki JSON.
 
 #### Usage
 
@@ -180,15 +181,15 @@ mw.hook( 'citizen.preferences.register' ).add( function ( register ) {
 } );
 ```
 
-The `register` function accepts the exact same config schema described above — `sections` and `preferences` with the same field reference.
+The `register` function accepts the same config schema as the on-wiki JSON — `sections` and `preferences` with the same field reference.
 
 #### Timing
 
-You don't need to worry about load order. `mw.hook` replays previously fired data to late subscribers, so your gadget's `.add()` callback will receive the `register` function regardless of whether the preferences panel has loaded yet.
+You don't need to worry about load order. `mw.hook` replays previously fired data to late subscribers, so your `.add()` callback receives the `register` function regardless of whether the preferences panel has loaded. The panel's config is reactive too — calling `register()` after the panel is open updates it in place, no reload needed.
 
 #### Example
 
-Here's a gadget registering a simple toggle:
+A gadget registering a simple toggle:
 
 ```js
 mw.hook( 'citizen.preferences.register' ).add( function ( register ) {
@@ -211,7 +212,7 @@ mw.hook( 'citizen.preferences.register' ).add( function ( register ) {
 
 #### Full gadget example
 
-Here's a complete example that registers a preference and reacts to changes — the kind of thing you'd put in a gadget's JavaScript file:
+A complete example that registers a preference and reacts to changes — the kind of thing you'd put in a gadget's JavaScript file:
 
 ```js
 // Register the preference
@@ -252,7 +253,7 @@ html.my-extension-dark-reader-clientpref-1 {
 
 ### Listening for changes
 
-You can react to preference changes in JavaScript using `mw.hook`:
+React to preference changes in JavaScript using `mw.hook`:
 
 ```js
 mw.hook( 'citizen.preferences.changed' ).add( function ( featureName, value ) {

--- a/docs/src/features/preferences.md
+++ b/docs/src/features/preferences.md
@@ -1,11 +1,11 @@
 ---
 title: Preferences
-description: How to customize the Citizen preferences panel
+description: A panel for personalizing the skin, extensible with on-wiki JSON or JavaScript.
 ---
 
 # Preferences
 
-Citizen's preferences panel is extensible. You can add, modify, or remove preferences through two paths — and both use the same configuration schema.
+Citizen's preferences panel lets readers personalize the skin — theme, font size, page width, and any other toggles your wiki adds. The panel is extensible: you can add, modify, or remove preferences through two paths, both using the same configuration schema.
 
 <LinkGrid>
     <LinkCard title="On-wiki JSON" href="#on-wiki-json" target="_self">
@@ -18,15 +18,24 @@ Citizen's preferences panel is extensible. You can add, modify, or remove prefer
 
 ## How it works
 
-Citizen ships with a set of built-in preferences (theme, font size, page width, pure black, auto-hide navigation, performance mode). Admins can override any of these, or add entirely new ones, by placing a JSON configuration on `MediaWiki:Citizen-preferences.json`. Gadgets and user scripts can do the same thing via the [JavaScript API](#javascript-api).
+Citizen ships with a set of built-in preferences, grouped into two sections:
 
-Changes take effect when users next open the preferences panel — the panel is lazy-loaded, so there's no need to purge caches.
+| Section | Preferences |
+| :--- | :--- |
+| `appearance` | Theme, font size, page width, pure black |
+| `behavior` | Auto-hide navigation, performance mode |
 
-## Configuration schema
+The panel is lazy-loaded, so it doesn't ship in the initial page bundle. Changes to preference configuration — whether through on-wiki JSON or the JavaScript API — take effect the next time a user opens the panel, with no cache purge required.
+
+## Extending preferences
+
+Admins can override any built-in preference, or add entirely new ones, through two paths. Gadgets and user scripts can do the same thing via the JavaScript API. Both paths share the same configuration schema.
+
+### Configuration schema
 
 Whether you're writing JSON on-wiki or passing a config object to the JavaScript API, the shape is the same. There are two top-level keys: `sections` and `preferences`.
 
-### Sections
+#### Sections
 
 Sections group related preferences together. Each section needs either an i18n message key or a literal label.
 
@@ -54,7 +63,7 @@ Using a literal label:
 }
 ```
 
-### Preference entries
+#### Preference entries
 
 Each preference is keyed by its feature name.
 
@@ -72,7 +81,7 @@ Each preference is keyed by its feature name.
 }
 ```
 
-#### Field reference
+**Field reference:**
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
@@ -83,7 +92,7 @@ Each preference is keyed by its feature name.
 | `descriptionMsg` / `description` | string | i18n message key or literal text for the description. |
 | `columns` | number | For radio type, number of columns (default: 2). |
 
-## `label` vs `labelMsg`
+### `label` vs `labelMsg`
 
 Both sections and preferences support two ways to set their display text:
 
@@ -92,11 +101,11 @@ Both sections and preferences support two ways to set their display text:
 
 The same pattern applies to `descriptionMsg` / `description`.
 
-## On-wiki JSON
+### On-wiki JSON
 
-This is the simplest way to manage preferences — just create a JSON page on your wiki.
+This is the simplest way to manage preferences — just create a JSON page on your wiki at `MediaWiki:Citizen-preferences.json`.
 
-### Merge behavior
+#### Merge behavior
 
 When you create `MediaWiki:Citizen-preferences.json`, your configuration is merged with the built-in defaults:
 
@@ -105,18 +114,9 @@ When you create `MediaWiki:Citizen-preferences.json`, your configuration is merg
 - **Overriding** specific fields of a built-in preference merges them — unspecified fields keep their default values.
 - **Options arrays** are replaced wholesale, not merged element-by-element. If you override `options`, provide the full list.
 
-### Built-in sections
+#### Examples
 
-Citizen ships with two sections:
-
-| Section | Preferences |
-| :--- | :--- |
-| `appearance` | Theme, font size, page width, pure black |
-| `behavior` | Auto-hide navigation, performance mode |
-
-### Examples
-
-#### Adding a custom toggle
+##### Adding a custom toggle
 
 ```json
 {
@@ -137,7 +137,7 @@ Citizen ships with two sections:
 }
 ```
 
-#### Removing a built-in preference
+##### Removing a built-in preference
 
 ```json
 {
@@ -147,7 +147,7 @@ Citizen ships with two sections:
 }
 ```
 
-#### Modifying theme options
+##### Modifying theme options
 
 This removes the "auto" option from the theme preference, leaving only day and night:
 
@@ -165,11 +165,11 @@ This removes the "auto" option from the theme preference, leaving only day and n
 }
 ```
 
-## JavaScript API
+### JavaScript API
 
 Gadgets and user scripts can register preferences at runtime using `mw.hook`. This is useful when you want a gadget to ship its own preference toggle without requiring an admin to edit the on-wiki JSON.
 
-### Usage
+#### Usage
 
 ```js
 mw.hook( 'citizen.preferences.register' ).add( function ( register ) {
@@ -182,11 +182,11 @@ mw.hook( 'citizen.preferences.register' ).add( function ( register ) {
 
 The `register` function accepts the exact same config schema described above — `sections` and `preferences` with the same field reference.
 
-### Timing
+#### Timing
 
 You don't need to worry about load order. `mw.hook` replays previously fired data to late subscribers, so your gadget's `.add()` callback will receive the `register` function regardless of whether the preferences panel has loaded yet.
 
-### Example
+#### Example
 
 Here's a gadget registering a simple toggle:
 
@@ -209,7 +209,7 @@ mw.hook( 'citizen.preferences.register' ).add( function ( register ) {
 } );
 ```
 
-## Full gadget example
+#### Full gadget example
 
 Here's a complete example that registers a preference and reacts to changes — the kind of thing you'd put in a gadget's JavaScript file:
 
@@ -240,7 +240,7 @@ mw.hook( 'citizen.preferences.changed' ).add( function ( featureName, value ) {
 } );
 ```
 
-## Styling custom preferences
+### Custom styles
 
 When a user selects a value, Citizen adds a CSS class to the `<html>` element in the format `<feature>-clientpref-<value>`. You can target these classes in `MediaWiki:Common.css` or gadget styles:
 
@@ -250,7 +250,7 @@ html.my-extension-dark-reader-clientpref-1 {
 }
 ```
 
-## Listening for changes
+### Listening for changes
 
 You can react to preference changes in JavaScript using `mw.hook`:
 

--- a/docs/src/features/share.md
+++ b/docs/src/features/share.md
@@ -19,18 +19,26 @@ Wiki admins choose which mode is active — see [Configuration](#configuration) 
 
 Citizen doesn't ship with a built-in service list. The right services depend on your audience — a German federated wiki may want Diaspora; a corporate intranet may want none at all. You pick.
 
+::: tip Which URL gets shared
+Native mode reads `<link rel="canonical">` and shares the canonical URL. The in-page panel — both the copy-link field and the service tiles — shares the current page URL without the hash. If you rely on canonical URLs for analytics or social previews, prefer Native mode.
+:::
+
 ### Short URLs and QR codes
 
 When [Extension:UrlShortener](https://www.mediawiki.org/wiki/Extension:UrlShortener) is installed, the share panel adds two buttons below the copy-link field:
 
-- **Copy short URL** — copies a shortened URL to the clipboard in one click. The result is reused for the rest of the session, so clicking again or reopening the panel is instant.
+- **Copy short URL** — copies a shortened URL to the clipboard in one click, with a brief success state on the button. The result is cached for the lifetime of the dialog, so clicking again or reopening the panel is instant.
 - **Show QR code** — opens a focused QR view inside the same panel, with the short URL printed below as a fallback for anything that can't scan. Only appears when `$wgUrlShortenerEnableQrCode` is enabled.
+
+If the UrlShortener API call fails, both buttons disappear together and the panel falls back to its copy-link-and-services layout.
 
 The copy-link field and the share tiles always use the full page URL — short URLs are reserved for the dedicated button and the QR view. If UrlShortener isn't installed, neither button appears and the rest of the panel works the same.
 
 ## Configuration
 
-Set the share mode via `$wgCitizenShareMode` in `LocalSettings.php`:
+Share is enabled by default. To turn it off entirely, set `$wgCitizenEnableShare = false;` in `LocalSettings.php`.
+
+When enabled, pick how share behaves with `$wgCitizenShareMode`:
 
 ```php
 $wgCitizenShareMode = 'auto'; // 'auto' | 'panel' | 'native'
@@ -47,6 +55,10 @@ $wgCitizenShareMode = 'auto'; // 'auto' | 'panel' | 'native'
 ### On-wiki JSON
 
 Create the page `MediaWiki:Citizen-share-services.json` on your wiki and paste a JSON array of service entries. Save the page, and the new services appear the next time anyone opens the panel.
+
+::: warning Allowed URL protocols
+Citizen drops any service whose `url` uses a protocol not in MediaWiki's `$wgUrlProtocols` list (`http://`, `https://`, `mailto:` and a handful of others by default). If a service silently disappears after you add it, check the protocol first.
+:::
 
 #### Starter pack
 
@@ -92,11 +104,11 @@ Icons are [Simple Icons](https://simpleicons.org/) (CC0).
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `name` | string | Internal identifier. Used as the tile's CSS id (`citizen-share-service-<name>`) so you can target it with custom CSS on your wiki. |
+| `name` | string | Internal identifier. Used as the tile's CSS id (`citizen-share-service-<name>`) so you can target it with custom CSS on your wiki. Characters outside `[a-zA-Z0-9_-]` are stripped from the id. |
 | `label` | string | The name your users see — read by screen readers and shown on hover. |
 | `url` | string | The link opened when the tile is clicked. Use `{{url}}` and `{{title}}` placeholders for the current page's URL and title. |
 | `color` | string | Background color of the tile. Match the service's brand color when possible. |
-| `open_in_modal` | boolean | Open in a small popup window instead of a new tab. Useful for services that show a share dialog, like X. |
+| `open_in_modal` | boolean | Open in a small popup window instead of a new tab. Useful for services that show a share dialog, like X. `mailto:` links always open in the same tab and ignore this flag. |
 | `icon` | string | The icon shown on the tile. See [Icons](#icons) below. |
 | `file` | string | Alternative to `icon`: the filename of an SVG uploaded to your wiki. See [Icons](#icons) below. |
 

--- a/docs/src/features/share.md
+++ b/docs/src/features/share.md
@@ -1,23 +1,25 @@
 ---
 title: Share
-description: How to configure Citizen's share panel and service tiles
+description: Share the current page via the browser's native share sheet or a configurable grid of services.
 ---
 
 # Share
 
-Citizen has three share modes, set via `$wgCitizenShareMode` in `LocalSettings.php`:
+The share panel lets readers send the current page to other people — through their device's native share sheet, a configurable grid of services on the wiki, or as a short URL or QR code.
 
-- **`'auto'`** *(default)* — uses the browser's Web Share API when available (mobile devices, desktop Safari, Chrome, Edge). Falls back to Citizen's in-page panel on browsers without it (e.g. desktop Firefox). Best of both worlds for most wikis.
-- **`'panel'`** — always opens Citizen's in-page panel. Use this when you want consistent branding across all browsers, or when your curated share targets are central to your wiki's identity.
-- **`'native'`** — always uses the Web Share API. Falls back to a clipboard copy with a toast notification on browsers without it. Use this when you want to defer entirely to the OS share experience.
+## How it works
 
-## What users see
+Citizen offers three share modes:
 
-When the panel opens, it always shows a copy-link field, so sharing always works even if you haven't set up any services. The grid of service tiles below it only appears when you've configured services on your wiki.
+- **Native** — surfaces the device's OS-level share sheet (apps, contacts, AirDrop, etc.). Available on mobile devices and desktop Safari, Chrome, and Edge; on browsers without Web Share API support it falls back to a clipboard copy with a toast notification.
+- **Panel** — opens Citizen's in-page panel. Always includes a copy-link field, and if you've configured services on your wiki, a grid of branded service tiles below it. Optionally adds short URL and QR code buttons when [Extension:UrlShortener](https://www.mediawiki.org/wiki/Extension:UrlShortener) is installed.
+- **Auto** *(default)* — uses Native when the browser supports it, falls back to Panel otherwise.
+
+Wiki admins choose which mode is active — see [Configuration](#configuration) below.
 
 Citizen doesn't ship with a built-in service list. The right services depend on your audience — a German federated wiki may want Diaspora; a corporate intranet may want none at all. You pick.
 
-## Short URLs and QR codes
+### Short URLs and QR codes
 
 When [Extension:UrlShortener](https://www.mediawiki.org/wiki/Extension:UrlShortener) is installed, the share panel adds two buttons below the copy-link field:
 
@@ -26,11 +28,27 @@ When [Extension:UrlShortener](https://www.mediawiki.org/wiki/Extension:UrlShorte
 
 The copy-link field and the share tiles always use the full page URL — short URLs are reserved for the dedicated button and the QR view. If UrlShortener isn't installed, neither button appears and the rest of the panel works the same.
 
-## Adding share services
+## Configuration
+
+Set the share mode via `$wgCitizenShareMode` in `LocalSettings.php`:
+
+```php
+$wgCitizenShareMode = 'auto'; // 'auto' | 'panel' | 'native'
+```
+
+| Value | When to use |
+| :--- | :--- |
+| `'auto'` *(default)* | Best of both worlds — most wikis should keep the default. |
+| `'panel'` | When you want consistent branding across all browsers, or when your curated share targets are central to your wiki's identity. |
+| `'native'` | When you want to defer entirely to the OS share experience. |
+
+## Extending the share panel
+
+### On-wiki JSON
 
 Create the page `MediaWiki:Citizen-share-services.json` on your wiki and paste a JSON array of service entries. Save the page, and the new services appear the next time anyone opens the panel.
 
-### Starter pack
+#### Starter pack
 
 Here's a Facebook / X / Mastodon / Bluesky setup you can copy in as-is. Icons are embedded directly, so nothing extra needs to be uploaded:
 
@@ -70,7 +88,7 @@ Here's a Facebook / X / Mastodon / Bluesky setup you can copy in as-is. Icons ar
 
 Icons are [Simple Icons](https://simpleicons.org/) (CC0).
 
-### Service fields
+#### Service fields
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
@@ -82,7 +100,7 @@ Icons are [Simple Icons](https://simpleicons.org/) (CC0).
 | `icon` | string | The icon shown on the tile. See [Icons](#icons) below. |
 | `file` | string | Alternative to `icon`: the filename of an SVG uploaded to your wiki. See [Icons](#icons) below. |
 
-### Icons
+#### Icons
 
 The icon is shown in white on the brand color, so single-color glyphs work best. Three ways to provide one:
 


### PR DESCRIPTION
## Summary

Pre-release hygiene pass on the four feature pages (`docs/src/features/*.md`). Three commits, layered:

- **Structure** (`a458ff7e`) — every page now follows the same skeleton: intro paragraph → `How it works` (user-facing behavior) → `Configuration` (LocalSettings.php-level `$wg*` vars, optional) → `Extending <feature>` (audience-specific sub-paths: on-wiki JSON, JavaScript API, custom styles).
- **Accuracy + prose** (`b445ea43`) — driven by a code-vs-docs audit of each page. Corrected outdated claims (history-mode action, animation-readiness timing, mobile-header inversion) and documented previously-missing surface area: `$wgCitizenEnableShare`, `visibilityCondition` field, `keybindings` entry property and shape, `addToken` action, `getItemDetail`, `tokenPattern` array form + `eagerMatch` / `variant`. Cut filler, prefer active voice, plain words for jargon.
- **Outline** (`37f54814`) — surface h3 headings in the right-rail outline so the new sub-sections are navigable. H4+ stay hidden.

Frontmatter `description` fields rewritten to one declarative sentence in user language ("A keyboard-driven palette…") instead of the previous "How to…" framing.

## Test plan

- [x] Build docs (`npm run docs:dev` from `docs/`) and walk through each feature page
- [x] Right-rail outline shows h3 sub-sections (Schema, JavaScript API, Keybindings, etc.) on feature pages and the config reference
- [x] `share.md`: intro paragraph reads cleanly, `$wgCitizenEnableShare` and URL-protocol callout render, UrlShortener "Show QR code" gating note is accurate
- [x] `preferences.md`: `visibilityCondition` row in the field reference table renders, examples still copy-pasteable
- [x] `command-palette.md`: new Keybindings sub-section renders with both tables, Migration callout still at the bottom under Extending
- [x] `performance-mode.md`: universal-selector note reads correctly
- [x] `npm run lint` from `docs/` is clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Extensively updated Command Palette, Performance Mode, Preferences, and Share feature documentation with detailed explanations and usage guidance
* Added comprehensive keybindings schema documentation and clarified configuration options for feature customization
* Reorganized documentation structure and enhanced outline generation for improved navigation and readability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1543)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->