### PR TITLE
docs(recipes): add recipe for forcing a single theme

### DIFF
--- a/docs/src/customization/recipes.md
+++ b/docs/src/customization/recipes.md
@@ -92,3 +92,27 @@ To hide a preference from the panel entirely, set it to `null`:
   }
 }
 ```
+
+## Force a theme site-wide
+
+To lock everyone into a single theme, combine two changes — set the default theme, then remove the picker so users can't switch.
+
+First, set the default in `LocalSettings.php` using a valid value for [`$wgCitizenThemeDefault`](../config/#wgcitizenthemedefault):
+
+```php
+$wgCitizenThemeDefault = 'dark';
+```
+
+Then remove the theme picker by editing `MediaWiki:Citizen-preferences.json`:
+
+```json
+{
+  "preferences": {
+    "skin-theme": null
+  }
+}
+```
+
+::: warning
+Users who picked a different theme before you applied this change have it stored in their browser's local storage. They'll keep seeing their old choice until they clear site data — local storage doesn't expire on its own. New visitors get the forced theme immediately.
+:::


### PR DESCRIPTION
## Summary

- Adds a recipe to `customization/recipes.md` that documents how to lock the wiki to a single theme by combining `$wgCitizenThemeDefault` with a `null` override in `MediaWiki:Citizen-preferences.json`.
- Includes a caveat that pre-existing user choices live in local storage and persist until site data is cleared.

Frequently asked by admins. Both mechanisms already exist; the recipe just connects them.

## Test plan

- [x] `npm run lint:md` passes (verified locally)
- [x] Recipe renders correctly in the VitePress preview
- [x] Cross-link `../config/#wgcitizenthemedefault` resolves to the `$wgCitizenThemeDefault` config entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new recipe guide on enforcing a site-wide theme, including configuration steps and information about how user theme preferences persist in browser storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->