### PR TITLE
fix(user-menu): show temp account notice instead of IP warning

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -110,6 +110,7 @@
 	"citizen-feature-custom-width-full-label": "Full",
 
 	"citizen-user-info-text-anon": "Your IP address will be publicly visible if you make any edits.",
+	"citizen-user-info-text-anon-temp": "If you make an edit, a temporary account will be created for you.",
 	"citizen-user-info-text-temp": "This temporary account was created after an edit was made without an account on this browser and device.",
 	"citizen-user-info-edits-label": "Edits",
 	"citizen-user-info-joined-label": "Joined",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -106,6 +106,7 @@
 	"citizen-feature-custom-width-wide-label": "Label for wide page width. An adjective that describes \"text\" ({{msg-mw|Citizen-feature-custom-width-name}}).",
 	"citizen-feature-custom-width-full-label": "Label for full page width. An adjective that describes \"text\" ({{msg-mw|Citizen-feature-custom-width-name}}).",
 	"citizen-user-info-text-anon": "Description in the user menu when user is not logged in.",
+	"citizen-user-info-text-anon-temp": "Description in the user menu when the user is not logged in and temporary accounts are enabled, so an edit will create a temporary account rather than expose the user's IP address.",
 	"citizen-user-info-text-temp": "Description in the user menu when user is using a temporary account.",
 	"citizen-user-info-edits-label": "Label for the edit count in the user info",
 	"citizen-user-info-joined-label": "Label for the registration date in the user info",

--- a/includes/Components/CitizenComponentUserInfo.php
+++ b/includes/Components/CitizenComponentUserInfo.php
@@ -8,6 +8,7 @@ use MediaWiki\Html\Html;
 use MediaWiki\Language\Language;
 use MediaWiki\Title\MalformedTitleException;
 use MediaWiki\Title\Title;
+use MediaWiki\User\TempUser\TempUserConfig;
 use MediaWiki\User\User;
 use MediaWiki\User\UserGroupManager;
 use MessageLocalizer;
@@ -25,6 +26,7 @@ class CitizenComponentUserInfo implements CitizenComponent {
 		private readonly MessageLocalizer $localizer,
 		private readonly Title $title,
 		private readonly User $user,
+		private readonly TempUserConfig $tempUserConfig,
 		private readonly array $userPageData,
 	) {
 	}
@@ -189,9 +191,17 @@ class CitizenComponentUserInfo implements CitizenComponent {
 				$data['data-user-groups'] = $this->getUserGroups();
 			}
 		} else {
+			// When an edit auto-creates a temporary account, the visitor's IP
+			// is not publicly exposed, so the IP-visibility warning would be
+			// inaccurate. Key on the 'edit' action specifically (rather than
+			// isEnabled()) since the message is about editing — a wiki could
+			// enable temp accounts for other actions only.
+			$anonText = $this->tempUserConfig->isAutoCreateAction( 'edit' )
+				? 'citizen-user-info-text-anon-temp'
+				: 'citizen-user-info-text-anon';
 			$data = [
 				'title' => $localizer->msg( 'notloggedin' ),
-				'text' => $localizer->msg( 'citizen-user-info-text-anon' )
+				'text' => $localizer->msg( $anonText )
 			];
 		}
 

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -24,6 +24,7 @@ use MediaWiki\Skins\Citizen\Components\CitizenComponentStickyHeader;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentTableOfContents;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentUserInfo;
 use MediaWiki\Title\Title;
+use MediaWiki\User\TempUser\TempUserConfig;
 use MediaWiki\User\UserFactory;
 use MediaWiki\User\UserGroupManager;
 use MediaWiki\User\UserIdentityLookup;
@@ -95,6 +96,7 @@ class SkinCitizen extends SkinMustache {
 		private readonly PermissionManager $permissionManager,
 		private readonly UserGroupManager $userGroupManager,
 		private readonly UrlUtils $urlUtils,
+		private readonly TempUserConfig $tempUserConfig,
 		// @phan-suppress-next-line PhanUndeclaredTypeParameter,PhanUndeclaredTypeProperty
 		private readonly ?MobileContext $mfContext,
 		array $options = []
@@ -245,6 +247,7 @@ class SkinCitizen extends SkinMustache {
 				$localizer,
 				$title,
 				$user,
+				$this->tempUserConfig,
 				$parentData['data-portlets']['data-user-page']
 			),
 			'data-sticky-header' => new CitizenComponentStickyHeader(

--- a/skin.json
+++ b/skin.json
@@ -37,7 +37,8 @@
 				"LanguageNameUtils",
 				"PermissionManager",
 				"UserGroupManager",
-				"UrlUtils"
+				"UrlUtils",
+				"TempUserConfig"
 			],
 			"optional_services": [
 				"MobileFrontend.Context"

--- a/tests/phpunit/Unit/Components/CitizenComponentUserInfoTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentUserInfoTest.php
@@ -7,6 +7,7 @@ namespace MediaWiki\Skins\Citizen\Tests\Unit\Components;
 use MediaWiki\Language\Language;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentUserInfo;
 use MediaWiki\Title\Title;
+use MediaWiki\User\TempUser\TempUserConfig;
 use MediaWiki\User\User;
 use MediaWiki\User\UserGroupManager;
 use MediaWikiUnitTestCase;
@@ -42,6 +43,30 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 		return $user;
 	}
 
+	private function createMockTempUserConfig( bool $autoCreateOnEdit ): TempUserConfig {
+		$tempUserConfig = $this->createMock( TempUserConfig::class );
+		$tempUserConfig->method( 'isAutoCreateAction' )
+			->with( 'edit' )
+			->willReturn( $autoCreateOnEdit );
+
+		return $tempUserConfig;
+	}
+
+	/**
+	 * Localizer whose Message objects echo back the requested key via text(),
+	 * so tests can assert which message key was selected.
+	 */
+	private function createKeyEchoLocalizer(): MessageLocalizer {
+		$localizer = $this->createMock( MessageLocalizer::class );
+		$localizer->method( 'msg' )->willReturnCallback( function ( $key ) {
+			$msg = $this->createMock( Message::class );
+			$msg->method( 'text' )->willReturn( $key );
+			return $msg;
+		} );
+
+		return $localizer;
+	}
+
 	/**
 	 * @covers ::getTemplateData
 	 */
@@ -72,6 +97,7 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 			$localizer,
 			$title,
 			$user,
+			$this->createMockTempUserConfig( false ),
 			$userPageData
 		);
 
@@ -113,6 +139,7 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 			$localizer,
 			$title,
 			$user,
+			$this->createMockTempUserConfig( false ),
 			$userPageData
 		);
 
@@ -124,5 +151,49 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 		$this->assertStringNotContainsString( 'pt-userpage-realname', $resultHtml );
 		$this->assertStringNotContainsString( 'pt-userpage-username', $resultHtml );
 		$this->assertStringContainsString( $encodedUsername, $resultHtml );
+	}
+
+	/**
+	 * @covers ::getTemplateData
+	 */
+	public function testAnonUserSeesIpWarningWhenTempAccountsDisabled(): void {
+		$user = $this->createMock( User::class );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$component = new CitizenComponentUserInfo(
+			$this->createMock( UserGroupManager::class ),
+			$this->createMock( Language::class ),
+			$this->createKeyEchoLocalizer(),
+			$this->createMock( Title::class ),
+			$user,
+			$this->createMockTempUserConfig( false ),
+			[]
+		);
+
+		$data = $component->getTemplateData();
+
+		$this->assertSame( 'citizen-user-info-text-anon', $data['text']->text() );
+	}
+
+	/**
+	 * @covers ::getTemplateData
+	 */
+	public function testAnonUserSeesTempWarningWhenTempAccountsEnabled(): void {
+		$user = $this->createMock( User::class );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$component = new CitizenComponentUserInfo(
+			$this->createMock( UserGroupManager::class ),
+			$this->createMock( Language::class ),
+			$this->createKeyEchoLocalizer(),
+			$this->createMock( Title::class ),
+			$user,
+			$this->createMockTempUserConfig( true ),
+			[]
+		);
+
+		$data = $component->getTemplateData();
+
+		$this->assertSame( 'citizen-user-info-text-anon-temp', $data['text']->text() );
 	}
 }

--- a/tests/phpunit/integration/SkinCitizenTest.php
+++ b/tests/phpunit/integration/SkinCitizenTest.php
@@ -25,6 +25,7 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 			$this->getServiceContainer()->getPermissionManager(),
 			$this->getServiceContainer()->getUserGroupManager(),
 			$this->getServiceContainer()->getUrlUtils(),
+			$this->getServiceContainer()->getTempUserConfig(),
 			null,
 			[
 				'name' => 'Citizen',


### PR DESCRIPTION
## Problem

Citizen's user menu always showed `citizen-user-info-text-anon` — *"Your IP address will be publicly visible if you make any edits."* — to logged-out visitors. That message is **factually wrong when the wiki has temporary accounts enabled** (`$wgAutoCreateTempUser`): in that configuration an anonymous edit auto-creates a temporary account, the public sees the temp username, and the IP is recorded privately. So the "IP will be publicly visible" claim is inaccurate.

## Fix

Mirror what MediaWiki core does in `IntroMessageBuilder` (swapping `anoneditwarning` for `autocreate-edit-warning`): inject the `TempUserConfig` service and, in the anonymous branch, select a temp-aware message when an edit would auto-create a temporary account.

- New message `citizen-user-info-text-anon-temp`: *"If you make an edit, a temporary account will be created for you."*
- Predicate: `TempUserConfig::isAutoCreateAction( 'edit' )` — keyed on the `edit` action specifically (the message is about editing), rather than the broader `isEnabled()`.
- Registered, temporary, and anon-without-temp-accounts users are unaffected — only the anonymous branch changed.

## Changes

| File | Change |
| --- | --- |
| `skin.json` | Register `TempUserConfig` service |
| `includes/SkinCitizen.php` | Inject `TempUserConfig`, pass to the component |
| `includes/Components/CitizenComponentUserInfo.php` | Branch the anon message on `isAutoCreateAction( 'edit' )` |
| `i18n/en.json` + `qqq.json` | New `citizen-user-info-text-anon-temp` key + doc |
| Tests (unit + integration) | Constructor updates; two tests asserting the correct key per config state |

## Testing

- `composer phpunit` — 134 tests, 322 assertions, OK
- `composer test` (lint + phpcs) — clean
- `composer phan` — no issues in changed files
- `npm run lint:i18n` — clean

No cache-safety concern: this only swaps one message string inside an existing template slot — no class, selector, or markup-structure change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved messaging for anonymous users editing without an account, displaying different text based on whether temporary accounts are automatically created for edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->