### PR TITLE
docs(showcase): 📚️ add CapoeiraWiki to showcase

### DIFF
--- a/docs/src/community/showcase.md
+++ b/docs/src/community/showcase.md
@@ -27,4 +27,5 @@ Check out these amazing wikis powering their content with Citizen:
  <LinkCard title="NITC Wiki" href="https://wiki.fosscell.org" />
  <LinkCard title="Superstar Racers Wiki" href="https://sr.conecorp.cc" />
  <LinkCard title="Stella Sora Wiki" href="https://stellasora.miraheze.org" />
+ <LinkCard title="CapoeiiraWiki" href="https://capoeirawiki.org" />
 </LinkGrid>


### PR DESCRIPTION
Add CapoeiraWiki to the Citizen skin community showcase.

CapoeiraWiki is an English-language MediaWiki project dedicated to documenting capoeira history, culture, movements, music, mestres, groups, books, and related sources. It uses the Citizen skin to provide a clean and accessible reading experience for both capoeira practitioners and general readers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new showcase entry for CapoeiiraWiki with a link to its website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->