### PR TITLE
Polish menu and command palette open and close animation

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -685,31 +685,47 @@ module.exports = exports = defineComponent( {
 	}
 }
 
-// Palette entrance/exit
-.citizen-command-palette-enter-active,
-.citizen-command-palette-leave-active {
+// Palette entrance/exit — clip-path expand from top + translate, matching the
+// menu animation pattern. Asymmetric timing: decelerate enter, accelerate exit.
+.citizen-command-palette-enter-active {
 	transition-timing-function: var( --transition-timing-function-ease-out );
 	transition-duration: var( --transition-duration-medium );
-	transition-property: transform, opacity;
+	transition-property: clip-path, transform, opacity;
 }
 
-.citizen-command-palette-enter-from {
-	opacity: 0;
-	transform: scale( 1.06 );
-	transform-origin: 50% 0;
+.citizen-command-palette-leave-active {
+	transition-timing-function: var( --transition-timing-function-ease-in );
+	transition-duration: var( --transition-duration-base );
+	transition-property: clip-path, transform, opacity;
 }
 
+.citizen-command-palette-enter-from,
 .citizen-command-palette-leave-to {
 	opacity: 0;
-	transform: scale( 1.04 );
-	transform-origin: 50% 0;
+	clip-path: inset( 0 0 100% 0 );
+	transform: translateY( calc( var( --space-xs ) * -1 ) );
 }
 
-// Backdrop entrance/exit
-.citizen-command-palette-backdrop-enter-active,
-.citizen-command-palette-backdrop-leave-active {
+// Explicit open-state endpoints so clip-path has two inset() values to
+// interpolate between. Without this, clip-path animates discretely between
+// inset() and the default (none) and the reveal jumps.
+.citizen-command-palette-enter-to,
+.citizen-command-palette-leave-from {
+	opacity: 1;
+	clip-path: inset( 0 0 0 0 );
+	transform: translateY( 0 );
+}
+
+// Backdrop entrance/exit — sync timing with the palette
+.citizen-command-palette-backdrop-enter-active {
 	transition-timing-function: var( --transition-timing-function-ease-out );
 	transition-duration: var( --transition-duration-medium );
+	transition-property: opacity;
+}
+
+.citizen-command-palette-backdrop-leave-active {
+	transition-timing-function: var( --transition-timing-function-ease-in );
+	transition-duration: var( --transition-duration-base );
 	transition-property: opacity;
 }
 

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -611,8 +611,6 @@ module.exports = exports = defineComponent( {
 		position: fixed;
 		inset: 0;
 		background-color: var( --background-color-backdrop-light );
-		-webkit-backdrop-filter: var( --backdrop-filter-blur );
-		backdrop-filter: var( --backdrop-filter-blur );
 	}
 
 	&__body {

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -190,6 +190,16 @@
 	}
 }
 
+// Honour the OS-level "reduce transparency" preference by disabling the
+// frosted glass effect, matching what the manual performance-mode opt-in does.
+// stylelint-disable-next-line plugin/use-baseline
+@media ( prefers-reduced-transparency: reduce ) {
+	:root {
+		--backdrop-filter-frosted-glass: none;
+		--opacity-glass: 1;
+	}
+}
+
 // T400838
 .citizen-feature-image-dimming-clientpref-1 {
 	:root.skin-theme-clientpref-night& {

--- a/resources/skins.citizen.styles/components/Drawer.less
+++ b/resources/skins.citizen.styles/components/Drawer.less
@@ -1,19 +1,22 @@
 .citizen-drawer {
 	&__card {
 		.mixin-citizen-header-card( start );
-		transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
+		--citizen-clip-closed: var( --citizen-clip-expand-up );
+		--citizen-translate-closed: var( --citizen-translate-expand-up );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			.citizen-header-position-left & {
 				right: unset;
 				left: 100%;
-				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-start );
+				--citizen-clip-closed: var( --citizen-clip-expand-right );
+				--citizen-translate-closed: var( --citizen-translate-expand-right );
 			}
 
 			.citizen-header-position-right & {
 				right: 100%;
 				left: unset;
-				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-start );
+				--citizen-clip-closed: var( --citizen-clip-expand-left );
+				--citizen-translate-closed: var( --citizen-translate-expand-left );
 			}
 
 			.citizen-header-position-top & {
@@ -21,7 +24,8 @@
 				right: unset;
 				bottom: unset;
 				left: 0;
-				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-start );
+				--citizen-clip-closed: var( --citizen-clip-expand-down );
+				--citizen-translate-closed: var( --citizen-translate-expand-down );
 			}
 
 			.citizen-header-position-bottom & {
@@ -29,7 +33,8 @@
 				right: unset;
 				bottom: 100%;
 				left: 0;
-				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
+				--citizen-clip-closed: var( --citizen-clip-expand-up );
+				--citizen-translate-closed: var( --citizen-translate-expand-up );
 			}
 		}
 	}

--- a/resources/skins.citizen.styles/components/Dropdown.less
+++ b/resources/skins.citizen.styles/components/Dropdown.less
@@ -126,8 +126,6 @@
 				content: '';
 				background: var( --background-color-backdrop-light );
 				opacity: 0;
-				-webkit-backdrop-filter: var( --backdrop-filter-blur );
-				backdrop-filter: var( --backdrop-filter-blur );
 				transition-timing-function: var( --transition-timing-function-ease );
 				transition-duration: var( --transition-duration-base );
 				transition-property: opacity;

--- a/resources/skins.citizen.styles/components/Dropdown.less
+++ b/resources/skins.citizen.styles/components/Dropdown.less
@@ -6,7 +6,7 @@
 		content-visibility: hidden;
 		transition-timing-function: var( --transition-timing-function-ease-in );
 		transition-duration: var( --transition-duration-base );
-		transition-property: transform, content-visibility;
+		transition-property: clip-path, transform, content-visibility;
 		transition-behavior: allow-discrete;
 
 		.citizen-menu__card-content {
@@ -59,13 +59,13 @@
 		&[ open ] {
 			+ .citizen-menu__card {
 				content-visibility: visible;
+				clip-path: inset( 0 0 0 0 );
 				transform: none;
 				transition-timing-function: var( --transition-timing-function-ease-out );
 				transition-duration: var( --transition-duration-medium );
 
 				.citizen-menu__card-content {
 					opacity: 1;
-					transition-delay: var( --transition-delay-menu );
 					transition-timing-function: var( --transition-timing-function-ease-out );
 					transition-duration: var( --transition-duration-medium );
 				}
@@ -82,19 +82,22 @@
 
 	.citizen-header__end & .citizen-menu__card {
 		.mixin-citizen-header-card( end );
-		transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-end );
+		--citizen-clip-closed: var( --citizen-clip-expand-up );
+		--citizen-translate-closed: var( --citizen-translate-expand-up );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			.citizen-header-position-left & {
 				right: unset;
 				left: 100%;
-				transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
+				--citizen-clip-closed: var( --citizen-clip-expand-right );
+				--citizen-translate-closed: var( --citizen-translate-expand-right );
 			}
 
 			.citizen-header-position-right & {
 				right: 100%;
 				left: unset;
-				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-end );
+				--citizen-clip-closed: var( --citizen-clip-expand-left );
+				--citizen-translate-closed: var( --citizen-translate-expand-left );
 			}
 
 			.citizen-header-position-top & {
@@ -102,7 +105,8 @@
 				right: 0;
 				bottom: unset;
 				left: unset;
-				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-start );
+				--citizen-clip-closed: var( --citizen-clip-expand-down );
+				--citizen-translate-closed: var( --citizen-translate-expand-down );
 			}
 
 			.citizen-header-position-bottom & {
@@ -110,7 +114,8 @@
 				right: 0;
 				bottom: 100%;
 				left: unset;
-				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-end );
+				--citizen-clip-closed: var( --citizen-clip-expand-up );
+				--citizen-translate-closed: var( --citizen-translate-expand-up );
 			}
 		}
 	}
@@ -126,7 +131,8 @@
 				content: '';
 				background: var( --background-color-backdrop-light );
 				opacity: 0;
-				transition-timing-function: var( --transition-timing-function-ease );
+				// Sync close timing with the card
+				transition-timing-function: var( --transition-timing-function-ease-in );
 				transition-duration: var( --transition-duration-base );
 				transition-property: opacity;
 			}
@@ -137,6 +143,8 @@
 					inset: 0;
 					z-index: @z-index-off-canvas-backdrop;
 					opacity: 1;
+					// Sync open timing with the card
+					transition-timing-function: var( --transition-timing-function-ease-out );
 					transition-duration: var( --transition-duration-medium );
 				}
 

--- a/resources/skins.citizen.styles/components/Menu.less
+++ b/resources/skins.citizen.styles/components/Menu.less
@@ -2,8 +2,21 @@
 	.mixin-citizen-font-styles( 'small' );
 
 	&__card {
-		--transform-origin-offset-start: var( --space-xs );
-		--transform-origin-offset-end: ~'calc( 100% - var( --space-xs ) )';
+		// Named clip-path and matching translate values for the card's closed state.
+		// Each describes the direction the card visually expands and slides as it
+		// opens — trigger is on the OPPOSITE side of the expand direction.
+		// Each consumer scope (Drawer, Pagetools, Search, ToC, header__end menus,
+		// StickyHeader) picks a direction by setting --citizen-clip-closed and
+		// --citizen-translate-closed; if a menu doesn't set them, the card renders
+		// without clipping or offset (no animation).
+		--citizen-clip-expand-up: inset( 100% 0 0 0 );
+		--citizen-clip-expand-down: inset( 0 0 100% 0 );
+		--citizen-clip-expand-right: inset( 0 100% 0 0 );
+		--citizen-clip-expand-left: inset( 0 0 0 100% );
+		--citizen-translate-expand-up: translateY( var( --space-xs ) );
+		--citizen-translate-expand-down: translateY( calc( var( --space-xs ) * -1 ) );
+		--citizen-translate-expand-right: translateX( calc( var( --space-xs ) * -1 ) );
+		--citizen-translate-expand-left: translateX( var( --space-xs ) );
 		margin: var( --space-xs );
 		contain: content;
 		-webkit-user-select: none;
@@ -11,7 +24,8 @@
 		border: var( --border-width-base ) solid var( --border-color-base );
 		border-radius: var( --border-radius-medium );
 		box-shadow: var( --box-shadow-large );
-		transform: scale( 0 );
+		clip-path: var( --citizen-clip-closed );
+		transform: var( --citizen-translate-closed );
 		.mixin-citizen-frosted-glass;
 
 		&-content {

--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -15,11 +15,14 @@
 			display: grid;
 			gap: var( --space-xs );
 			max-height: 60vh;
-			transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-end );
+			// Mobile toolbar sits at the bottom; card expands upward.
+			--citizen-clip-closed: var( --citizen-clip-expand-up );
+			--citizen-translate-closed: var( --citizen-translate-expand-up );
 
 			@media ( min-width: @min-width-breakpoint-desktop ) {
 				top: 100%;
-				transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-start );
+				--citizen-clip-closed: var( --citizen-clip-expand-down );
+				--citizen-translate-closed: var( --citizen-translate-expand-down );
 			}
 
 			&-content {

--- a/resources/skins.citizen.styles/components/Search.less
+++ b/resources/skins.citizen.styles/components/Search.less
@@ -10,7 +10,9 @@
 		max-width: ~'calc(100vw - var( --padding-page ) )';
 		max-height: var( --header-card-maxheight );
 		margin-inline: auto;
-		transform-origin: center var( --transform-origin-offset-start );
+		// Search bar at the top; card drops down.
+		--citizen-clip-closed: var( --citizen-clip-expand-down );
+		--citizen-translate-closed: var( --citizen-translate-expand-down );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			top: @position-offset-y-desktop;

--- a/resources/skins.citizen.styles/components/StickyHeader.less
+++ b/resources/skins.citizen.styles/components/StickyHeader.less
@@ -148,7 +148,8 @@
 			right: calc( var( --space-xs ) * -1 );
 			max-width: 80vw;
 			max-height: 60vh;
-			transform-origin: var( --transform-origin-offset-end ) var( --transform-origin-offset-start );
+			--citizen-clip-closed: var( --citizen-clip-expand-down );
+			--citizen-translate-closed: var( --citizen-translate-expand-down );
 
 			&-content {
 				padding-block: var( --space-xs );

--- a/resources/skins.citizen.styles/components/TableOfContents.less
+++ b/resources/skins.citizen.styles/components/TableOfContents.less
@@ -151,7 +151,9 @@
 			// in extremely short height. but it should be good for now
 			max-height: ~'calc( var( --header-card-maxheight ) - 8rem )';
 			padding: var( --space-xs );
-			transform-origin: var( --transform-origin-offset-start ) var( --transform-origin-offset-end );
+			// Floating button at the bottom; card expands upward.
+			--citizen-clip-closed: var( --citizen-clip-expand-up );
+			--citizen-translate-closed: var( --citizen-translate-expand-up );
 		}
 
 		.citizen-dropdown {
@@ -211,6 +213,7 @@
 			border: 0;
 			border-radius: 0;
 			box-shadow: none;
+			clip-path: none;
 			transform: none;
 
 			.citizen-menu__card-content {

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -68,11 +68,9 @@
 	--space-xxl: calc( 2 * var( --space-unit ) );
 
 	// Transition
-	--transition-delay-menu: 100ms;
-	// @see https://www.joshwcomeau.com/animation/css-transitions/#custom-curves-7
-	--transition-timing-function-ease: cubic-bezier( 0.44, 0.21, 0, 1 );
-	--transition-timing-function-ease-in: cubic-bezier( 0.75, 0, 1, 1 );
-	--transition-timing-function-ease-out: cubic-bezier( 0.215, 0.61, 0.355, 1 );
+	--transition-timing-function-ease: cubic-bezier( 0.2, 0, 0, 1 );
+	--transition-timing-function-ease-in: cubic-bezier( 0.3, 0, 0.8, 0.15 );
+	--transition-timing-function-ease-out: cubic-bezier( 0.05, 0.7, 0.1, 1 );
 
 	// Transform
 	// Add affordance to thumbnails to replace magnify icon


### PR DESCRIPTION
## Summary
- Replace the menu card's scale-from-corner animation with an axis-anchored `clip-path` expand + small translate, applied across all seven dropdown menus (Drawer, UserMenu, Preferences, Search, PageTools more/languages, TableOfContents). Per-header-position direction comes from named tokens defined in `Menu.less`.
- Apply the same animation pattern to the command palette entrance/exit.
- Swap `--transition-timing-function-ease/-in/-out` values for an emphasized set (front-loaded enter, accelerated exit), tighten the inner content fade (no delay, matched curve), and sync the mobile dismiss overlay timing to the card.
- Drop `backdrop-filter: blur(2px)` from the mobile dismiss overlay on the menu drawer and from the command palette backdrop. Tracing showed this blur ran a fullscreen GPU shader every frame the overlay was rendered.
- Honour `prefers-reduced-transparency: reduce` automatically (drops the frosted-glass effect at the OS level, mirroring the manual `performance-mode` opt-in).

## Commits
Five self-contained commits, organized so each can be reviewed and reverted independently:

1. `feat(a11y): respect the reduce-transparency preference`
2. `perf(dropdown): drop blur on mobile dismiss overlay`
3. `feat(menu): polish open and close animation`
4. `feat(commandPalette): polish entrance and exit animation`
5. `perf(commandPalette): drop blur on dismiss backdrop`

## Performance

Two perf commits drop \`backdrop-filter: blur(2px)\` from the dismiss overlays on the menu drawer and command palette. Tested on starcitizen.tools at ~500 px viewport with 6× CPU throttle, 8 open/close cycles per variant.

The blur ran a GPU shader over the full viewport every frame the overlay was rendered — not just during the open/close transition. With the drawer or palette typically open for hundreds of milliseconds, the bulk of the cost was paid while the user was reading the menu, not while it was animating.

Isolated measurement (overlay change only, animation unchanged):

| Metric | Before (\`blur(2px)\`) | After (no blur) | Change |
| --- | ---: | ---: | ---: |
| Dropped frames | 69 | 34 | **↓51%** |
| Drop rate | 67.0% | 52.3% | ↓22% |
| Worst-case single-frame GPU stall | 173.5 ms | 5.4 ms | **↓97%** |
| GPU \`StartDrawToSwapStart\` total | 2126 ms | 706 ms | ↓67% |
| GPU pipeline total | 10.5 s | 8.5 s | ↓19% |

The animation pass is a visual polish change — not perf-motivated, no perf delta claimed.

## Test plan

- [x] Open each of the 7 menus on desktop (≥1120 px) at each header position (left / right / top / bottom). Verify the card expands outward from the trigger edge along the correct axis.
- [x] Open each menu at mobile width (<1120 px). Verify the dim overlay appears (no blur) and the card opens correctly.
- [x] Open the command palette on desktop and mobile. Verify entrance/exit motion.
- [x] Emulate \`prefers-reduced-motion: reduce\` via DevTools. Verify menus and palette open/close instantly.
- [x] Emulate \`prefers-reduced-transparency: reduce\`. Verify card backgrounds become opaque without breaking visual hierarchy.
- [x] Optionally: trace the drawer open on a mid-tier Android device. Confirm the overlay-blur removal translates to fewer dropped frames in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated UI component animations for smoother transitions across command palette, menus, and dropdowns.

* **Accessibility**
  * Added support for the operating system's "reduce transparency" setting, disabling frosted glass effects when enabled.

* **Style**
  * Refined animation timing curves for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->