### PR TITLE
docs(guide): rewrite migrating to Citizen 4 guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -71,10 +71,6 @@ export default defineConfig({
 						text: "Installation",
 						link: "/guide/installation",
 					},
-					{
-						text: "Migrating to Citizen 4",
-						link: "/guide/migrating-to-citizen-4",
-					},
 				],
 			},
 			{
@@ -151,6 +147,10 @@ export default defineConfig({
 					{
 						text: "Changelogs",
 						link: "/changelogs/",
+					},
+					{
+						text: "Migrating to Citizen 4",
+						link: "/guide/migrating-to-citizen-4",
 					},
 					{
 						text: "Contribute",

--- a/docs/src/guide/migrating-to-citizen-4.md
+++ b/docs/src/guide/migrating-to-citizen-4.md
@@ -5,98 +5,99 @@ description: Preview the Citizen 4 changes and migrate your wiki before the rele
 
 # Migrating to Citizen 4
 
-Citizen 4.0 will ship breaking changes. This cycle, that means the new color token pipeline becoming the default — tokens are the CSS custom properties documented in [Theming](../customization/theming.md). This guide walks you through migrating your wiki ahead of the release, using the **preview channel** to rehearse everything safely on your production wiki. Citizen majors ship alongside MediaWiki LTS releases, so there's a long runway — start whenever it suits you.
+Citizen 4 will be released some time after MediaWiki 1.47 LTS. Use the [preview channel](../contribute/preview-channel.md) to test the changes.
 
-Preview features are production-quality, but their shape may change during the cycle — changes are announced in the release notes.
+## What's changing
 
-## Try it in your browser
+- **New color token pipeline** — colors are defined as `light-dark()` pairs built from primitive ramps instead of computed channel math. Most existing overrides keep working; see [Migrate your token overrides](#migrate-your-token-overrides).
+
+## Migration steps
+
+Preview the changes in your own browser, deploy your fixes behind a guard, then turn the whole wiki on when you're ready. Every step is safe to do ahead of the release.
+
+### 1. Try it in your browser
 
 Append `?citizenpreview=4` to any page URL on your wiki. The choice persists in a 24-hour cookie for your browser only; readers are unaffected. Append `?citizenpreview=0` to switch back.
 
-While previewing, check:
+### 2. Deploy fixes behind a guard
 
-- Your site CSS (`MediaWiki:Citizen.css`, `MediaWiki:Common.css`) in **both** light and dark schemes
-- Gadgets that style or read skin colors
-- Any hardcoded colors that clash with the new palette
+Wrap your fixes so they apply only in the preview. The `citizen-v4` class is inert for stable readers, so a guarded fix is safe to deploy right away:
 
-::: warning Shared caches
-On wikis behind a CDN, the URL parameter varies the cache key but the **cookie does not**. Rehearse anonymous views via the URL parameter, or while logged in — logged-in traffic typically bypasses the CDN.
-:::
+| Where | How to target it |
+| :--- | :--- |
+| CSS | `:root.citizen-v4 { … }` |
+| JavaScript | `document.documentElement.classList.contains( 'citizen-v4' )` |
 
-## Fix things, guarded
+The class stays on `<html>` for the whole Citizen 4 release, so your guarded fixes keep working after you upgrade. Drop the guards once you've finished migrating; the class itself is removed in Citizen 5.
 
-Write your migration fixes inside a `:root.citizen-v4` guard. Guarded rules are inert for stable readers and active in preview — safe to deploy immediately:
+### 3. Turn it on wiki-wide
 
-```css
-:root.citizen-v4 {
-    --color-surface-1: light-dark( #f7f2ea, #201d18 );
-}
-```
-
-Note the two-value `light-dark()` form — a single value would silently break dark mode; see [Light and dark are one declaration now](#light-and-dark-are-one-declaration-now).
-
-The `citizen-v4` class stays on `<html>` through the **whole 4.x lifetime**, so your guarded fixes keep applying after you upgrade. Unguard them at your leisure during 4.x; the class is removed in 5.0. The guard itself survives the upgrade, but if a preview feature's shape changes during the cycle — see the rebrand note below — you may still need to update what's inside it.
-
-Gadget JavaScript can detect the channel the same way:
-
-```js
-const isCitizen4 = document.documentElement.classList.contains( 'citizen-v4' );
-```
-
-## Wiki-wide preview
-
-Once your rehearsal looks clean, you can put the whole wiki on the preview with [`$wgCitizenPreview`](../config/index.md#wgcitizenpreview):
+Once your fixes are in place, you can put the whole wiki on the preview with [`$wgCitizenPreview`](../config/index.md#wgcitizenpreview):
 
 ```php [LocalSettings.php]
 $wgCitizenPreview = 4;
 ```
 
-Only the value `4` activates the preview during this cycle; `0` or any other value keeps the stable experience. The URL parameter and cookie take precedence over the config, so individual browsers can still switch back with `?citizenpreview=0` while the wiki is on the preview.
+Only the value `4` activates the preview during this cycle; `0` or any other value keeps the stable experience.
 
-## Migrating your token overrides
+## Migrate your token overrides
 
 Most token names are unchanged — the big shift is **how** values resolve.
 
 ### Light and dark are one declaration now
 
-The new pipeline defines colors as `light-dark()` pairs and drives them with `color-scheme`. A plain override wins in **both** schemes and silently breaks dark mode:
+The new pipeline defines colors as `light-dark()` pairs and drives them with `color-scheme`.
+
+The Citizen 3 pattern, which still works:
 
 ```css
-/* Breaks dark mode: applies this light value in both schemes */
-:root.citizen-v4 {
+:root {
     --color-surface-0: #fffaf0;
 }
 
-/* Correct: provide both halves */
+:root.skin-theme-clientpref-night {
+    --color-surface-0: #16130e;
+}
+
+@media ( prefers-color-scheme: dark ) {
+    :root.skin-theme-clientpref-os {
+        --color-surface-0: #16130e;
+    }
+}
+```
+
+The recommended Citizen 4 form — one declaration covers all three modes:
+
+```css
 :root.citizen-v4 {
     --color-surface-0: light-dark( #fffaf0, #16130e );
 }
 ```
 
-### Your CSS still wins
-
-Citizen's new tokens live in a CSS cascade layer (`@layer citizen-tokens`). Site CSS is unlayered, and unlayered styles beat layered ones — your `:root` overrides always win without specificity tricks. This is by design.
+The `light-dark()` form is also simpler, and it lets custom themes build on the base — a theme sets `color-scheme`, overrides only the colors it changes, and everything else falls back to the right light or dark value.
 
 ### Removed tokens
 
-A diff of the two pipelines' compiled stylesheets shows 58 custom properties removed. All of them are internal color math. The legacy pipeline decomposed each color into separate channel properties (lightness, chroma, saturation, hue) and computed surface and state shades from them with `calc()`; the new pipeline ships static `light-dark()` pairs instead, so the intermediates no longer exist. **No surface, text, border, or background token is removed** — if you only ever overrode tokens like `--color-surface-1` or `--color-base`, this section doesn't affect you.
-
-Overriding a removed property is a silent no-op in the preview. Four of them were global tuning knobs, so they get their own migration advice:
-
-| Removed token | What to do instead |
+| If you overrode… | To migrate |
 | :--- | :--- |
-| `--delta-lightness-hover-state` | No replacement — hover shades are no longer computed. Override the affected state token directly, as a `light-dark()` pair (for example `--color-surface-1--hover`). |
-| `--delta-lightness-active-state` | Same, for active shades (for example `--color-surface-1--active`). |
-| `--delta-lightness-state-base` | The base value the hover and active deltas derived from. Same guidance. |
-| `--delta-lightness-surface-base` | Stepped the surface ramp (`--color-surface-1` to `--color-surface-4`) away from the page background. Override the surface tokens directly. |
+| A surface, text, border, or background token | Nothing — the names are unchanged. |
+| A color's channel to retune it (e.g. `--color-base-oklch__l`) | Set the color token itself (e.g. `--color-base`). |
+| An HSL color fallback (`…-hsl__*`) | Nothing — Citizen 4 drops the HSL fallback, but modern browsers already used the OKLCH colors in Citizen 3. |
+| A `--delta-lightness-*` state or surface delta | Set the affected token directly (e.g. `--color-surface-1--hover`). |
+| The primary-color hue (`--color-progressive-oklch__h`) | See [Rebranding the primary color](#rebranding-the-primary-color). |
 
-The remaining 54 are per-color channel decompositions. If you overrode one of them to retune a color, override the color token itself now. Two of them (`--color-progressive-oklch__l` and `--color-progressive-oklch__c`) are the primary-color rebrand knobs from the [Theming](../customization/theming.md#primary-color) guide — see [Rebranding the primary color](#rebranding-the-primary-color) below.
-
-::: details Full list of removed internal tokens
+::: details Full list of removed tokens
 
 Channel key: `__l` lightness, `__c` chroma, `__s` saturation, `__h` hue.
 
-**OKLCH channel properties (24):**
+**State and surface deltas:**
+
+- `--delta-lightness-hover-state`
+- `--delta-lightness-active-state`
+- `--delta-lightness-state-base`
+- `--delta-lightness-surface-base`
+
+**OKLCH channels:**
 
 - `--color-base-oklch__c`, `--color-base-oklch__l`
 - `--color-disabled-oklch__c`, `--color-disabled-oklch__l`
@@ -111,7 +112,7 @@ Channel key: `__l` lightness, `__c` chroma, `__s` saturation, `__h` hue.
 - `--color-surface-4-oklch__c`, `--color-surface-4-oklch__l`
 - `--shadow-color-oklch__c`, `--shadow-color-oklch__l`
 
-**HSL channel properties (22):**
+**HSL channels:**
 
 - `--color-base-hsl__l`, `--color-base-hsl__s`
 - `--color-disabled-hsl__l`, `--color-disabled-hsl__s`
@@ -125,7 +126,7 @@ Channel key: `__l` lightness, `__c` chroma, `__s` saturation, `__h` hue.
 - `--color-surface-4-hsl__l`, `--color-surface-4-hsl__s`
 - `--shadow-color-hsl__l`, `--shadow-color-hsl__s`
 
-**Standalone channel properties (8):**
+**Standalone channels:**
 
 - `--background-color-subtle__l`, `--background-color-subtle__s`
 - `--color-destructive__h`, `--color-destructive__l`
@@ -134,15 +135,9 @@ Channel key: `__l` lightness, `__c` chroma, `__s` saturation, `__h` hue.
 
 :::
 
-Every other custom property the legacy pipeline defines is also emitted by the new one under the same name. The diff also adds 170 properties that only exist in the new pipeline — mostly the primitive color ramps everything is now built from, plus additional state variants.
-
 ### Rebranding the primary color
 
-In Citizen 3, the [Theming](../customization/theming.md#primary-color) guide's rebrand recipe was to override the progressive channel properties — usually just the hue. The new pipeline builds the primary color differently: a single hue property, `--color-primary-oklch__h`, generates a full ramp of primary shades (`--color-primary-50` through `--color-primary-1000`), and semantic tokens like `--color-progressive` pick their light and dark stops from that ramp.
-
-Here is how the old knobs map:
-
-- **Hue** (`--color-progressive-oklch__h`): still emitted as an alias of the new property, so styles that *read* it keep resolving — but overriding it no longer changes the skin. Move your override to `--color-primary-oklch__h`. The value stays the same, and since it's a plain hue angle rather than a color, it doesn't need a `light-dark()` pair:
+Move your hue override from `--color-progressive-oklch__h` to `--color-primary-oklch__h`. The value is the same:
 
 ```css
 /* Citizen 3 */
@@ -156,12 +151,4 @@ Here is how the old knobs map:
 }
 ```
 
-- **Lightness and chroma** (`--color-progressive-oklch__l`, `--color-progressive-oklch__c`): removed. Each ramp stop bakes in its own lightness and chroma, so there is no single knob anymore. If the hue alone doesn't get you there, override the semantic tokens (`--color-progressive`, `--color-progressive--hover`, `--color-progressive--active`) directly with `light-dark()` pairs.
-
-The hue also does more than before: UI surfaces carry a subtle tint of it by default. A second knob, `--color-neutral-oklch__h`, controls that tint: it defaults to the primary hue, and setting it to a different value decouples the chrome from the accent (for example, gray chrome with a colorful accent).
-
-The soft-deprecated HSL fallback properties (`--color-progressive-hsl__h`, `__s`, `__l`) are still emitted for the few styles that read them, but they no longer feed the accent color anywhere — migrate to the new hue property.
-
-One caveat: of everything in the preview, the retheme surface is the most likely to still evolve before 4.0 ships — keep an eye on the release notes and the [Theming](../customization/theming.md) guide.
-
-Whichever way it evolves, guarded fixes stay inert until a reader is on the preview, and `?citizenpreview=0` reverts your own browser instantly.
+Citizen 4 can tint the neutral surfaces separately from the accent. `--color-neutral-oklch__h` sets their hue and defaults to the primary hue — set it to a different value to decouple the two.


### PR DESCRIPTION
Follow-up to #1617 reorganizing the **Migrating to Citizen 4** guide.

- Moves the page from the **Guide** sidebar group to **Project**, alongside the preview-channel docs.
- Durable lead — drops the dated framing and points at the preview channel page instead.
- Adds a **What's changing** index and numbered **Migration steps** (preview → guard → wiki-wide).
- Reworks **Migrate your token overrides** into an action-first "if you overrode X → to migrate Y" table, with the full removed-token list kept as a collapsed reference.

Docs-only. `npm run lint:md` and the VitePress build (which fails on dead links) both pass.

Opened as a draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1nvemkh9DazpEg4QwMQZ4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Citizen 4 migration guide with a clearer overview and step-by-step migration path.
  * Expanded guidance for previewing, deploying, and enabling the new version across a wiki.
  * Revised color and token migration instructions to better explain how to update existing overrides.
* **Style**
  * Adjusted the sidebar navigation so the migration guide now appears under the Project section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->