### PR TITLE
fix(header): use dvh for dropdown card max-height on mobile

### DIFF
--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -41,8 +41,11 @@
 	--height-sticky-header: 0px;
 	// Width or height of citizen-header, depending on the orientation
 	--header-size: @header-size;
-	// Max-height allowed for header card
-	--header-card-maxheight: calc( 100vh - var( --header-size ) - var( --space-xs ) * 2 );
+	// Max-height allowed for header card. Uses dvh, not vh: on mobile vh
+	// resolves to the largest viewport (address bar retracted), so the card
+	// overflows the visible area while the bar is showing. dvh tracks the
+	// currently-visible height.
+	--header-card-maxheight: calc( 100dvh - var( --header-size ) - var( --space-xs ) * 2 );
 	// Width of the gradient in citizen-overflow
 	--overflow-gradient-size: 2rem;
 	// Width of the body content
@@ -178,7 +181,7 @@
 				--header-direction: column;
 				--header-inset-block-start: 0px;
 				--header-inset-block-end: 0px;
-				--header-card-maxheight: calc( 100vh - var( --space-xs ) * 2 );
+				--header-card-maxheight: calc( 100dvh - var( --space-xs ) * 2 );
 			}
 
 			&-top,


### PR DESCRIPTION
## Summary

The header dropdown cards (preferences, user menu, notifications, search, ToC) overflow the visible viewport on mobile browsers when the address bar is showing.

Commit 422c4d78 set `--header-card-maxheight` to `calc( 100vh - … )`. On mobile, `vh` resolves to the **largest** viewport — the height with the address bar retracted — so a card sized to it extends below the currently-visible area while the bar is on screen.

This switches both occurrences (the default top/bottom-header value and the left/right column-orientation value) to `100dvh`, the dynamic viewport unit that tracks the currently-visible height. It matches the existing `100dvh` usage in `common.less`, so no `vh` fallback is needed for the browser baseline.

## Testing

- `npm run lint:styles` clean.
- `skins.citizen.styles` compiles via `load.php` (less.php passes `calc( 100dvh … )` through correctly); the token emits `calc(100dvh - …)` and resolves to a real px max-height in the browser.
- All header cards consume the token via the `.citizen-menu__card` mixin, so the fix covers them all.

**Note:** the before/after can't be reproduced in DevTools device emulation (it doesn't simulate the retractable address bar, so `dvh` == `vh` there). The fix is the canonical one for this symptom; best confirmed on a real mobile browser with the address bar visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header display on mobile devices by adjusting height calculations to account for address bar retraction during scrolling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StarCitizenTools/mediawiki-skins-Citizen/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->