### PR TITLE
fix: stop preloading the unused default logo

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -139,13 +139,11 @@
 	},
 	"ResourceModules": {
 		"skins.citizen.tokens": {
-			"class": "MediaWiki\\ResourceLoader\\SkinModule",
 			"styles": [
 				"resources/skins.citizen.tokens/tokens.less"
 			]
 		},
 		"skins.citizen.tokens.new": {
-			"class": "MediaWiki\\ResourceLoader\\SkinModule",
 			"styles": [
 				"resources/skins.citizen.tokens.new/tokens.less"
 			]


### PR DESCRIPTION
## Problem

On any Citizen page, **two `change-your-logo` SVGs are downloaded** when only one is shown:

| File | Source | Shown? |
| --- | --- | --- |
| `change-your-logo-icon.svg` | Citizen's own `<img class="mw-logo-icon">` (Header/Drawer/Footer), resolved from `$wgLogos` | ✅ yes |
| `change-your-logo.svg` | A `Link: <…/change-your-logo.svg>;rel=preload;as=image` header on the skin's stylesheet bundle, plus a dead `.mw-wiki-logo { background-image }` rule | ❌ never |

## Root cause

`skins.citizen.tokens` and `skins.citizen.tokens.new` are pure design-token files (CSS custom properties), but they were declared as `MediaWiki\ResourceLoader\SkinModule` **without a `features` list**. A featureless `SkinModule` falls back to `SkinModule::DEFAULT_FEATURES_ABSENT = ['logo']`, which silently turns the `logo` feature **on**. That feature:

- emits a `.mw-wiki-logo { background-image: url(change-your-logo.svg) }` rule (dead — Citizen has no `.mw-wiki-logo` element), and
- adds a `rel=preload;as=image` **Link header**, which the browser fetches unconditionally regardless of whether the element exists.

Citizen renders its own `<img>` logo, so the wide placeholder was downloaded on every page view but never displayed. Because the **default** token pipeline (`skins.citizen.tokens`) was affected too, this hit every wiki, not just those on the opt-in new pipeline.

`skins.citizen.styles` was **not** the culprit — its map-form `features` never auto-adds `logo`.

## Fix

Drop the `class` line on both token modules so they become the default `FileModule`. Design tokens need no skin features, so this removes the `logo` default (and its preload) without enabling any other feature.

```diff
 "skins.citizen.tokens": {
-    "class": "MediaWiki\\ResourceLoader\\SkinModule",
     "styles": [ "resources/skins.citizen.tokens/tokens.less" ]
 },
 "skins.citizen.tokens.new": {
-    "class": "MediaWiki\\ResourceLoader\\SkinModule",
     "styles": [ "resources/skins.citizen.tokens.new/tokens.less" ]
 },
```

## Test plan

Verified against a local MediaWiki dev wiki (Main_Page), before vs after:

- [x] `Link: …change-your-logo.svg…;rel=preload` header **removed** from the `only=styles` load.php bundle
- [x] Network: image requests drop from 15 → 14; `change-your-logo.svg` no longer requested; `change-your-logo-icon.svg` (the visible logo) still loads
- [x] Token CSS unchanged — both modules still emit their full set of `--*` custom properties (765 / 753)
- [x] Visible logo still renders (`naturalWidth > 0`), zero `.mw-wiki-logo` elements, no console errors
- [x] `skin.json` is valid JSON


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified resource module configuration in skin settings with no impact to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->