### PR TITLE
ci: watch docs npm dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## What

Adds a second npm entry to `.github/dependabot.yml` pointing at `/docs`.

## Why

The existing npm config only watches `directory: "/"` (the repo root), so Dependabot **version-updates** never look at `docs/package.json`. Routine bumps for the VitePress docs site — VitePress itself and its plugins — were never proposed. (The docs dependency bumps that show up in history came from Dependabot **security-updates**, a separate mechanism that scans every lockfile regardless of directory config and only fires on advisories.)

This is what let VitePress `2.0.0-alpha.18` sit unnoticed until it was upgraded by hand in #1623.

## Note

This mirrors the root entry (no grouping), so docs deps will get individual daily PRs like root deps do. If that is too noisy, we can add a `groups:` block to bundle docs updates into a single PR — happy to switch to that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1nvemkh9DazpEg4QwMQZ4
