### PR TITLE
refactor(menu): centralize card expand direction in the cascade

### DIFF
--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -19,6 +19,13 @@
 	backdrop-filter: var( --backdrop-filter-frosted-glass );
 }
 
+// Pick the closed-state direction for a card.
+// @direction: up | down | left | right (trigger sits on the OPPOSITE side).
+.mixin-citizen-card-expand( @direction ) {
+	--citizen-clip-closed: ~'var( --citizen-clip-expand-@{direction} )';
+	--citizen-translate-closed: ~'var( --citizen-translate-expand-@{direction} )';
+}
+
 // Header card popups
 .mixin-citizen-header-card( @position ) {
 	right: 0;

--- a/resources/skins.citizen.styles/components/Drawer.less
+++ b/resources/skins.citizen.styles/components/Drawer.less
@@ -1,22 +1,16 @@
 .citizen-drawer {
 	&__card {
 		.mixin-citizen-header-card( start );
-		--citizen-clip-closed: var( --citizen-clip-expand-up );
-		--citizen-translate-closed: var( --citizen-translate-expand-up );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			.citizen-header-position-left & {
 				right: unset;
 				left: 100%;
-				--citizen-clip-closed: var( --citizen-clip-expand-right );
-				--citizen-translate-closed: var( --citizen-translate-expand-right );
 			}
 
 			.citizen-header-position-right & {
 				right: 100%;
 				left: unset;
-				--citizen-clip-closed: var( --citizen-clip-expand-left );
-				--citizen-translate-closed: var( --citizen-translate-expand-left );
 			}
 
 			.citizen-header-position-top & {
@@ -24,8 +18,6 @@
 				right: unset;
 				bottom: unset;
 				left: 0;
-				--citizen-clip-closed: var( --citizen-clip-expand-down );
-				--citizen-translate-closed: var( --citizen-translate-expand-down );
 			}
 
 			.citizen-header-position-bottom & {
@@ -33,8 +25,6 @@
 				right: unset;
 				bottom: 100%;
 				left: 0;
-				--citizen-clip-closed: var( --citizen-clip-expand-up );
-				--citizen-translate-closed: var( --citizen-translate-expand-up );
 			}
 		}
 	}

--- a/resources/skins.citizen.styles/components/Dropdown.less
+++ b/resources/skins.citizen.styles/components/Dropdown.less
@@ -82,22 +82,16 @@
 
 	.citizen-header__end & .citizen-menu__card {
 		.mixin-citizen-header-card( end );
-		--citizen-clip-closed: var( --citizen-clip-expand-up );
-		--citizen-translate-closed: var( --citizen-translate-expand-up );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			.citizen-header-position-left & {
 				right: unset;
 				left: 100%;
-				--citizen-clip-closed: var( --citizen-clip-expand-right );
-				--citizen-translate-closed: var( --citizen-translate-expand-right );
 			}
 
 			.citizen-header-position-right & {
 				right: 100%;
 				left: unset;
-				--citizen-clip-closed: var( --citizen-clip-expand-left );
-				--citizen-translate-closed: var( --citizen-translate-expand-left );
 			}
 
 			.citizen-header-position-top & {
@@ -105,8 +99,6 @@
 				right: 0;
 				bottom: unset;
 				left: unset;
-				--citizen-clip-closed: var( --citizen-clip-expand-down );
-				--citizen-translate-closed: var( --citizen-translate-expand-down );
 			}
 
 			.citizen-header-position-bottom & {
@@ -114,8 +106,6 @@
 				right: 0;
 				bottom: 100%;
 				left: unset;
-				--citizen-clip-closed: var( --citizen-clip-expand-up );
-				--citizen-translate-closed: var( --citizen-translate-expand-up );
 			}
 		}
 	}

--- a/resources/skins.citizen.styles/components/Menu.less
+++ b/resources/skins.citizen.styles/components/Menu.less
@@ -2,21 +2,16 @@
 	.mixin-citizen-font-styles( 'small' );
 
 	&__card {
-		// Named clip-path and matching translate values for the card's closed state.
-		// Each describes the direction the card visually expands and slides as it
-		// opens — trigger is on the OPPOSITE side of the expand direction.
-		// Each consumer scope (Drawer, Pagetools, Search, ToC, header__end menus,
-		// StickyHeader) picks a direction by setting --citizen-clip-closed and
-		// --citizen-translate-closed; if a menu doesn't set them, the card renders
-		// without clipping or offset (no animation).
-		--citizen-clip-expand-up: inset( 100% 0 0 0 );
-		--citizen-clip-expand-down: inset( 0 0 100% 0 );
-		--citizen-clip-expand-right: inset( 0 100% 0 0 );
-		--citizen-clip-expand-left: inset( 0 0 0 100% );
-		--citizen-translate-expand-up: translateY( var( --space-xs ) );
-		--citizen-translate-expand-down: translateY( calc( var( --space-xs ) * -1 ) );
-		--citizen-translate-expand-right: translateX( calc( var( --space-xs ) * -1 ) );
-		--citizen-translate-expand-left: translateX( var( --space-xs ) );
+		// Closed-state animation direction (--citizen-clip-closed and
+		// --citizen-translate-closed) comes from the page-level cascade in
+		// tokens-citizen.less, keyed off the active .citizen-header-position-*
+		// class on <html>. That is correct for cards anchored to the header
+		// (drawer, header__end menus) — they inherit and require no per-scope
+		// declaration. Any new card whose trigger is NOT on the same edge as
+		// the active header (search, page-actions, sticky header, mobile ToC,
+		// future menus) MUST call .mixin-citizen-card-expand( ... ) in its own
+		// scope to pick its direction; inheriting the page-level value will
+		// produce a wrong animation direction.
 		margin: var( --space-xs );
 		contain: content;
 		-webkit-user-select: none;

--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -16,13 +16,11 @@
 			gap: var( --space-xs );
 			max-height: 60vh;
 			// Mobile toolbar sits at the bottom; card expands upward.
-			--citizen-clip-closed: var( --citizen-clip-expand-up );
-			--citizen-translate-closed: var( --citizen-translate-expand-up );
+			.mixin-citizen-card-expand( up );
 
 			@media ( min-width: @min-width-breakpoint-desktop ) {
 				top: 100%;
-				--citizen-clip-closed: var( --citizen-clip-expand-down );
-				--citizen-translate-closed: var( --citizen-translate-expand-down );
+				.mixin-citizen-card-expand( down );
 			}
 
 			&-content {

--- a/resources/skins.citizen.styles/components/Search.less
+++ b/resources/skins.citizen.styles/components/Search.less
@@ -11,8 +11,7 @@
 		max-height: var( --header-card-maxheight );
 		margin-inline: auto;
 		// Search bar at the top; card drops down.
-		--citizen-clip-closed: var( --citizen-clip-expand-down );
-		--citizen-translate-closed: var( --citizen-translate-expand-down );
+		.mixin-citizen-card-expand( down );
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			top: @position-offset-y-desktop;

--- a/resources/skins.citizen.styles/components/StickyHeader.less
+++ b/resources/skins.citizen.styles/components/StickyHeader.less
@@ -148,8 +148,7 @@
 			right: calc( var( --space-xs ) * -1 );
 			max-width: 80vw;
 			max-height: 60vh;
-			--citizen-clip-closed: var( --citizen-clip-expand-down );
-			--citizen-translate-closed: var( --citizen-translate-expand-down );
+			.mixin-citizen-card-expand( down );
 
 			&-content {
 				padding-block: var( --space-xs );

--- a/resources/skins.citizen.styles/components/TableOfContents.less
+++ b/resources/skins.citizen.styles/components/TableOfContents.less
@@ -152,8 +152,7 @@
 			max-height: ~'calc( var( --header-card-maxheight ) - 8rem )';
 			padding: var( --space-xs );
 			// Floating button at the bottom; card expands upward.
-			--citizen-clip-closed: var( --citizen-clip-expand-up );
-			--citizen-translate-closed: var( --citizen-translate-expand-up );
+			.mixin-citizen-card-expand( up );
 		}
 
 		.citizen-dropdown {

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -77,6 +77,20 @@
 	// On hover, enlarge the image to inform the user that a full-size image will be shown (to MMV or file page)
 	--transform-image-hover: scale( 1.1 );
 
+	// Card open animation — closed-state direction tokens.
+	// Each name describes the direction the card visually expands; the trigger
+	// sits on the OPPOSITE side. Consumers pick a direction via the
+	// .mixin-citizen-card-expand mixin or inherit one from the page-level
+	// cascade defined alongside the header-position tokens below.
+	--citizen-clip-expand-up: inset( 100% 0 0 0 );
+	--citizen-clip-expand-down: inset( 0 0 100% 0 );
+	--citizen-clip-expand-right: inset( 0 100% 0 0 );
+	--citizen-clip-expand-left: inset( 0 0 0 100% );
+	--citizen-translate-expand-up: translateY( var( --space-xs ) );
+	--citizen-translate-expand-down: translateY( calc( var( --space-xs ) * -1 ) );
+	--citizen-translate-expand-right: translateX( calc( var( --space-xs ) * -1 ) );
+	--citizen-translate-expand-left: translateX( var( --space-xs ) );
+
 	// Codex Design Tokens but not included as CSS variables
 	--border-base: var( --border-width-base ) solid var( --border-color-base );
 	--border-subtle: var( --border-width-base ) solid var( --border-color-subtle );
@@ -120,6 +134,14 @@
 	@media ( prefers-contrast: less ) {
 		--font-weight-normal: 300;
 	}
+
+	// Card open animation — page-level direction cascade.
+	// The default below is overridden by the per-position cascade inside the
+	// header-position media query a few lines down. Header-anchored cards
+	// (drawer, header__end menus) inherit these values without local
+	// declarations; cards with a fixed direction call .mixin-citizen-card-expand
+	// in their own scope.
+	.mixin-citizen-card-expand( up );
 
 	// Header position tokens
 	// These drive dynamic layout calc()s; a unitless 0 is type <number>
@@ -171,6 +193,7 @@
 				--header-inset-inline-start: 0px;
 				--header-inset-inline-end: auto;
 				--header-border-inline-end-width: var( --border-width-base );
+				.mixin-citizen-card-expand( right );
 			}
 
 			&-right {
@@ -178,6 +201,7 @@
 				--header-inset-inline-start: auto;
 				--header-inset-inline-end: 0px;
 				--header-border-inline-start-width: var( --border-width-base );
+				.mixin-citizen-card-expand( left );
 			}
 
 			&-top {
@@ -185,6 +209,7 @@
 				--header-inset-block-start: 0px;
 				--header-inset-block-end: auto;
 				--header-border-block-end-width: var( --border-width-base );
+				.mixin-citizen-card-expand( down );
 			}
 
 			&-bottom {
@@ -192,6 +217,7 @@
 				--header-inset-block-start: auto;
 				--header-inset-block-end: 0px;
 				--header-border-block-start-width: var( --border-width-base );
+				.mixin-citizen-card-expand( up );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1569. The previous PR left each menu consumer responsible for picking its own `--citizen-clip-closed` / `--citizen-translate-closed` direction, which meant the per-header-position mapping was duplicated in `Drawer.less` and `Dropdown.less`, and any new direction-dependent property had to be added to every consumer (six files). The mobile-ToC scope was missed during the previous PR for exactly that reason.

This refactor:
- Moves the eight direction tokens (`--citizen-clip-expand-up/down/left/right` and the matching translates) from `Menu.less` to `:root` in `tokens-citizen.less`.
- Adds `.mixin-citizen-card-expand( up | down | left | right )` in `resources/mixins.less` — a single call sets both `--citizen-clip-closed` and `--citizen-translate-closed` from the named direction tokens.
- Drives the page-level direction cascade from the existing `.citizen-header-position-*` class on `<html>` (default `up` on `:root`, four desktop overrides keyed off the position class). Header-anchored cards (Drawer, header__end menus) inherit the direction; cards with a fixed direction (Search, page-actions, sticky header, mobile ToC) call the mixin in their own scope.
- Strips the per-position direction blocks from `Drawer.less` and `Dropdown.less` — they no longer mention `--citizen-clip-closed` or `--citizen-translate-closed`.

After this, the per-header-position mapping exists in **one** place. Adding a new direction-dependent CSS property (say a per-direction `box-shadow` offset) touches the mixin alone — no consumer file changes.

Pure refactor — no behaviour change, no perf delta claimed.

## Files touched

9 files, +48 / −45.

| File | Change |
| --- | --- |
| `resources/mixins.less` | Add `.mixin-citizen-card-expand(@direction)` |
| `resources/skins.citizen.styles/tokens-citizen.less` | Add 8 direction tokens; add page-level cascade (`:root` default + 4 header-position overrides) |
| `resources/skins.citizen.styles/components/Menu.less` | Remove the 8 direction token definitions (moved) |
| `resources/skins.citizen.styles/components/Drawer.less` | Remove the four per-header-position direction-variable blocks |
| `resources/skins.citizen.styles/components/Dropdown.less` | Same removal for header__end menus |
| `resources/skins.citizen.styles/components/Pagetools.less` | Replace two-line declaration with one mixin call (×2) |
| `resources/skins.citizen.styles/components/Search.less` | Replace with mixin call |
| `resources/skins.citizen.styles/components/StickyHeader.less` | Replace with mixin call |
| `resources/skins.citizen.styles/components/TableOfContents.less` | Replace with mixin call (mobile scope) |

No template, JS, or PHP changes.

## Verification

Smoke-tested against the local dev MediaWiki with the refactor applied. Closed-state computed CSS at each `(viewport × header-position)` cell:

| Scope | Header position | Closed clip-path | Closed transform |
| --- | --- | --- | --- |
| Drawer | desktop, left | `inset(0 100% 0 0)` | `translateX(-0.5rem)` |
| Drawer | desktop, right | `inset(0 0 0 100%)` | `translateX(0.5rem)` |
| Drawer | desktop, top | `inset(0 0 100% 0)` | `translateY(-0.5rem)` |
| Drawer | desktop, bottom | `inset(100% 0 0 0)` | `translateY(0.5rem)` |
| header__end menu | matches drawer per position | | |
| Drawer | mobile (no position class) | `inset(100% 0 0 0)` | `translateY(0.5rem)` |
| Page-actions | desktop | `inset(0 0 100% 0)` (fixed) | `translateY(-0.5rem)` |
| Page-actions | mobile | `inset(100% 0 0 0)` (fixed) | `translateY(0.5rem)` |
| ToC | mobile | `inset(100% 0 0 0)` (fixed) | `translateY(0.5rem)` |

\`drawerInheritsFromRoot: true\` confirmed at all four desktop positions — proves the cascade is doing the work, not a local declaration.

\`@media (prefers-reduced-motion: reduce)\` (from MW core's `accessibility.less`) and \`@media (prefers-reduced-transparency: reduce)\` (our previous PR's commit) are both still loaded — unaffected.

## Test plan

- [ ] `npm run lint:styles` clean (already verified).
- [ ] Open each header-anchored menu at each desktop header position (left/right/top/bottom) — verify direction matches the table above by visual or computed-style spot-check.
- [ ] Open page-actions, search, sticky-header dropdown, mobile ToC — verify each retains its fixed direction regardless of header position.
- [ ] Emulate `prefers-reduced-motion: reduce` — transitions zero out, menus open instantly.
- [ ] Verify no template/JS/PHP changes (none in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a new mixin for managing card expansion animation behavior.
  * Updated drawer, dropdown, menu, page tools, search, sticky header, and table of contents styling to use the new mixin approach.
  * Added CSS custom properties and component-level mixin configurations to token definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->