### PR TITLE
feat: ✨ overhaul the theme system (preview)

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -35,6 +35,9 @@ $wgCitizenThemeDefault = 'auto';
 - `'auto'`: Matches the user's system or browser preference
 - `'light'`: Always starts in light mode
 - `'dark'`: Always starts in dark mode
+- `'black'`: Always starts in the Black theme
+
+The option also accepts any theme value registered on the wiki, e.g. `'ocean'` for a [custom theme](../customization/theming.md#creating-a-theme). The config itself is not gated — but the Black theme and custom themes ride the [preview channel](../contribute/preview-channel.md) until Citizen 4. Outside the preview, `'black'` falls back to an equivalent dark rendering, and custom themes won't render correctly.
 
 ### `$wgCitizenEnableCollapsibleSections`
 

--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -121,6 +121,8 @@ Citizen supports Light, Dark, Pure Black, and Automatic modes. Use these selecto
 | Pure black | `.skin-theme-clientpref-night.citizen-feature-pure-black-clientpref-1` |
 | Automatic | `.skin-theme-clientpref-os` |
 
+Theming works differently on the Citizen 4 preview — see [Themes (Citizen 4 preview)](#themes-citizen-4-preview) below.
+
 ### Inverting images in dark mode
 
 Some images, especially black text or icons on a transparent background, become invisible in dark mode. Citizen exposes a `--filter-invert` CSS variable that inverts colors only when a dark theme is active. Apply it to the element containing the image:
@@ -128,6 +130,81 @@ Some images, especially black text or icons on a transparent background, become 
 ```css
 filter: var( --filter-invert );
 ```
+
+## Themes (Citizen 4 preview)
+
+::: warning Preview (Citizen 4)
+This section describes theming in Citizen 4. Until it ships, these features require the [preview channel](../contribute/preview-channel.md).
+:::
+
+In Citizen 4, themes replace theme modes: a theme is a named set of overrides for the CSS custom properties documented throughout this page. The picker offers Black alongside Light, Dark, and Automatic, and the pure black switch is retired: its look ships as the Black theme, so pick Black in the preferences panel if you had it enabled.
+
+| Theme | Selector |
+| :--- | :--- |
+| Light | `.skin-theme-clientpref-day` |
+| Dark | `.skin-theme-clientpref-night` |
+| Black | `.skin-theme-clientpref-black` |
+| Automatic | `.skin-theme-clientpref-os` |
+| Wiki-defined | `.skin-theme-clientpref-<value>` |
+
+### Creating a theme
+
+Citizen's own Black theme is defined as a small set of overrides, so a theme you add on your wiki appears in the preferences panel right next to the built-in ones. Creating one takes two steps.
+
+#### Register the theme in the picker
+
+Add your theme to the `skin-theme` options in `MediaWiki:Citizen-preferences.json` — see [Extending preferences](../features/preferences.md#extending-preferences) for the full schema. The `options` array replaces the built-in list, so include the built-in themes you want to keep:
+
+```json
+{
+  "preferences": {
+    "skin-theme": {
+      "options": [
+        { "value": "os", "labelMsg": "citizen-theme-os-label" },
+        { "value": "day", "labelMsg": "citizen-theme-day-label" },
+        { "value": "night", "labelMsg": "citizen-theme-night-label" },
+        { "value": "black", "labelMsg": "citizen-theme-black-label" },
+        { "value": "ocean", "label": "Ocean" }
+      ],
+      "columns": 5
+    }
+  }
+}
+```
+
+The picker grid keeps the built-in column count unless you set `columns` to match your option count — leave it out and your fifth theme wraps onto a row of its own. Use `label` for a plain-text name, or `labelMsg` with an interface message (e.g. `MediaWiki:Ocean-theme-label`) on multilingual wikis. Theme values may contain letters and numbers only.
+
+#### Define the theme in CSS
+
+Add a block to `MediaWiki:Citizen.css` keyed to your theme's value, starting with a `color-scheme` declaration — the comments walk through the rest:
+
+```css
+:root.skin-theme-clientpref-ocean {
+    color-scheme: dark;
+
+    /* Dark baseline for effects light-dark() can't express — copy as-is */
+    --opacity-glass: 0.8;
+    --shadow-opacity: 0.44;
+    --font-grade: 0;
+    --filter-invert: invert( 1 ) hue-rotate( 180deg );
+
+    /* Your palette — override only what differs from the default dark theme */
+    --color-primary-oklch__h: 220;
+    --color-neutral-oklch__h: 220;
+}
+```
+
+Every property you don't override falls through to the default palette's [`light-dark()` pairs](../guide/migrating-to-citizen-4.md#light-and-dark-are-one-declaration-now) — color values that carry a light and a dark side and resolve per `color-scheme`. A dark theme starts from the built-in dark palette, a light theme (`color-scheme: light`) from the light palette, and you sculpt from there. The hue channels are the most useful knobs — `--color-primary-oklch__h` alone rebrands the accent, and `--color-neutral-oklch__h` tints the surfaces to match; see [Rebranding the primary color](../guide/migrating-to-citizen-4.md#rebranding-the-primary-color) for how the two relate.
+
+One limitation to know about: a few dark-mode extras are keyed to the built-in themes by name — the image dimming preference, and dark-mode fixes for some extensions — so they don't fire for custom themes. If your theme needs one of them, replicate it in your theme's CSS block.
+
+::: tip
+To make your theme the default for new visitors, set `$wgCitizenThemeDefault = 'ocean';`. Keep the theme registered in the picker too — the preferences panel can't show a selection for a value it doesn't know about.
+:::
+
+::: warning
+The theme picker's preview swatch can't read your CSS, so custom themes preview with an adaptive light/dark swatch rather than your palette.
+:::
 
 ## Performance considerations
 

--- a/docs/src/guide/migrating-to-citizen-4.md
+++ b/docs/src/guide/migrating-to-citizen-4.md
@@ -10,6 +10,7 @@ Citizen 4 will be released some time after MediaWiki 1.47 LTS. Use the [preview 
 ## What's changing
 
 - **New color token pipeline** — colors are defined as `light-dark()` pairs built from primitive ramps instead of computed channel math. Most existing overrides keep working; see [Migrate your token overrides](#migrate-your-token-overrides).
+- **Pure black mode becomes the Black theme** — the switch is retired in favor of a real theme; see [Pure black mode becomes the Black theme](#pure-black-mode-becomes-the-black-theme).
 
 ## Migration steps
 
@@ -152,3 +153,7 @@ Move your hue override from `--color-progressive-oklch__h` to `--color-primary-o
 ```
 
 Citizen 4 can tint the neutral surfaces separately from the accent. `--color-neutral-oklch__h` sets their hue and defaults to the primary hue — set it to a different value to decouple the two.
+
+## Pure black mode becomes the Black theme
+
+The pure black switch is now a theme in the theme picker. The switch retires without carry-over — if you had it enabled, pick the [Black theme](../customization/theming.md#themes-citizen-4-preview) in the preferences panel to get the same look.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -75,6 +75,7 @@
 	"citizen-theme-description": "Switch between light and dark mode",
 	"citizen-theme-day-label": "Light",
 	"citizen-theme-night-label": "Dark",
+	"citizen-theme-black-label": "Black",
 	"citizen-theme-os-label": "Auto",
 	"citizen-feature-autohide-navigation-name": "Automatically hide navigation",
 	"citizen-feature-autohide-navigation-description": "Hide the navigation bar when scrolling down",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -77,6 +77,7 @@
 	"citizen-theme-description": "Description for theme.",
 	"citizen-theme-day-label": "Label for light/day theme.",
 	"citizen-theme-night-label": "Label for dark/night theme.",
+	"citizen-theme-black-label": "Label for the black theme — a dark theme with pure black backgrounds. Shown in the theme picker of the preferences panel.\n{{Identical|Black}}",
 	"citizen-theme-os-label": "Label for automatic theme (which respects any operating system setting).",
 	"citizen-feature-autohide-navigation-name": "Label for automatically hide navigation",
 	"citizen-feature-autohide-navigation-description": "Description for automatically hide navigation preference.",

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -135,6 +135,13 @@ class SkinCitizen extends SkinMustache {
 		$theme = $config->get( 'CitizenThemeDefault' );
 		if ( isset( self::CLIENTPREFS_THEME_MAP[$theme] ) ) {
 			$classes[] = 'skin-theme-clientpref-' . self::CLIENTPREFS_THEME_MAP[$theme];
+		} elseif ( is_string( $theme ) && preg_match( '/^[a-zA-Z0-9]+$/', $theme ) === 1 ) {
+			// Theme values outside the legacy vocabulary — 'black' or a
+			// wiki-defined theme — map straight to their clientpref class.
+			// The charset mirrors the clientprefs value validation in
+			// MediaWiki core (isValidFeatureValue in mediawiki.user.js);
+			// keep the two in sync.
+			$classes[] = 'skin-theme-clientpref-' . $theme;
 		}
 
 		// Default client preferences

--- a/resources/skins.citizen.preferences/App.vue
+++ b/resources/skins.citizen.preferences/App.vue
@@ -85,17 +85,20 @@ const clientPrefs = require( './clientPrefs.polyfill.js' )();
  * side per preview — without swapping classes or reading computed
  * styles.
  *
- * @param {string} value - 'os', 'day', or 'night'
+ * @param {string} value - Theme value, e.g. 'os', 'day', 'night', 'black'
  * @return {string}
  */
 function getThemeColorScheme( value ) {
 	if ( value === 'day' ) {
 		return 'light';
 	}
-	if ( value === 'night' ) {
+	// Shipped themes — their scheme is known, hardcode it.
+	if ( value === 'night' || value === 'black' ) {
 		return 'dark';
 	}
-	// 'os' (or anything else) — defer to the user's OS preference.
+	// 'os' — and wiki-defined themes, whose real scheme lives in their
+	// CSS where the swatch can't read it. Adaptive is the least-wrong
+	// preview for both.
 	return 'light dark';
 }
 

--- a/resources/skins.citizen.preferences/defaultConfig.js
+++ b/resources/skins.citizen.preferences/defaultConfig.js
@@ -7,6 +7,21 @@ const { PreferencesConfig } = require( './types.js' );
  * @return {PreferencesConfig} Default config with sections and preferences
  */
 function getDefaultConfig() {
+	// Black ships as a theme on the preview channel; the legacy world
+	// keeps the pure-black switch instead.
+	// citizen-v4-remove — at the 4.0 flip, inline the v4 branches and
+	// delete the pure-black entry.
+	const isV4 = document.documentElement.classList.contains( 'citizen-v4' );
+
+	const themeOptions = [
+		{ value: 'os', labelMsg: 'citizen-theme-os-label' },
+		{ value: 'day', labelMsg: 'citizen-theme-day-label' },
+		{ value: 'night', labelMsg: 'citizen-theme-night-label' }
+	];
+	if ( isV4 ) {
+		themeOptions.push( { value: 'black', labelMsg: 'citizen-theme-black-label' } );
+	}
+
 	return {
 		sections: {
 			appearance: { labelMsg: 'citizen-preferences-section-appearance' },
@@ -15,13 +30,9 @@ function getDefaultConfig() {
 		preferences: {
 			'skin-theme': {
 				section: 'appearance',
-				options: [
-					{ value: 'os', labelMsg: 'citizen-theme-os-label' },
-					{ value: 'day', labelMsg: 'citizen-theme-day-label' },
-					{ value: 'night', labelMsg: 'citizen-theme-night-label' }
-				],
+				options: themeOptions,
 				type: 'radio',
-				columns: 3,
+				columns: themeOptions.length,
 				labelMsg: 'citizen-theme-name',
 				descriptionMsg: 'citizen-theme-description',
 				visibilityCondition: 'always'
@@ -53,14 +64,16 @@ function getDefaultConfig() {
 			},
 			// Switch preferences use short-form options (strings).
 			// normalizeConfig() converts these to { value: '0' } / { value: '1' }.
-			'citizen-feature-pure-black': {
-				section: 'appearance',
-				options: [ '0', '1' ],
-				type: 'switch',
-				labelMsg: 'citizen-feature-pure-black-name',
-				descriptionMsg: 'citizen-feature-pure-black-description',
-				visibilityCondition: 'dark-theme'
-			},
+			...( isV4 ? {} : {
+				'citizen-feature-pure-black': {
+					section: 'appearance',
+					options: [ '0', '1' ],
+					type: 'switch',
+					labelMsg: 'citizen-feature-pure-black-name',
+					descriptionMsg: 'citizen-feature-pure-black-description',
+					visibilityCondition: 'dark-theme'
+				}
+			} ),
 			'citizen-feature-image-dimming': {
 				section: 'appearance',
 				options: [ '0', '1' ],

--- a/resources/skins.citizen.preferences/init.js
+++ b/resources/skins.citizen.preferences/init.js
@@ -57,7 +57,13 @@ function initApp() {
 		Object.assign( config.preferences, updated.preferences );
 	}
 
-	const themeDefault = THEME_CONFIG_MAP[ serverConfig.wgCitizenThemeDefault ] || 'os';
+	// Legacy config vocabulary maps to clientpref values; anything else
+	// ('black', wiki-defined themes) passes through. No charset check
+	// here, unlike the PHP side: the value never reaches the DOM raw —
+	// App.vue validates it against the registered options list, so an
+	// unregistered value safely falls back to the first option.
+	const themeDefault = THEME_CONFIG_MAP[ serverConfig.wgCitizenThemeDefault ] ||
+		serverConfig.wgCitizenThemeDefault || 'os';
 
 	const app = Vue.createMwApp( App );
 	app.provide( 'preferencesConfig', config );

--- a/resources/skins.citizen.preferences/useVisibility.js
+++ b/resources/skins.citizen.preferences/useVisibility.js
@@ -1,4 +1,4 @@
-const { computed, onMounted, onUnmounted, ref } = require( 'vue' );
+const { computed, onMounted, onUnmounted, ref, watch } = require( 'vue' );
 
 /**
  * Tablet breakpoint from Codex design tokens.
@@ -9,7 +9,12 @@ const TABLET_BREAKPOINT = 1119;
 
 /**
  * Composable that determines whether a preference group should be visible
- * based on its visibility condition and the current theme value.
+ * based on its visibility condition.
+ *
+ * The `dark-theme` condition derives from the document's computed
+ * `color-scheme` rather than from specific theme values, so it works for
+ * any theme. The `themeValue` ref is watched to re-resolve the scheme
+ * whenever the theme changes.
  *
  * @param {string} condition - Visibility condition:
  *   'always', 'dark-theme', or 'tablet-viewport'
@@ -19,11 +24,31 @@ const TABLET_BREAKPOINT = 1119;
 function useVisibility( condition, themeValue ) {
 	const isDarkScheme = ref( false );
 	const isTabletViewport = ref( false );
+	const rootColorScheme = ref( 'light' );
 
 	let darkMediaQuery = null;
 	let tabletMediaQuery = null;
 	let darkHandler = null;
 	let tabletHandler = null;
+
+	/**
+	 * The dark-theme condition resolves from the document's computed
+	 * `color-scheme` — set by both token pipelines and by any custom
+	 * theme following the theme contract — so it holds for themes this
+	 * module has never heard of.
+	 */
+	function readRootColorScheme() {
+		rootColorScheme.value =
+			window.getComputedStyle( document.documentElement ).colorScheme || 'light';
+	}
+
+	if ( condition === 'dark-theme' ) {
+		readRootColorScheme();
+		// Theme switches swap the :root class before themeValue updates
+		// (App.vue setValue), so the computed style is fresh when this
+		// watcher runs.
+		watch( themeValue, readRootColorScheme );
+	}
 
 	onMounted( () => {
 		if ( condition === 'dark-theme' ) {
@@ -58,14 +83,14 @@ function useVisibility( condition, themeValue ) {
 
 	const isVisible = computed( () => {
 		switch ( condition ) {
-			case 'dark-theme':
-				if ( themeValue.value === 'night' ) {
-					return true;
+			case 'dark-theme': {
+				const schemes = rootColorScheme.value.split( /\s+/ );
+				if ( !schemes.includes( 'dark' ) ) {
+					return false;
 				}
-				if ( themeValue.value === 'os' ) {
-					return isDarkScheme.value;
-				}
-				return false;
+				// 'light dark' — the OS decides.
+				return schemes.includes( 'light' ) ? isDarkScheme.value : true;
+			}
 			case 'tablet-viewport':
 				return isTabletViewport.value;
 			default:

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -3,8 +3,8 @@
 // citizen-v4-remove — the pure-black switch is replaced by the Black
 // theme on the preview channel (skins.citizen.tokens.new/themes/black.less).
 // This mixin and the .citizen-feature-pure-black-clientpref-1 block below
-// keep the old look working for cached HTML and the legacy world until
-// the 4.0 flip.
+// serve the legacy world only until the 4.0 flip; the consumer block is
+// scoped out of v4, where the picker no longer offers the switch.
 .feature-pure-black() {
 	// ----- Legacy mode: zero out chroma on legacy derivation primitives -----
 	--color-surface-0-oklch__l: 0%;
@@ -101,12 +101,16 @@
 }
 
 .citizen-feature-pure-black-clientpref-1 {
-	:root.skin-theme-clientpref-night& {
+	// The :not() guard keeps a stored switch from rendering night as
+	// pure black in the v4 world, which offers no way to turn it off —
+	// stored switches retire without carry-over; users pick the Black
+	// theme instead.
+	:root:not( .citizen-v4 ).skin-theme-clientpref-night& {
 		.feature-pure-black();
 	}
 
 	@media ( prefers-color-scheme: dark ) {
-		:root.skin-theme-clientpref-os& {
+		:root:not( .citizen-v4 ).skin-theme-clientpref-os& {
 			.feature-pure-black();
 		}
 	}

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -1,5 +1,10 @@
 @import '../tokens-codex.less';
 
+// citizen-v4-remove — the pure-black switch is replaced by the Black
+// theme on the preview channel (skins.citizen.tokens.new/themes/black.less).
+// This mixin and the .citizen-feature-pure-black-clientpref-1 block below
+// keep the old look working for cached HTML and the legacy world until
+// the 4.0 flip.
 .feature-pure-black() {
 	// ----- Legacy mode: zero out chroma on legacy derivation primitives -----
 	--color-surface-0-oklch__l: 0%;
@@ -202,7 +207,8 @@
 
 // T400838
 .citizen-feature-image-dimming-clientpref-1 {
-	:root.skin-theme-clientpref-night& {
+	:root.skin-theme-clientpref-night&,
+	:root.skin-theme-clientpref-black& {
 		--filter-image-brightness: brightness( 0.8 );
 	}
 

--- a/resources/skins.citizen.tokens.new/background-color.less
+++ b/resources/skins.citizen.tokens.new/background-color.less
@@ -24,6 +24,13 @@
 		--background-color-notice-subtle: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
 		--background-color-inverted: light-dark( var( --color-neutral-1000 ), var( --color-neutral-50 ) );
 
+		// Icon backgrounds — Citizen extension consumed by skinStyles
+		// (e.g. SemanticMediaWiki). Alpha rides the icon opacity ramp.
+		// less.php can't parse var() inside rgba(), hence the escapes.
+		--background-color-icon: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base ) ), rgba( 255, 255, 255, var( --opacity-icon-base ) ) )';
+		--background-color-icon--hover: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--hover ) ), rgba( 255, 255, 255, var( --opacity-icon-base--hover ) ) )';
+		--background-color-icon--active: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--active ) ), rgba( 255, 255, 255, var( --opacity-icon-base--active ) ) )';
+
 		// Filled state backgrounds — theme-invariant per Codex (filled
 		// buttons stay saturated). Not aliased to --color-progressive/-destructive:
 		// those are theme-variant text colors, and chaining would drag fills

--- a/resources/skins.citizen.tokens.new/background-color.less
+++ b/resources/skins.citizen.tokens.new/background-color.less
@@ -26,7 +26,7 @@
 
 		// Icon backgrounds — Citizen extension consumed by skinStyles
 		// (e.g. SemanticMediaWiki). Alpha rides the icon opacity ramp.
-		// less.php can't parse var() inside rgba(), hence the escapes.
+		// Escapes kept for parity with the legacy pipeline's declarations.
 		--background-color-icon: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base ) ), rgba( 255, 255, 255, var( --opacity-icon-base ) ) )';
 		--background-color-icon--hover: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--hover ) ), rgba( 255, 255, 255, var( --opacity-icon-base--hover ) ) )';
 		--background-color-icon--active: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--active ) ), rgba( 255, 255, 255, var( --opacity-icon-base--active ) ) )';

--- a/resources/skins.citizen.tokens.new/dark-overrides.less
+++ b/resources/skins.citizen.tokens.new/dark-overrides.less
@@ -1,8 +1,8 @@
 /**
  * Dark-mode overrides for theme-variant non-color tokens — all Citizen
  * extensions. light-dark() only handles color values, so these
- * non-color tokens (opacity, font-grade, filter, percentages) plus
- * the dark-only icon-* backgrounds get a separate companion mixin.
+ * non-color tokens (opacity, font-grade, filter, percentages) get a
+ * separate companion mixin.
  *
  * Called at .skin-theme-clientpref-night and at clientpref-os under
  * prefers-color-scheme: dark.
@@ -13,10 +13,4 @@
 	--font-grade: 0;
 	--filter-invert: invert( 1 ) hue-rotate( 180deg );
 	--color-progressive-hsl__l: 60%;
-
-	// Dark-only — light mode renders icons via a different pattern
-	// that doesn't consume these tokens.
-	--background-color-icon: ~'rgba( 255, 255, 255, var( --opacity-icon-base ) )';
-	--background-color-icon--hover: ~'rgba( 255, 255, 255, var( --opacity-icon-base--hover ) )';
-	--background-color-icon--active: ~'rgba( 255, 255, 255, var( --opacity-icon-base--active ) )';
 }

--- a/resources/skins.citizen.tokens.new/opacity.less
+++ b/resources/skins.citizen.tokens.new/opacity.less
@@ -10,7 +10,7 @@
 	:root.citizen-token-new {
 		// Codex (with Citizen-added --active stop, sitting between
 		// hover and selected — consumed by --background-color-icon--active
-		// in dark-overrides.less).
+		// in background-color.less).
 		--opacity-icon-base: 0.6;
 		--opacity-icon-base--hover: 0.74;
 		--opacity-icon-base--active: 0.87;

--- a/resources/skins.citizen.tokens.new/themes/black.less
+++ b/resources/skins.citizen.tokens.new/themes/black.less
@@ -1,0 +1,39 @@
+/**
+ * Black theme — dark-only preset.
+ *
+ * Reference implementation of the theme contract documented in
+ * docs/src/customization/theming.md: declare color-scheme, apply the
+ * non-color dark baseline, then override only the tokens that differ
+ * from the default theme. Everything not overridden falls through the
+ * light-dark() pairs to the default palette.
+ */
+@import ( reference ) '../dark-overrides.less';
+
+.new-theme-black() {
+	// The second selector is the pre-rename generation class, kept for
+	// one minor so compiled CSS keeps matching cached HTML.
+	// citizen-v4-remove
+	:root.citizen-v4.skin-theme-clientpref-black,
+	:root.citizen-token-new.skin-theme-clientpref-black {
+		color-scheme: dark;
+		.new-dark-overrides();
+
+		// Neutral ramp at zero chroma — pure gray, no accent tint. Same
+		// lightness stops as primitives-citizen.less, except the deepest
+		// stop drops to 0% so surface-0 renders pitch black. Hue is
+		// inert at chroma 0. The primary ramp is untouched: the
+		// progressive accent stays tinted on black, matching the legacy
+		// pure-black mode.
+		--color-neutral-50: oklch( 98% 0 0 );
+		--color-neutral-100: oklch( 94% 0 0 );
+		--color-neutral-200: oklch( 90% 0 0 );
+		--color-neutral-300: oklch( 84% 0 0 );
+		--color-neutral-400: oklch( 73% 0 0 );
+		--color-neutral-500: oklch( 51% 0 0 );
+		--color-neutral-600: oklch( 39% 0 0 );
+		--color-neutral-700: oklch( 30% 0 0 );
+		--color-neutral-800: oklch( 22% 0 0 );
+		--color-neutral-900: oklch( 17% 0 0 );
+		--color-neutral-1000: oklch( 0% 0 0 );
+	}
+}

--- a/resources/skins.citizen.tokens.new/tokens.less
+++ b/resources/skins.citizen.tokens.new/tokens.less
@@ -31,6 +31,7 @@
 @import ( reference ) 'font.less';
 @import ( reference ) 'misc.less';
 @import ( reference ) 'dark-overrides.less';
+@import ( reference ) 'themes/black.less';
 
 @layer citizen-tokens {
 	.new-primitives-codex();
@@ -70,4 +71,8 @@
 			.new-dark-overrides();
 		}
 	}
+
+	// Shipped themes. Each theme file is self-contained — selector,
+	// color-scheme, and overrides — mirroring the wiki-facing contract.
+	.new-theme-black();
 }

--- a/resources/skins.citizen.tokens/tokens.less
+++ b/resources/skins.citizen.tokens/tokens.less
@@ -13,6 +13,9 @@
 @import ( reference ) 'tokens-codex.less';
 @import ( reference ) 'tokens-theme-base.less';
 @import ( reference ) 'tokens-theme-dark.less';
+// Imported only for .feature-pure-black(), reused by the Black-theme
+// alias below; a reference import emits nothing unless invoked.
+@import ( reference ) '../skins.citizen.styles/common/features.less';
 
 @layer citizen-tokens {
 	.tokens-codex-legacy();
@@ -32,6 +35,17 @@
 			:root& {
 				.theme-dark-legacy();
 			}
+		}
+	}
+
+	// citizen-v4-remove — Black-theme alias. Users migrated to
+	// skin-theme=black on the preview channel keep a dark, pure-black
+	// rendering if the wiki turns the preview back off. Dies with the
+	// legacy pipeline at the 4.0 flip.
+	.skin-theme-clientpref-black {
+		:root& {
+			.theme-dark-legacy();
+			.feature-pure-black();
 		}
 	}
 }

--- a/skin.json
+++ b/skin.json
@@ -992,7 +992,7 @@
 	"config": {
 		"ThemeDefault": {
 			"value": "auto",
-			"description": "Default theme of the skin. Valid values are 'light', 'dark' and 'auto'.",
+			"description": "Default theme of the skin. Accepts 'auto', 'light', 'dark', or any theme value such as 'black' or a wiki-defined theme.",
 			"descriptionmsg": "citizen-config-themedefault",
 			"public": true
 		},

--- a/skin.json
+++ b/skin.json
@@ -312,6 +312,7 @@
 				"citizen-preferences-section-appearance",
 				"citizen-preferences-section-behavior",
 				"citizen-theme-description",
+				"citizen-theme-black-label",
 				"citizen-theme-day-label",
 				"citizen-theme-name",
 				"citizen-theme-night-label",

--- a/tests/phpunit/integration/SkinCitizenTest.php
+++ b/tests/phpunit/integration/SkinCitizenTest.php
@@ -130,6 +130,17 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 		$this->assertStringNotContainsString( 'skin-theme-clientpref-', $attrs['class'] );
 	}
 
+	public function testSetSkinThemeWithCustomValue(): void {
+		$this->overrideConfigValues( [
+			'CitizenThemeDefault' => 'black',
+		] );
+
+		$skin = $this->createSkinInstance();
+		$attrs = $skin->getHtmlElementAttributes();
+
+		$this->assertStringContainsString( 'skin-theme-clientpref-black', $attrs['class'] );
+	}
+
 	public function testCollapsibleSectionsBodyClass(): void {
 		$title = Title::newFromText( 'CollapsibleSectionsTest' );
 		RequestContext::resetMain();

--- a/tests/vitest/skins.citizen.preferences/App.test.js
+++ b/tests/vitest/skins.citizen.preferences/App.test.js
@@ -32,9 +32,12 @@ mw.loader.require = vi.fn( () => ( {
 	}
 } ) );
 
-// Mock getComputedStyle to return fake CSS custom property values
+// Mock getComputedStyle to return fake CSS custom property values and a
+// resolved color-scheme (which useVisibility's dark-theme condition reads).
+let mockColorScheme = 'light';
 const originalGetComputedStyle = globalThis.getComputedStyle;
 globalThis.getComputedStyle = vi.fn( () => ( {
+	colorScheme: mockColorScheme,
 	getPropertyValue: vi.fn( ( prop ) => {
 		if ( prop === '--color-surface-0' ) {
 			return '#ffffff';
@@ -145,6 +148,7 @@ beforeAll( async () => {
 
 afterEach( () => {
 	document.documentElement.className = '';
+	mockColorScheme = 'light';
 	vi.clearAllMocks();
 } );
 
@@ -360,7 +364,7 @@ describe( 'App', () => {
 
 		it( 'should show dark-theme preference when theme changes to night', async () => {
 			// pure-black has dark-theme visibility condition;
-			// with os theme and matchMedia=false it is hidden via v-show.
+			// with a light resolved color-scheme it is hidden via v-show.
 			const wrapper = mountApp( ALL_PREF_CLASSES );
 
 			const pureBlack = wrapper.find(
@@ -369,7 +373,9 @@ describe( 'App', () => {
 
 			expect( pureBlack.attributes( 'style' ) ).toContain( 'display: none' );
 
-			// Changing theme to night makes dark-theme conditions visible.
+			// Changing the theme swaps the root class, so the computed
+			// color-scheme resolves to dark and dark-theme conditions show.
+			mockColorScheme = 'dark';
 			const radioGroup = wrapper.findComponent( { name: 'RadioGroup' } );
 			radioGroup.vm.$emit( 'update:modelValue', 'night' );
 			await wrapper.vm.$nextTick();

--- a/tests/vitest/skins.citizen.preferences/App.test.js
+++ b/tests/vitest/skins.citizen.preferences/App.test.js
@@ -278,6 +278,36 @@ describe( 'App', () => {
 		} );
 	} );
 
+	describe( 'preview channel (citizen-v4)', () => {
+		beforeEach( () => {
+			document.documentElement.classList.add( 'citizen-v4' );
+		} );
+
+		afterEach( () => {
+			document.documentElement.classList.remove( 'citizen-v4' );
+		} );
+
+		it( 'should preview the black theme swatch with a dark color scheme', () => {
+			// Build fresh instead of reusing BASE_CONFIG — the cached base
+			// was built without the citizen-v4 class, so it has the legacy
+			// three-theme shape. mountApp resets the classList, but the
+			// config is already built by then.
+			const v4Config = normalizeConfig( getDefaultConfig() );
+
+			const wrapper = mountApp( ALL_PREF_CLASSES, v4Config );
+
+			const radios = wrapper.findAllComponents( { name: 'CdxRadio' } );
+			const blackRadio = radios.find(
+				( c ) => c.props( 'inputValue' ) === 'black'
+			);
+			expect( blackRadio ).toBeTruthy();
+			const preview = blackRadio.find(
+				'.citizen-preferences-card__preview--theme'
+			);
+			expect( preview.attributes( 'style' ) ).toContain( 'color-scheme: dark' );
+		} );
+	} );
+
 	describe( 'initialization', () => {
 		it( 'should initialize values from classList', () => {
 			const classes = ALL_PREF_CLASSES.map( ( cls ) =>

--- a/tests/vitest/skins.citizen.preferences/defaultConfig.test.js
+++ b/tests/vitest/skins.citizen.preferences/defaultConfig.test.js
@@ -83,4 +83,43 @@ describe( 'defaultConfig', () => {
 		expect( config.preferences[ 'citizen-feature-pure-black' ].visibilityCondition )
 			.toBe( 'dark-theme' );
 	} );
+
+	describe( 'preview channel (citizen-v4)', () => {
+		beforeEach( () => {
+			document.documentElement.classList.add( 'citizen-v4' );
+		} );
+
+		afterEach( () => {
+			document.documentElement.classList.remove( 'citizen-v4' );
+		} );
+
+		it( 'should offer Black as a fourth theme', () => {
+			const config = getDefaultConfig();
+
+			const themePref = config.preferences[ 'skin-theme' ];
+			expect( themePref.options ).toHaveLength( 4 );
+			expect( themePref.options[ 3 ] ).toEqual( {
+				value: 'black', labelMsg: 'citizen-theme-black-label'
+			} );
+			expect( themePref.columns ).toBe( 4 );
+		} );
+
+		it( 'should not offer the pure black switch', () => {
+			const config = getDefaultConfig();
+
+			expect( config.preferences ).not.toHaveProperty( 'citizen-feature-pure-black' );
+			expect( Object.keys( config.preferences ) ).toHaveLength( 6 );
+		} );
+	} );
+
+	describe( 'legacy world', () => {
+		it( 'should keep three theme options and the pure black switch', () => {
+			const config = getDefaultConfig();
+
+			const themePref = config.preferences[ 'skin-theme' ];
+			expect( themePref.options ).toHaveLength( 3 );
+			expect( themePref.columns ).toBe( 3 );
+			expect( config.preferences ).toHaveProperty( 'citizen-feature-pure-black' );
+		} );
+	} );
 } );

--- a/tests/vitest/skins.citizen.preferences/init.test.js
+++ b/tests/vitest/skins.citizen.preferences/init.test.js
@@ -12,6 +12,9 @@ Vue.createMwApp = vi.fn( () => ( { provide: mockProvide, mount: mockMount } ) );
 // Mutable mock — modify .overrides/.messages between tests
 const overridesMock = require( '../mocks/preferencesOverrides.js' );
 
+// Mutable mock — modify .wgCitizenThemeDefault between tests
+const configMock = require( '../mocks/preferencesConfig.js' );
+
 let initApp;
 
 beforeAll( async () => {
@@ -32,6 +35,8 @@ afterEach( () => {
 	// Reset overrides mock to defaults
 	overridesMock.overrides = null;
 	overridesMock.messages = {};
+	// Reset config mock to defaults
+	configMock.wgCitizenThemeDefault = 'auto';
 	// Reset register hook between tests
 	mw.hook( 'citizen.preferences.register' )._reset();
 } );
@@ -115,6 +120,24 @@ describe( 'initApp', () => {
 
 		// preferencesConfig.js mock has wgCitizenThemeDefault: 'auto' → maps to 'os'
 		expect( mockProvide ).toHaveBeenCalledWith( 'themeDefault', 'os' );
+	} );
+
+	it( 'should pass non-legacy theme defaults through to the app', () => {
+		configMock.wgCitizenThemeDefault = 'black';
+		document.body.innerHTML = '<div id="citizen-preferences-content"></div>';
+
+		initApp();
+
+		expect( mockProvide ).toHaveBeenCalledWith( 'themeDefault', 'black' );
+	} );
+
+	it( 'should map legacy theme default vocabulary', () => {
+		configMock.wgCitizenThemeDefault = 'dark';
+		document.body.innerHTML = '<div id="citizen-preferences-content"></div>';
+
+		initApp();
+
+		expect( mockProvide ).toHaveBeenCalledWith( 'themeDefault', 'night' );
 	} );
 
 	it( 'should fire citizen.preferences.register hook', () => {

--- a/tests/vitest/skins.citizen.preferences/useVisibility.test.js
+++ b/tests/vitest/skins.citizen.preferences/useVisibility.test.js
@@ -17,6 +17,16 @@ function createMatchMediaMock( matches ) {
 	};
 }
 
+/**
+ * Mocks the computed color-scheme on the document element.
+ *
+ * @param {string} colorScheme
+ * @return {import('vitest').MockInstance}
+ */
+function mockRootColorScheme( colorScheme ) {
+	return vi.spyOn( window, 'getComputedStyle' ).mockReturnValue( { colorScheme } );
+}
+
 // useVisibility relies on Vue lifecycle hooks (onMounted/onUnmounted),
 // so it must be called inside a component's setup(). We mount a minimal
 // wrapper component to test the composable in its intended context.
@@ -67,63 +77,74 @@ describe( 'useVisibility', () => {
 			globalThis.matchMedia = vi.fn( () => createMatchMediaMock( false ) );
 		} );
 
-		it( 'should be visible when themeValue is night', () => {
-			const themeValue = ref( 'night' );
+		it( 'should be visible when the resolved scheme is dark', async () => {
+			mockRootColorScheme( 'dark' );
+			const themeValue = ref( 'black' );
 
 			const wrapper = mountWithVisibility( 'dark-theme', themeValue );
+			await flushPromises();
 
 			expect( wrapper.text() ).toBe( 'visible' );
 		} );
 
-		it( 'should be hidden when themeValue is day', () => {
+		it( 'should be hidden when the resolved scheme is light', async () => {
+			mockRootColorScheme( 'light' );
+			globalThis.matchMedia = vi.fn( () => createMatchMediaMock( true ) );
 			const themeValue = ref( 'day' );
 
 			const wrapper = mountWithVisibility( 'dark-theme', themeValue );
+			await flushPromises();
 
 			expect( wrapper.text() ).toBe( '' );
 		} );
 
-		it( 'should be visible when themeValue is os and prefers-color-scheme is dark', async () => {
+		it( 'should follow the OS preference when the scheme is adaptive', async () => {
+			mockRootColorScheme( 'light dark' );
 			globalThis.matchMedia = vi.fn( () => createMatchMediaMock( true ) );
 			const themeValue = ref( 'os' );
 
 			const wrapper = mountWithVisibility( 'dark-theme', themeValue );
 			await flushPromises();
 
+			expect( globalThis.matchMedia ).toHaveBeenCalledWith( '(prefers-color-scheme: dark)' );
 			expect( wrapper.text() ).toBe( 'visible' );
 		} );
 
-		it( 'should be hidden when themeValue is os and prefers-color-scheme is light', () => {
-			globalThis.matchMedia = vi.fn( () => createMatchMediaMock( false ) );
+		it( 'should be hidden for adaptive scheme when the OS is light', async () => {
+			mockRootColorScheme( 'light dark' );
 			const themeValue = ref( 'os' );
 
 			const wrapper = mountWithVisibility( 'dark-theme', themeValue );
+			await flushPromises();
 
 			expect( wrapper.text() ).toBe( '' );
 		} );
 
-		it( 'should react to themeValue changes', async () => {
+		it( 'should re-resolve when the theme value changes', async () => {
+			const spy = mockRootColorScheme( 'light' );
 			const themeValue = ref( 'day' );
 
 			const wrapper = mountWithVisibility( 'dark-theme', themeValue );
+			await flushPromises();
 
 			expect( wrapper.text() ).toBe( '' );
 
-			themeValue.value = 'night';
-			await flushPromises();
+			spy.mockReturnValue( { colorScheme: 'dark' } );
+			themeValue.value = 'black';
+			await wrapper.vm.$nextTick();
 
 			expect( wrapper.text() ).toBe( 'visible' );
 		} );
 
-		it( 'should register a matchMedia listener for prefers-color-scheme', () => {
-			const mockQuery = createMatchMediaMock( false );
-			globalThis.matchMedia = vi.fn( () => mockQuery );
-			const themeValue = ref( 'os' );
+		it( 'should treat a missing color-scheme as light', async () => {
+			mockRootColorScheme( '' );
+			globalThis.matchMedia = vi.fn( () => createMatchMediaMock( true ) );
+			const themeValue = ref( 'unknowntheme' );
 
-			mountWithVisibility( 'dark-theme', themeValue );
+			const wrapper = mountWithVisibility( 'dark-theme', themeValue );
+			await flushPromises();
 
-			expect( globalThis.matchMedia ).toHaveBeenCalledWith( '(prefers-color-scheme: dark)' );
-			expect( mockQuery.addEventListener ).toHaveBeenCalledWith( 'change', expect.any( Function ) );
+			expect( wrapper.text() ).toBe( '' );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary

Themes become first-class on the Citizen 4 preview channel:

- **Black is a real theme** — a fourth option in the theme picker. It's defined as a small partial override block (`skins.citizen.tokens.new/themes/black.less`): `color-scheme: dark`, the non-color dark baseline, and a zero-chroma neutral ramp with the deepest stop at pure black. Every token it doesn't override falls through the default palette's `light-dark()` pairs — the file doubles as the reference implementation of the theme contract.
- **Wikis can define their own themes** with the exact same mechanism: register an option in `MediaWiki:Citizen-preferences.json`, add a CSS block in `MediaWiki:Citizen.css`. Documented in a new "Themes (Citizen 4 preview)" section of the theming guide, which keeps all Citizen 4 content separate from the Citizen 3 sections.
- **The pure black switch is retired without carry-over.** Its styles are scoped out of the v4 world (`:root:not( .citizen-v4 )`) so a previously stored switch can't render night as pure black with no way to turn it off — users pick the Black theme in the preferences panel instead. Citizen 4 is a breaking release; a storage-mutating migration script that would have had to outlive the 4.0 flip wasn't worth the complexity. The legacy world keeps the switch, and a legacy-pipeline alias keeps `skin-theme-clientpref-black` rendering dark + pure black if a wiki turns the preview back off.
- **`$wgCitizenThemeDefault` accepts any theme value** (`black` or a wiki-defined theme) alongside the legacy `auto`/`light`/`dark` vocabulary.
- Groundwork that helps both worlds: icon background tokens are defined in light mode again (as `light-dark()` pairs), and dark-only preferences like image dimming now resolve from the computed `color-scheme` — and apply on Black — instead of a hardcoded theme list.

## Preview-channel notes

New-world changes ride the preview-only `skins.citizen.tokens.new` module or `citizen-v4` gates in JS; legacy-side survivors carry `citizen-v4-remove` markers and are listed in the flip cleanup ledger.

## Verification

- 987 Vitest tests and 166 PHPUnit tests green; stylelint/eslint/banana/markdownlint clean.
- Full in-browser pass in both worlds: the 4-option picker, Black rendering (pure black surfaces, tinted accent, dark UA controls), a stored pure-black switch confirmed inert in v4 (plain dark, Black one click away) and still functional in legacy, an end-to-end custom "Ocean" theme (picker registration, CSS, server default), `?uselang=x-xss` on the new message, and image dimming exercised on Black in both worlds.

## Follow-ups (tracked separately, not in this PR)

#1639 (skinStyles dark-state selector sweep), #1640 (theme picker redesign for v4), #1641 (unregistered default theme in the picker), #1642 (theme-aware theme-color meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmcTY8FeRJHdn3ncK5Ua38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Black theme with a dark-only appearance.
  * Added support for custom theme values and expanded theme selection in the Citizen 4 preview.
  * Updated theme previews and dark-mode behavior to reflect each theme’s color scheme.

* **Documentation**
  * Documented Black and custom themes, preview-channel behavior, configuration, and migration guidance.
  * Clarified theme configuration options and the retirement of the pure black switch.

* **Bug Fixes**
  * Improved image dimming and theme visibility behavior for Black and custom themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->