### PR TITLE
fix: restore the Read button in the sticky header on history pages

### DIFF
--- a/includes/Components/CitizenComponentStickyHeader.php
+++ b/includes/Components/CitizenComponentStickyHeader.php
@@ -21,10 +21,20 @@ class CitizenComponentStickyHeader implements CitizenComponent {
 		'icon' => 'speechBubbles'
 	];
 
+	private const VIEW_ICON = [
+		'id' => 'ca-view-sticky-header',
+		'clickTarget' => '#ca-view > a',
+		'icon' => 'eye'
+	];
+
+	// The subject/associated page tab id is namespace-specific (ca-nstab-main,
+	// ca-nstab-user, ...) and is marked `selected` on the subject page itself, so
+	// target any unselected nstab tab — i.e. the "back to the article" link shown
+	// on talk pages.
 	private const SUBJECT_ICON = [
 		'id' => 'ca-subject-sticky-header',
-		'clickTarget' => '#ca-subject > a',
-		'icon' => 'eye'
+		'clickTarget' => "[id^='ca-nstab-']:not(.selected) > a",
+		'icon' => 'article'
 	];
 
 	private const HISTORY_ICON = [
@@ -74,13 +84,14 @@ class CitizenComponentStickyHeader implements CitizenComponent {
 		}
 
 		array_push( $icons,
+			self::VIEW_ICON,
+			self::SUBJECT_ICON,
 			self::HISTORY_ICON,
 			$this->visualEditorTabPositionFirst ? self::EDIT_VE_ICON : self::EDIT_WIKITEXT_ICON,
 			$this->visualEditorTabPositionFirst ? self::EDIT_WIKITEXT_ICON : self::EDIT_VE_ICON,
 			self::EDIT_PROTECTED_ICON,
 			self::ADD_SECTION_ICON,
-			self::TALK_ICON,
-			self::SUBJECT_ICON
+			self::TALK_ICON
 		);
 		$iconButtons = [];
 		foreach ( $icons as $icon ) {

--- a/tests/phpunit/Unit/Components/CitizenComponentStickyHeaderTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentStickyHeaderTest.php
@@ -30,7 +30,7 @@ class CitizenComponentStickyHeaderTest extends MediaWikiUnitTestCase {
 
 		$this->assertArrayHasKey( 'array-icon-buttons', $data );
 		$buttons = $data['array-icon-buttons'];
-		$this->assertCount( 8, $buttons, 'There should be 8 icon buttons' );
+		$this->assertCount( 9, $buttons, 'There should be 9 icon buttons' );
 
 		// Verify button properties for the first button as a sample check
 		$firstButton = $buttons[0];
@@ -39,9 +39,27 @@ class CitizenComponentStickyHeaderTest extends MediaWikiUnitTestCase {
 		$this->assertStringContainsString( 'cdx-button--icon-only', $firstButton['class'] );
 		$this->assertContains( [ 'key' => 'tabindex', 'value' => '-1' ], $firstButton['array-attributes'] );
 
+		// The read/view button comes first (after share) and targets the read view
+		// tab, which (unlike the old #ca-subject) exists in MediaWiki output (#1586).
+		$viewButton = $buttons[1];
+		$this->assertSame( 'eye', $viewButton['icon'] );
+		$this->assertContains(
+			[ 'key' => 'data-mw-citizen-click-target', 'value' => '#ca-view > a' ],
+			$viewButton['array-attributes']
+		);
+
+		// The subject button targets the (namespace-specific, unselected) associated
+		// page tab, i.e. the "back to the article" link shown on talk pages.
+		$subjectButton = $buttons[2];
+		$this->assertSame( 'article', $subjectButton['icon'] );
+		$this->assertContains(
+			[ 'key' => 'data-mw-citizen-click-target', 'value' => "[id^='ca-nstab-']:not(.selected) > a" ],
+			$subjectButton['array-attributes']
+		);
+
 		// Verify the order of edit icons
-		$this->assertSame( $expectedFirstEditIcon, $buttons[2]['icon'] );
-		$this->assertSame( $expectedSecondEditIcon, $buttons[3]['icon'] );
+		$this->assertSame( $expectedFirstEditIcon, $buttons[4]['icon'] );
+		$this->assertSame( $expectedSecondEditIcon, $buttons[5]['icon'] );
 	}
 
 	public static function provideVisualEditorTabPosition(): iterable {


### PR DESCRIPTION
Closes #1586

## Problem

On a Revision History (or edit) page, scrolling replaces the page header with the condensed sticky header, and the **"Read" action disappears** — the leftmost content button becomes "Revision History". Desktop only.

## Root cause

The sticky header is a fixed set of icon "fake buttons", each pointing at a content-navigation tab via `data-mw-citizen-click-target`. The read button targeted **`#ca-subject`**, which does not exist in current MediaWiki content navigation:

- the read view tab is `#ca-view`
- the subject/associated-page tab is `#ca-nstab-<namespace>` (e.g. `#ca-nstab-main`, `#ca-nstab-user`), marked `.selected` on the subject page itself

`StickyHeader.initFakeButtons()` removes any fake button whose target can't be found, so `#ca-subject` was **always** stripped — on subject *and* talk pages. You notice it on history/edit views, where you want a way back to reading, so the History button becomes the most prominent action.

## Fix

`CitizenComponentStickyHeader.php`:

1. **Read button** → `#ca-view > a` (the read view, present on every subject read/history/edit view), placed at the front so the sticky header mirrors the main header's *Share, Read, Edit, Discussion* order.
2. **Subject button** kept, but retargeted from the dead `#ca-subject` to the real associated-page tab — `[id^='ca-nstab-']:not(.selected) > a`. The `:not(.selected)` means it only appears when the subject page isn't the current one, i.e. as a "back to the article" link on **talk pages** (with the `article` icon), and stays out of the way on subject pages where the Read button already covers it.

## Test plan

Verified on a local wiki:

- [x] **Subject history page**: sticky header shows **Share → Read → History → Edit → Edit source → Discussion**; Read (`#ca-view`) returns to the article; the subject button is correctly pruned (its tab is selected).
- [x] **Talk page** (`Talk:Main_Page`): subject button shows the `article` icon, tooltip "View the content page", and resolves to the article (`/wiki/Main_Page`) — the back-to-article affordance is preserved and now actually works (`#ca-subject` never matched before).
- [x] PHPUnit: OK (134 tests, 330 assertions); `composer test` (parallel-lint + phpcs): All good.

## Note

On talk pages whose subject tab is namespace-specific (`ca-nstab-user`, etc.), the attribute-prefix selector handles every namespace, so the button works regardless of namespace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added view button to the sticky header.

* **Bug Fixes**
  * Fixed behavior of the article/subject page button in the sticky header.

* **Style**
  * Reordered sticky header navigation buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->