### PR TITLE
feat(footer): ✨ forward-compat for MediaWiki 1.47 footer menu migration

### DIFF
--- a/includes/Components/CitizenComponentFooter.php
+++ b/includes/Components/CitizenComponentFooter.php
@@ -8,22 +8,27 @@ use MessageLocalizer;
 
 /**
  * CitizenComponentFooter component
+ *
+ * Consumes the polyfilled $parentData['data-portlets'] footer slice
+ * (data-footer-places, data-footer-icons) produced by
+ * SkinCitizen::polyfillFooterPortlets().
  */
 class CitizenComponentFooter implements CitizenComponent {
 
 	public function __construct(
 		private readonly MessageLocalizer $localizer,
-		private readonly array $footerData
+		private readonly array $footerPortlets
 	) {
 	}
 
 	public function getTemplateData(): array {
-		$localizer = $this->localizer;
-		$footerData = $this->footerData;
-
-		return $footerData + [
-			'msg-citizen-footer-desc' => $localizer->msg( "citizen-footer-desc" )->inContentLanguage()->parse(),
-			'msg-citizen-footer-tagline' => $localizer->msg( "citizen-footer-tagline" )->inContentLanguage()->parse()
+		return [
+			'data-footer-places' => $this->footerPortlets['data-footer-places'] ?? [],
+			'data-footer-icons' => $this->footerPortlets['data-footer-icons'] ?? [],
+			'msg-citizen-footer-desc' => $this->localizer
+				->msg( 'citizen-footer-desc' )->inContentLanguage()->parse(),
+			'msg-citizen-footer-tagline' => $this->localizer
+				->msg( 'citizen-footer-tagline' )->inContentLanguage()->parse(),
 		];
 	}
 }

--- a/includes/Components/CitizenComponentPageFooter.php
+++ b/includes/Components/CitizenComponentPageFooter.php
@@ -8,6 +8,9 @@ use MessageLocalizer;
 
 /**
  * CitizenComponentPageFooter component
+ *
+ * Consumes $parentData['data-portlets']['data-footer-info'] (polyfilled
+ * by SkinCitizen::polyfillFooterPortlets() for MW 1.43–1.46 compatibility).
  */
 class CitizenComponentPageFooter implements CitizenComponent {
 
@@ -20,10 +23,14 @@ class CitizenComponentPageFooter implements CitizenComponent {
 	public function getTemplateData(): array {
 		$footerData = $this->footerData;
 
-		// Add label to footer-info to use in PageFooter
+		if ( !isset( $footerData['array-items'] ) ) {
+			return $footerData;
+		}
+
 		foreach ( $footerData['array-items'] as &$item ) {
-			$msgKey = 'citizen-page-info-' . $item['name'];
-			$item['label'] = $this->localizer->msg( $msgKey )->text();
+			$name = $item['name'] ?? '';
+			$msg = $this->localizer->msg( 'citizen-page-info-' . $name );
+			$item['label'] = $msg->exists() ? $msg->text() : ( $item['label'] ?? '' );
 		}
 
 		return $footerData;

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -159,6 +159,7 @@ class SkinCitizen extends SkinMustache {
 	 */
 	public function getTemplateData(): array {
 		$parentData = parent::getTemplateData();
+		self::polyfillFooterPortlets( $parentData );
 
 		$config = $this->getConfig();
 		$localizer = $this->getContext();
@@ -379,6 +380,80 @@ class SkinCitizen extends SkinMustache {
 			'rel' => 'manifest',
 			'href' => $href,
 		] );
+	}
+
+	/**
+	 * Normalize a footer menu data array to the canonical Citizen shape that
+	 * Footer.mustache consumes.
+	 *
+	 * Different sources of footer menu data carry slightly different outer
+	 * fields — SkinComponentFooter::formatFooterDataForCurrentSpec strips
+	 * 'class' and injects 'className', whereas raw portlet output (from
+	 * SkinComponentMenu via getPortletData) keeps 'class' and never sets
+	 * 'className'. This helper standardises on Citizen's expected shape so
+	 * the template can render either source identically.
+	 *
+	 * @param array $data Source menu data (must include 'array-items' to be usable)
+	 * @param bool $isIcons True for footer-icons (toggles 'noprint' className)
+	 * @param string $id Canonical DOM id (e.g. 'footer-places')
+	 * @return array Canonical Citizen footer menu shape
+	 */
+	private static function normalizeFooterMenu( array $data, bool $isIcons, string $id ): array {
+		return [
+			'id' => $id,
+			'className' => $isIcons ? 'noprint' : null,
+			'array-items' => $data['array-items'] ?? [],
+		];
+	}
+
+	/**
+	 * Populate $parentData['data-portlets']['data-footer-{places,info,icons}']
+	 * so Citizen's templates can consume the modern portlet location on every
+	 * supported MW version.
+	 *
+	 * Either-or strategy: if the portlet bucket already carries items
+	 * (canonical source on MW 1.47+), keep it but normalize its shape.
+	 * Otherwise, build it from the legacy $parentData['data-footer'].*
+	 * slice (canonical source on MW 1.43–1.46). When both are empty, the
+	 * key is set to [] so Mustache skips the empty <nav> render.
+	 *
+	 * Trade-off: on MW 1.43–1.46, an extension that uses
+	 * SkinTemplateNavigation::Universal directly with a footer-* key would
+	 * populate only the portlet bucket, and this strategy would then NOT
+	 * fall back to the legacy bucket — so the built-in privacy/about/
+	 * disclaimer links would be dropped. This is accepted as a rare edge
+	 * case (the MW manual documents that the new hook "only applies to
+	 * modern skins using that menu"). T426358 forward-compat for MW 1.47
+	 * is the primary scope.
+	 *
+	 * @param array &$parentData The full parent template data array
+	 */
+	private static function polyfillFooterPortlets( array &$parentData ): void {
+		if ( !isset( $parentData['data-portlets'] ) || !is_array( $parentData['data-portlets'] ) ) {
+			$parentData['data-portlets'] = [];
+		}
+
+		$pairs = [
+			[ 'data-footer-places', 'data-places', false, 'footer-places' ],
+			[ 'data-footer-info', 'data-info', false, 'footer-info' ],
+			[ 'data-footer-icons', 'data-icons', true, 'footer-icons' ],
+		];
+
+		foreach ( $pairs as [ $portletKey, $legacyKey, $isIcons, $id ] ) {
+			$portlet = $parentData['data-portlets'][ $portletKey ] ?? null;
+			$legacy = $parentData['data-footer'][ $legacyKey ] ?? null;
+
+			if ( !empty( $portlet['array-items'] ) ) {
+				$source = $portlet;
+			} elseif ( !empty( $legacy['array-items'] ) ) {
+				$source = $legacy;
+			} else {
+				$parentData['data-portlets'][ $portletKey ] = [];
+				continue;
+			}
+
+			$parentData['data-portlets'][ $portletKey ] = self::normalizeFooterMenu( $source, $isIcons, $id );
+		}
 	}
 
 }

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -175,7 +175,10 @@ class SkinCitizen extends SkinMustache {
 		$components = [
 			'data-footer' => new CitizenComponentFooter(
 				$localizer,
-				$parentData['data-footer']
+				[
+					'data-footer-places' => $parentData['data-portlets']['data-footer-places'] ?? [],
+					'data-footer-icons' => $parentData['data-portlets']['data-footer-icons'] ?? [],
+				]
 			),
 			'data-main-menu' => new CitizenComponentMainMenu( $sidebar ),
 			'data-page-footer' => new CitizenComponentPageFooter(

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -183,7 +183,7 @@ class SkinCitizen extends SkinMustache {
 			'data-main-menu' => new CitizenComponentMainMenu( $sidebar ),
 			'data-page-footer' => new CitizenComponentPageFooter(
 				$localizer,
-				$parentData['data-footer']['data-info']
+				$parentData['data-portlets']['data-footer-info'] ?? []
 			),
 			'data-page-heading' => new CitizenComponentPageHeading(
 				$this->userFactory,

--- a/skin.json
+++ b/skin.json
@@ -62,7 +62,10 @@
 						"views",
 						"actions",
 						"variants",
-						"associated-pages"
+						"associated-pages",
+						"footer-info",
+						"footer-places",
+						"footer-icons"
 					],
 					"scripts": [
 						"skins.citizen.scripts"

--- a/templates/Footer.mustache
+++ b/templates/Footer.mustache
@@ -4,13 +4,13 @@
 	@prop string html of list item
 	@prop footerItem[] items
 
-	@typedef object footerRow
-	@prop string className of list element
+	@typedef object footerMenu
 	@prop string id of list element
+	@prop string|null className of list element
 	@prop footerItem[] array-items
 
-	footerRow[] array-footer-rows iterable list of footer rows
-	footerRow[] array-footer-icons iterable list of footer icons
+	footerMenu data-footer-places site links (privacy/about/disclaimer + Universal-hook additions)
+	footerMenu data-footer-icons site footer icons (noprint)
 	string msg-sitetitle
 	string msg-citizen-footer-desc
 	string msg-citizen-footer-tagline
@@ -26,11 +26,11 @@
 				</div>
 				<p id="footer-desc" class="citizen-footer__desc">{{{msg-citizen-footer-desc}}}</p>
 			</div>
-			{{#data-places}}{{>Footer__row}}{{/data-places}}
+			{{#data-footer-places}}{{>Footer__row}}{{/data-footer-places}}
 		</section>
 		<section class="citizen-footer__bottom">
 			<div id="footer-tagline">{{{msg-citizen-footer-tagline}}}</div>
-			{{#data-icons}}{{>Footer__row}}{{/data-icons}}
+			{{#data-footer-icons}}{{>Footer__row}}{{/data-footer-icons}}
 		</section>
 	</div>
 </footer>

--- a/tests/phpunit/Unit/Components/CitizenComponentFooterTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentFooterTest.php
@@ -16,51 +16,52 @@ use MessageLocalizer;
  */
 class CitizenComponentFooterTest extends MediaWikiUnitTestCase {
 
-	public function provideFooterData(): array {
+	public function provideFooterPortlets(): array {
 		return [
-			'Footer data with places and icons' => [
-				'places' => [
-					'footer-places-privacy' => [
-						'text' => 'Privacy policy',
-						'href' => '/wiki/Privacy_policy'
+			'footer portlets with places and icons' => [
+				[
+					'data-footer-places' => [
+						'id' => 'footer-places',
+						'className' => null,
+						'array-items' => [
+							[ 'id' => 'footer-places-privacy', 'html' => '<a>Privacy</a>' ],
+							[ 'id' => 'footer-places-about', 'html' => '<a>About</a>' ],
+						],
 					],
-					'footer-places-about' => [
-						'text' => 'About',
-						'href' => '/wiki/About'
-					]
+					'data-footer-icons' => [
+						'id' => 'footer-icons',
+						'className' => 'noprint',
+						'array-items' => [
+							[ 'id' => 'footer-poweredbyico', 'html' => '<img>' ],
+						],
+					],
 				],
-				'icons' => [
-					'poweredby' => [
-						'src' => '/path/to/icon.png',
-						'alt' => 'Powered by MediaWiki'
-					]
-				]
-			]
+			],
 		];
 	}
 
 	/**
 	 * @covers ::__construct
 	 * @covers ::getTemplateData
-	 * @dataProvider provideFooterData
+	 * @dataProvider provideFooterPortlets
 	 */
-	public function testGetTemplateData( array $footerData ): void {
+	public function testGetTemplateData( array $footerPortlets ): void {
 		$localizer = $this->createMock( MessageLocalizer::class );
 		$localizer->method( 'msg' )->willReturnCallback( function ( $key ) {
 			return $this->createConfiguredMock( Message::class, [
-				// Simulated localization output.
 				'inContentLanguage' => $this->createConfiguredMock( Message::class, [
-					'parse' => "$key-mocked"
-				] )
+					'parse' => "$key-mocked",
+				] ),
 			] );
 		} );
 
-		$component = new CitizenComponentFooter( $localizer, $footerData );
-		$expected = array_merge( $footerData, [
-			'msg-citizen-footer-desc' => 'citizen-footer-desc-mocked',
-			'msg-citizen-footer-tagline' => 'citizen-footer-tagline-mocked'
-		] );
+		$component = new CitizenComponentFooter( $localizer, $footerPortlets );
+		$result = $component->getTemplateData();
 
-		$this->assertSame( $expected, $component->getTemplateData() );
+		$this->assertSame( $footerPortlets['data-footer-places'], $result['data-footer-places'] );
+		$this->assertSame( $footerPortlets['data-footer-icons'], $result['data-footer-icons'] );
+		$this->assertArrayNotHasKey( 'data-footer-info', $result );
+		$this->assertSame( 'citizen-footer-desc-mocked', $result['msg-citizen-footer-desc'] );
+		$this->assertSame( 'citizen-footer-tagline-mocked', $result['msg-citizen-footer-tagline'] );
 	}
 }

--- a/tests/phpunit/Unit/Components/CitizenComponentPageFooterTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentPageFooterTest.php
@@ -21,66 +21,104 @@ class CitizenComponentPageFooterTest extends MediaWikiUnitTestCase {
 	 * @covers ::getTemplateData
 	 * @dataProvider provideFooterData
 	 */
-	public function testGetTemplateData( array $footerData, array $expected ): void {
-		// Create a mock MessageLocalizer
+	public function testGetTemplateData( array $footerData, array $expected, array $knownMessages ): void {
 		$localizer = $this->createMock( MessageLocalizer::class );
 		$localizer->method( 'msg' )
-			->willReturnCallback( function ( $key ) {
+			->willReturnCallback( function ( $key ) use ( $knownMessages ) {
+				$exists = in_array( $key, $knownMessages, true );
 				$message = $this->createMock( Message::class );
-				$message->method( 'text' )
-					->willReturn( 'Translated ' . $key );
+				$message->method( 'exists' )->willReturn( $exists );
+				$message->method( 'text' )->willReturn( 'Translated ' . $key );
 				return $message;
 			} );
 
-		// Create component instance
 		$component = new CitizenComponentPageFooter( $localizer, $footerData );
-
-		// Get template data
 		$result = $component->getTemplateData();
 
-		// Assertions
 		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'array-items', $result );
-		$this->assertSameSize( $expected, $result['array-items'] );
+		$this->assertSameSize( $expected, $result['array-items'] ?? [] );
 
-		// Check each item
-		foreach ( $result['array-items'] as $item ) {
-			$name = $item['name'];
-			$this->assertArrayHasKey( $name, $expected );
+		foreach ( $result['array-items'] ?? [] as $item ) {
+			$name = $item['name'] ?? '';
+			$this->assertArrayHasKey( $name, $expected, "Unexpected item: $name" );
 			$this->assertSame( $expected[$name], $item );
 		}
 	}
 
 	public static function provideFooterData(): iterable {
-		yield 'footer with lastmod and viewcount' => [
+		yield 'first-party items with matching messages' => [
 			[
 				'array-items' => [
-					[
-						'name' => 'lastmod',
-						'id' => 'footer-info-lastmod',
-						'html' => 'Last modified: 2024-03-10'
-					],
-					[
-						'name' => 'viewcount',
-						'id' => 'footer-info-viewcount',
-						'html' => 'Views: 100'
-					]
-				]
+					[ 'name' => 'lastmod', 'id' => 'footer-info-lastmod', 'html' => 'Last modified: 2024-03-10' ],
+					[ 'name' => 'copyright', 'id' => 'footer-info-copyright', 'html' => '(c) 2024' ],
+				],
 			],
 			[
 				'lastmod' => [
 					'name' => 'lastmod',
 					'id' => 'footer-info-lastmod',
 					'html' => 'Last modified: 2024-03-10',
-					'label' => 'Translated citizen-page-info-lastmod'
+					'label' => 'Translated citizen-page-info-lastmod',
 				],
-				'viewcount' => [
-					'name' => 'viewcount',
-					'id' => 'footer-info-viewcount',
-					'html' => 'Views: 100',
-					'label' => 'Translated citizen-page-info-viewcount'
-				]
-			]
+				'copyright' => [
+					'name' => 'copyright',
+					'id' => 'footer-info-copyright',
+					'html' => '(c) 2024',
+					'label' => 'Translated citizen-page-info-copyright',
+				],
+			],
+			[ 'citizen-page-info-lastmod', 'citizen-page-info-copyright' ],
+		];
+
+		yield 'third-party item with explicit label falls back to label' => [
+			[
+				'array-items' => [
+					[
+						'name' => 'externalref',
+						'id' => 'footer-info-externalref',
+						'html' => '<a>Ref</a>',
+						'label' => 'External reference',
+					],
+				],
+			],
+			[
+				'externalref' => [
+					'name' => 'externalref',
+					'id' => 'footer-info-externalref',
+					'html' => '<a>Ref</a>',
+					'label' => 'External reference',
+				],
+			],
+			[],
+		];
+
+		yield 'third-party item without label falls back to empty string' => [
+			[
+				'array-items' => [
+					[ 'name' => 'mystery', 'id' => 'footer-info-mystery', 'html' => 'opaque' ],
+				],
+			],
+			[
+				'mystery' => [
+					'name' => 'mystery',
+					'id' => 'footer-info-mystery',
+					'html' => 'opaque',
+					'label' => '',
+				],
+			],
+			[],
+		];
+
+		yield 'empty array-items' => [
+			[ 'array-items' => [] ],
+			[],
+			[],
+		];
+
+		yield 'no array-items key' => [
+			[],
+			[],
+			[],
 		];
 	}
 }

--- a/tests/phpunit/Unit/SkinCitizenFooterPolyfillTest.php
+++ b/tests/phpunit/Unit/SkinCitizenFooterPolyfillTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Unit;
+
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWikiUnitTestCase;
+use ReflectionMethod;
+
+/**
+ * @group Citizen
+ * @coversDefaultClass \MediaWiki\Skins\Citizen\SkinCitizen
+ */
+class SkinCitizenFooterPolyfillTest extends MediaWikiUnitTestCase {
+
+	private function invokeNormalize( array $data, bool $isIcons, string $id ): array {
+		$method = new ReflectionMethod( SkinCitizen::class, 'normalizeFooterMenu' );
+		return $method->invoke( null, $data, $isIcons, $id );
+	}
+
+	private function invokePolyfill( array &$parentData ): void {
+		$method = new ReflectionMethod( SkinCitizen::class, 'polyfillFooterPortlets' );
+		$method->invokeArgs( null, [ &$parentData ] );
+	}
+
+	/**
+	 * @covers ::normalizeFooterMenu
+	 */
+	public function testNormalizeProducesCanonicalShape(): void {
+		$data = [
+			'id' => 'p-footer-places',
+			'class' => 'mw-portlet mw-portlet-footer-places',
+			'array-items' => [
+				[ 'id' => 'footer-places-privacy', 'html' => '<a>Privacy</a>' ],
+			],
+		];
+
+		$result = $this->invokeNormalize( $data, false, 'footer-places' );
+
+		$this->assertSame( 'footer-places', $result['id'] );
+		$this->assertNull( $result['className'] );
+		$this->assertCount( 1, $result['array-items'] );
+		$this->assertSame( 'footer-places-privacy', $result['array-items'][0]['id'] );
+		$this->assertArrayNotHasKey( 'class', $result );
+	}
+
+	/**
+	 * @covers ::normalizeFooterMenu
+	 */
+	public function testNormalizeIconsSetsNoprintClassName(): void {
+		$result = $this->invokeNormalize( [ 'array-items' => [] ], true, 'footer-icons' );
+
+		$this->assertSame( 'noprint', $result['className'] );
+	}
+
+	/**
+	 * @covers ::normalizeFooterMenu
+	 */
+	public function testNormalizeDefaultsArrayItemsWhenKeyAbsentInHelperIsolation(): void {
+		$result = $this->invokeNormalize( [], false, 'footer-info' );
+
+		$this->assertSame( [], $result['array-items'] );
+	}
+
+	/**
+	 * @covers ::polyfillFooterPortlets
+	 */
+	public function testPolyfillUsesPortletWhenPresent(): void {
+		$parentData = [
+			'data-portlets' => [
+				'data-footer-places' => [
+					'id' => 'p-footer-places',
+					'class' => 'mw-portlet mw-portlet-footer-places',
+					'array-items' => [
+						[ 'id' => 'footer-places-ext', 'html' => '<a>From portlet</a>' ],
+					],
+				],
+			],
+			'data-footer' => [
+				'data-places' => [
+					'id' => 'footer-places',
+					'array-items' => [
+						[ 'id' => 'footer-places-privacy', 'html' => '<a>Privacy</a>' ],
+					],
+				],
+			],
+		];
+
+		$this->invokePolyfill( $parentData );
+
+		$this->assertSame( 'footer-places', $parentData['data-portlets']['data-footer-places']['id'] );
+		$this->assertNull( $parentData['data-portlets']['data-footer-places']['className'] );
+		$this->assertCount( 1, $parentData['data-portlets']['data-footer-places']['array-items'] );
+		$this->assertSame(
+			'footer-places-ext',
+			$parentData['data-portlets']['data-footer-places']['array-items'][0]['id']
+		);
+	}
+
+	/**
+	 * @covers ::polyfillFooterPortlets
+	 */
+	public function testPolyfillFallsBackToLegacyWhenPortletEmpty(): void {
+		$parentData = [
+			'data-portlets' => [],
+			'data-footer' => [
+				'data-places' => [
+					'id' => 'footer-places',
+					'array-items' => [
+						[ 'id' => 'footer-places-privacy', 'html' => '<a>Privacy</a>' ],
+					],
+				],
+				'data-info' => [
+					'id' => 'footer-info',
+					'array-items' => [
+						[ 'id' => 'footer-info-lastmod', 'html' => 'modified' ],
+					],
+				],
+				'data-icons' => [
+					'id' => 'footer-icons',
+					'array-items' => [
+						[ 'id' => 'footer-poweredbyico', 'html' => '<img>' ],
+					],
+				],
+			],
+		];
+
+		$this->invokePolyfill( $parentData );
+
+		$this->assertSame(
+			'footer-places-privacy',
+			$parentData['data-portlets']['data-footer-places']['array-items'][0]['id']
+		);
+		$this->assertSame( 'footer-info', $parentData['data-portlets']['data-footer-info']['id'] );
+		$this->assertSame(
+			'footer-info-lastmod',
+			$parentData['data-portlets']['data-footer-info']['array-items'][0]['id']
+		);
+		$this->assertSame( 'noprint', $parentData['data-portlets']['data-footer-icons']['className'] );
+		$this->assertSame(
+			'footer-poweredbyico',
+			$parentData['data-portlets']['data-footer-icons']['array-items'][0]['id']
+		);
+	}
+
+	/**
+	 * @covers ::polyfillFooterPortlets
+	 */
+	public function testPolyfillBothEmptyYieldsEmptyArray(): void {
+		$parentData = [
+			'data-portlets' => [],
+			'data-footer' => [
+				'data-places' => [ 'array-items' => [] ],
+			],
+		];
+
+		$this->invokePolyfill( $parentData );
+
+		$this->assertSame( [], $parentData['data-portlets']['data-footer-places'] );
+	}
+
+	/**
+	 * @covers ::polyfillFooterPortlets
+	 */
+	public function testPolyfillHandlesMissingDataPortletsKey(): void {
+		$parentData = [
+			'data-footer' => [
+				'data-places' => [
+					'id' => 'footer-places',
+					'array-items' => [
+						[ 'id' => 'footer-places-privacy', 'html' => '<a>Privacy</a>' ],
+					],
+				],
+			],
+		];
+
+		$this->invokePolyfill( $parentData );
+
+		$this->assertIsArray( $parentData['data-portlets'] );
+		$this->assertSame(
+			'footer-places-privacy',
+			$parentData['data-portlets']['data-footer-places']['array-items'][0]['id']
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Forward-compat for [T426358](https://phabricator.wikimedia.org/T426358) — MediaWiki 1.47's migration of footer menus from `$parentData['data-footer'].*` to `$parentData['data-portlets'].data-footer-{places,info,icons}` populated via `SkinTemplateNavigation::Universal`.

Citizen now reads footer menu data from the modern portlet location on every supported MW version. A polyfill bridges 1.43–1.46 (where the new keys may be empty) so the same template path works everywhere.

## What changed

- **`SkinCitizen::polyfillFooterPortlets()`** — populates `\$parentData['data-portlets'].data-footer-{places,info,icons}` on every MW version. Either-or strategy: prefer the portlet bucket when it carries items (canonical on 1.47+), otherwise fall back to the legacy `data-footer.*` slice. Pure helper `normalizeFooterMenu()` produces the canonical Citizen shape (id, className, array-items).
- **`CitizenComponentFooter`** — consumes the polyfilled portlet slice. Exposes `data-footer-places` and `data-footer-icons` for the site footer template.
- **`CitizenComponentPageFooter`** — consumes `data-portlets.data-footer-info`. Falls back to the item's own `label` (or empty string) when `citizen-page-info-{name}` doesn't exist. Third-party items added via `SkinTemplateNavigation::Universal` no longer render as `⧼key⧽` placeholders.
- **`Footer.mustache`** — section names migrated to `data-footer-places` / `data-footer-icons`.
- **`skin.json`** — declares `footer-info`, `footer-places`, `footer-icons` in `menus` to opt out of MW 1.47's legacy forwarding shim.

## Compatibility

| MW version | Behavior |
|---|---|
| 1.43–1.46 | \`data-portlets.data-footer-*\` is typically empty; polyfill populates from \`data-footer.*\`. No change in rendered output. |
| 1.47+ | \`data-portlets.data-footer-*\` is the canonical source; Citizen reads from there directly. The \`menus\` declaration skips the legacy forwarding shim. |

Rendered HTML is byte-identical when no extension uses the new Universal hook for footer items, so no cache-coherence two-commit split is needed.

## Trade-off note

The polyfill uses either-or, not merging. On 1.43–1.46, if an extension uses \`SkinTemplateNavigation::Universal\` to add \`footer-*\` items directly, the portlet bucket would carry only the extension's items and the legacy built-ins (privacy/about/disclaimer) would be dropped. The MediaWiki manual documents the new hook as "only applying to modern skins", so this is expected to be rare; documented in the \`polyfillFooterPortlets\` docblock.

## Test plan

- [ ] PHPUnit suite passes (\`composer phpunit\`) — 129 tests
- [ ] Lints + style checks pass (\`composer preflight\`)
- [ ] Site footer renders correctly (privacy/about/disclaimer, footer icons)
- [ ] PageFooter renders article metadata with localized labels (no \`⧼key⧽\`)
- [ ] Print preview still hides \`#footer-icons\` (\`.noprint\` class intact)
- [ ] XSS test with \`?uselang=x-xss\` passes

Bug: T426358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reorganized footer component to better handle and display footer sections including places, footer information, and icons.
  * Enhanced footer menu portlet system for improved rendering and organization of footer menu items.
  * Improved footer template structure for better content organization and display reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1557)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->