### PR TITLE
fix(search): read prefill from search trigger element, not click target

### DIFF
--- a/resources/skins.citizen.scripts/search.js
+++ b/resources/skins.citizen.scripts/search.js
@@ -62,11 +62,8 @@ function bindOpenOnSlash( window, triggerOpen ) {
  */
 function bindSearchTrigger( document, triggerOpen ) {
 	document.querySelectorAll( '.citizen-search-trigger' ).forEach( ( trigger ) => {
-		trigger.addEventListener( 'click', ( event ) => {
-			const prefill = event.target.dataset && event.target.dataset.citizenSearchPrefill ?
-				event.target.dataset.citizenSearchPrefill :
-				null;
-			triggerOpen( prefill );
+		trigger.addEventListener( 'click', () => {
+			triggerOpen( trigger.dataset.citizenSearchPrefill || null );
 		} );
 	} );
 }

--- a/tests/vitest/skins.citizen.scripts/search.test.js
+++ b/tests/vitest/skins.citizen.scripts/search.test.js
@@ -143,5 +143,19 @@ describe( 'search', () => {
 
 			expect( triggerOpen ).toHaveBeenCalledWith( null );
 		} );
+
+		it( 'reads prefill from the trigger when a descendant is clicked', () => {
+			document.body.innerHTML =
+				'<details id="citizen-search-details"></details>' +
+				'<div class="citizen-search-trigger" data-citizen-search-prefill="Ship:">' +
+					'<div class="hangar-searchbar">Search ships <i></i></div>' +
+				'</div>';
+
+			init( { window, document, triggerOpen } );
+
+			document.querySelector( '.hangar-searchbar i' ).click();
+
+			expect( triggerOpen ).toHaveBeenCalledWith( 'Ship:' );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

- The `.citizen-search-trigger` click handler read `data-citizen-search-prefill` from `event.target`, which is the deepest descendant under the cursor — not the element the listener is bound to. When a trigger contained any child markup, clicks on those descendants resolved to `null` prefill.
- Read the dataset from the bound `trigger` element instead, so prefill works regardless of where inside the trigger the click lands.
- Added a regression test that clicks a nested element inside the trigger and asserts the prefill propagates.

### Before

```html
<div class="citizen-search-trigger" data-citizen-search-prefill="Ship:">
  <div class="hangar-searchbar">Search ships <i></i></div>
</div>
```

Clicking `.hangar-searchbar` or the `<i>` icon opened search with no prefill. Only clicking the bare gap on `.citizen-search-trigger` itself worked.

### After

Any click inside `.citizen-search-trigger` opens search with the configured prefill.

## Test plan

- [x] `npx vitest run tests/vitest/skins.citizen.scripts/search.test.js` — new test asserts nested-descendant click propagates prefill (9/9 pass)
- [x] Full Vitest suite — 948/948 pass (via pre-commit hook)
- [x] `npm run lint:js` clean on changed files
- [ ] Manual: click an inner element inside a `.citizen-search-trigger` (e.g. main-page searchbar) and verify the search opens with the configured prefill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search trigger behavior to properly read and apply prefill text values from trigger elements.

* **Tests**
  * Added test coverage to verify correct handling of prefill values when clicking nested elements within search triggers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1550)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->