### PR TITLE
fix(userMenu): clean up menu for temporary users

### DIFF
--- a/includes/Hooks/SkinHooks.php
+++ b/includes/Hooks/SkinHooks.php
@@ -420,10 +420,20 @@ class SkinHooks implements
 		$isTemp = $user->isTemp();
 
 		if ( $isTemp ) {
-			// Remove temporary user page text from user menu and recreate it in user info
+			// Remove temporary user page text and the temp username link from
+			// user menu — both are already shown in the user info header
 			unset( $links['user-menu']['tmpuserpage'] );
-			// Remove links as they are added to the bottom of user menu later
-			// unset( $links['user-menu']['logout'] );
+			unset( $links['user-menu']['userpage'] );
+
+			// Move account links to appear right before the exit session link
+			$tail = [];
+			foreach ( [ 'createaccount', 'login', 'logout' ] as $key ) {
+				if ( isset( $links['user-menu'][$key] ) ) {
+					$tail[$key] = $links['user-menu'][$key];
+					unset( $links['user-menu'][$key] );
+				}
+			}
+			$links['user-menu'] += $tail;
 		} elseif ( $isRegistered ) {
 			// Remove user page link from user menu and recreate it in user info
 			unset( $links['user-menu']['userpage'] );

--- a/tests/phpunit/integration/Hooks/SkinHooksTest.php
+++ b/tests/phpunit/integration/Hooks/SkinHooksTest.php
@@ -241,19 +241,42 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 		$this->assertArrayHasKey( 'preferences', $links['user-menu'] );
 	}
 
-	public function testUserMenuRemovesTmpuserpageForTemp(): void {
+	public function testUserMenuRemovesTmpuserpageAndUserpageForTemp(): void {
 		$sktemplate = $this->createSkinTemplateWithUser( true, true );
 		$links = [
 			'user-menu' => [
 				'tmpuserpage' => [ 'id' => 'pt-tmpuserpage' ],
-				'preferences' => [ 'id' => 'pt-preferences' ],
+				'userpage' => [ 'id' => 'pt-userpage' ],
+				'mytalk' => [ 'id' => 'pt-mytalk' ],
 			],
 		];
 
 		SkinHooks::onSkinTemplateNavigation( $sktemplate, $links );
 
 		$this->assertArrayNotHasKey( 'tmpuserpage', $links['user-menu'] );
-		$this->assertArrayHasKey( 'preferences', $links['user-menu'] );
+		$this->assertArrayNotHasKey( 'userpage', $links['user-menu'] );
+		$this->assertArrayHasKey( 'mytalk', $links['user-menu'] );
+	}
+
+	public function testUserMenuMovesAccountLinksBeforeLogoutForTemp(): void {
+		$sktemplate = $this->createSkinTemplateWithUser( true, true );
+		$links = [
+			'user-menu' => [
+				'userpage' => [ 'id' => 'pt-userpage' ],
+				'createaccount' => [ 'id' => 'pt-createaccount' ],
+				'login' => [ 'id' => 'pt-login' ],
+				'mytalk' => [ 'id' => 'pt-mytalk' ],
+				'mycontris' => [ 'id' => 'pt-mycontris' ],
+				'logout' => [ 'id' => 'pt-logout' ],
+			],
+		];
+
+		SkinHooks::onSkinTemplateNavigation( $sktemplate, $links );
+
+		$this->assertSame(
+			[ 'mytalk', 'mycontris', 'createaccount', 'login', 'logout' ],
+			array_keys( $links['user-menu'] )
+		);
 	}
 
 	public function testUserMenuRemovesAnonuserpageForAnon(): void {


### PR DESCRIPTION
## Summary

- Hide the redundant temp username link (`mw-temp-user-link`) in the user menu for temporary users — the user info header already shows it, matching how the userpage link is handled for logged-in users.
- Move `createaccount` and `login` to the tail of the user menu so they sit right next to the exit session link, instead of appearing early in the list (where MW core's `addAccountLinks` places them for temp users).

Both changes are defensive no-ops on MW 1.43, where `SkinTemplate::buildPersonalUrls` does not add a `userpage` entry for temp users (`addPersonalPageItem` gates on `isNamedUser`) and does not call `addAccountLinks` inside the logged-in branch. They take effect on MW 1.44+ where temp users get the redundant entries.

## Test plan

- [x] Updated `SkinHooksTest::testUserMenuRemovesTmpuserpageAndUserpageForTemp` asserts both `tmpuserpage` and `userpage` are removed for temp users while other entries remain.
- [x] Added `SkinHooksTest::testUserMenuMovesAccountLinksBeforeLogoutForTemp` asserts the final order is `mytalk, mycontris, createaccount, login, logout`.
- [x] `composer phpunit -- skins/Citizen/tests/phpunit/integration/Hooks/SkinHooksTest.php` — all 23 tests pass.
- [ ] Manual check on MW 1.44+ with temp accounts enabled: user menu shows no `mw-temp-user-link` entry and account links sit right above "Exit session".
- [ ] Manual check on MW 1.43: user menu for temp users is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the temporary user menu to remove the user page link.
  * Reordered account-related links (create account, login, logout) in the temporary user menu for improved navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->