### PR TITLE
fix: keep the skin working when the interface language is invalid

### DIFF
--- a/resources/skins.citizen.notifications/components/NotificationItem.vue
+++ b/resources/skins.citizen.notifications/components/NotificationItem.vue
@@ -77,7 +77,8 @@ const RELATIVE_UNITS = [
 /**
  * Format a unix timestamp (seconds) as a compact localized relative time via
  * Intl's narrow style, e.g. "now", "2m ago", "5h ago", "3d ago". Returns ''
- * for a missing/invalid timestamp or where Intl is unsupported.
+ * for a missing/invalid timestamp, where Intl is unsupported, or where the
+ * user language is not a valid BCP 47 tag.
  *
  * @param {number} unixSeconds
  * @return {string}
@@ -95,10 +96,24 @@ function formatRelativeTime( unixSeconds ) {
 	const match = RELATIVE_UNITS.find( ( unit ) => abs >= unit[ 1 ] );
 	const unitName = match ? match[ 0 ] : 'second';
 	const divisor = match ? match[ 1 ] : 1;
-	const rtf = new RelativeTimeFormat(
-		mw.config.get( 'wgUserLanguage' ) || undefined,
-		{ style: 'narrow', numeric: 'auto' }
-	);
+
+	let rtf;
+	try {
+		rtf = new RelativeTimeFormat(
+			mw.config.get( 'wgUserLanguage' ) || undefined,
+			{ style: 'narrow', numeric: 'auto' }
+		);
+	} catch ( e ) {
+		// A structurally invalid BCP 47 tag (e.g. the x-xss testing
+		// pseudo-language) makes the constructor throw. Degrade to no relative
+		// timestamp rather than breaking the notification row's render.
+		mw.log.warn(
+			'[Citizen] Skipping the notification relative time; the interface language is not a valid BCP 47 tag:',
+			e
+		);
+		return '';
+	}
+
 	return rtf.format( Math.round( deltaSeconds / divisor ), unitName );
 }
 

--- a/resources/skins.citizen.scripts/lastModified.js
+++ b/resources/skins.citizen.scripts/lastModified.js
@@ -49,7 +49,22 @@ function createLastModified( { document, Intl: IntlObj } ) {
 		}
 
 		const lang = document.documentElement.getAttribute( 'lang' );
-		const rtf = new IntlObj.RelativeTimeFormat( lang );
+
+		let rtf;
+		try {
+			rtf = new IntlObj.RelativeTimeFormat( lang );
+		} catch ( e ) {
+			// A structurally invalid BCP 47 tag (e.g. the x-xss testing
+			// pseudo-language) makes the constructor throw. The relative time is
+			// a progressive enhancement, so leave the server-rendered absolute
+			// timestamp in place rather than aborting the rest of skin init.
+			mw.log.warn(
+				'[Citizen] Skipping the relative last-modified time; the interface language is not a valid BCP 47 tag:',
+				e
+			);
+			return;
+		}
+
 		const timestamp = lastmodEl.getAttribute( 'data-timestamp' );
 
 		lastmodEl.lastChild.textContent = formatTimeAgo( timestamp, Date.now(), rtf, DIVISIONS );

--- a/tests/vitest/skins.citizen.notifications/NotificationItem.test.js
+++ b/tests/vitest/skins.citizen.notifications/NotificationItem.test.js
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+const { mount } = require( '@vue/test-utils' );
+// Require vue (CJS) before the SFC dynamic import so both resolve to one
+// Vue instance — otherwise @vue/test-utils' mount throws `app.onUnmount`.
+require( 'vue' );
+const mw = require( '../mocks/mw.js' );
+globalThis.mw = mw;
+
+let NotificationItem;
+
+beforeAll( async () => {
+	const mod = await import( '../../../resources/skins.citizen.notifications/components/NotificationItem.vue' );
+	NotificationItem = mod.default;
+} );
+
+function makeItem( timestamp ) {
+	return {
+		id: 1,
+		read: false,
+		timestamp: timestamp,
+		categoryLabel: 'Mention',
+		header: 'A notification',
+		body: '',
+		primaryUrl: '',
+		secondaryLinks: []
+	};
+}
+
+describe( 'NotificationItem relative time', () => {
+	afterEach( () => {
+		mw.config.get.mockReset();
+		mw.config.get.mockReturnValue( null );
+		mw.log.warn.mockClear();
+	} );
+
+	it( 'should render without throwing when the user language is not a valid BCP 47 tag', () => {
+		mw.config.get.mockImplementation( ( key ) => ( key === 'wgUserLanguage' ? 'x-xss' : null ) );
+		const oneHourAgo = Math.floor( Date.now() / 1000 ) - 3600;
+
+		const mountItem = () => mount( NotificationItem, { props: { item: makeItem( oneHourAgo ) } } );
+
+		expect( mountItem ).not.toThrow();
+	} );
+
+	it( 'should leave the relative time empty and warn when the language tag is invalid', () => {
+		mw.config.get.mockImplementation( ( key ) => ( key === 'wgUserLanguage' ? 'x-xss' : null ) );
+		const oneHourAgo = Math.floor( Date.now() / 1000 ) - 3600;
+
+		const wrapper = mount( NotificationItem, { props: { item: makeItem( oneHourAgo ) } } );
+
+		expect( wrapper.find( '.citizen-notifications__item-time' ).text() ).toBe( '' );
+		expect( mw.log.warn ).toHaveBeenCalled();
+	} );
+
+	it( 'should render a relative time for a valid language tag', () => {
+		mw.config.get.mockImplementation( ( key ) => ( key === 'wgUserLanguage' ? 'en' : null ) );
+		const oneHourAgo = Math.floor( Date.now() / 1000 ) - 3600;
+
+		const wrapper = mount( NotificationItem, { props: { item: makeItem( oneHourAgo ) } } );
+
+		expect( wrapper.find( '.citizen-notifications__item-time' ).text() ).not.toBe( '' );
+	} );
+} );

--- a/tests/vitest/skins.citizen.scripts/lastModified.test.js
+++ b/tests/vitest/skins.citizen.scripts/lastModified.test.js
@@ -1,4 +1,9 @@
-const { formatTimeAgo, DIVISIONS } = require( '../../../resources/skins.citizen.scripts/lastModified.js' );
+// @vitest-environment jsdom
+
+const mw = require( '../mocks/mw.js' );
+globalThis.mw = mw;
+
+const { createLastModified, formatTimeAgo, DIVISIONS } = require( '../../../resources/skins.citizen.scripts/lastModified.js' );
 
 describe( 'formatTimeAgo', () => {
 	let rtf;
@@ -90,5 +95,44 @@ describe( 'formatTimeAgo', () => {
 		formatTimeAgo( String( timestampSeconds ), nowMs, rtf, DIVISIONS );
 
 		expect( rtf.format ).toHaveBeenCalledWith( -1, 'minutes' );
+	} );
+} );
+
+describe( 'createLastModified', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+		document.documentElement.removeAttribute( 'lang' );
+		mw.log.warn.mockClear();
+	} );
+
+	it( 'should not throw when the page language is not a valid BCP 47 tag', () => {
+		document.body.innerHTML = '<span id="citizen-lastmod-relative" data-timestamp="1000000">3 January 2020</span>';
+		document.documentElement.setAttribute( 'lang', 'x-xss' );
+
+		const lastModified = createLastModified( { document, Intl } );
+
+		expect( () => lastModified.init() ).not.toThrow();
+	} );
+
+	it( 'should leave the server-rendered timestamp in place and warn when the language tag is invalid', () => {
+		document.body.innerHTML = '<span id="citizen-lastmod-relative" data-timestamp="1000000">3 January 2020</span>';
+		document.documentElement.setAttribute( 'lang', 'x-xss' );
+
+		createLastModified( { document, Intl } ).init();
+
+		expect( document.getElementById( 'citizen-lastmod-relative' ).textContent ).toBe( '3 January 2020' );
+		expect( mw.log.warn ).toHaveBeenCalled();
+	} );
+
+	it( 'should replace the timestamp with a relative time for a valid language tag', () => {
+		const nowSeconds = Math.floor( Date.now() / 1000 );
+		document.body.innerHTML = `<span id="citizen-lastmod-relative" data-timestamp="${ nowSeconds - 30 }">3 January 2020</span>`;
+		document.documentElement.setAttribute( 'lang', 'en' );
+
+		createLastModified( { document, Intl } ).init();
+
+		const text = document.getElementById( 'citizen-lastmod-relative' ).textContent;
+		expect( text ).not.toBe( '3 January 2020' );
+		expect( text ).toMatch( /second/i );
 	} );
 } );


### PR DESCRIPTION
## What & why

`createLastModified().init()` passed the page language straight into `Intl.RelativeTimeFormat`. When the interface language is not a valid BCP 47 tag, the constructor throws `RangeError`. Because `init()` runs synchronously in `skin.js`'s `main()`, the exception aborted **every feature wired after it**: share, performance mode, the preferences panel trigger, and content enhancements never initialized.

This is not limited to the `x-xss` testing pseudo-language. MediaWiki's `uselang` handling is a loose character check, not a "is this a real language" check, so **any structurally-safe-but-unknown `uselang` value passes through verbatim** into both `<html lang>` and `wgUserLanguage` — a plain URL parameter, no flag or login required. Verified on a wiki:

| `uselang=` | `<html lang>` / `wgUserLanguage` | `Intl.RelativeTimeFormat` |
| --- | --- | --- |
| `zh-min-nan` (a real UI language) | `nan` (normalized) | OK |
| `x-xss` (`$wgUseXssLanguage`) | `x-xss` | **throws** |
| `zzzz-not-a-lang` (arbitrary) | `zzzz-not-a-lang` | **throws** |

Legitimately-selectable languages are normalized to valid BCP 47 and never hit this. Invalid codes — the `x-xss` test flag *or* an arbitrary unknown `uselang` — do.

The fix wraps each construction in `try/catch` and bails out on failure, leaving the server-rendered absolute timestamp in place (last-modified) or degrading to no relative timestamp (notifications). The relative time is a progressive enhancement, so skipping it is a safe fallback.

While sweeping for sibling bugs, I found the **same crash class** in `NotificationItem.vue`, which builds `Intl.RelativeTimeFormat` from `wgUserLanguage` without a guard — the same invalid-`uselang` inputs throw while the notification row renders, breaking the panel. It's guarded the same way.

The two guards are kept local rather than extracted into a shared helper: the sites live in independent ResourceLoader packages with no shared module, acquire the constructor differently (DI vs guarded global), and have different fallbacks — coincidental duplication, not a shared decision.

## Changes

- `fix(scripts):` guard `createLastModified()` against an invalid `<html lang>` — **Fixes #1638**
- `fix(notifications):` guard `NotificationItem`'s relative-time formatter against an invalid `wgUserLanguage` — **Refs #1638**

## Testing

- TDD throughout — each fix has tests that failed first with the exact `RangeError`, then passed.
- Full JS suite **993/993 across 63 files**; both changed files clean under `lint:js` and `lint:styles`.
- **Real browser** under `?uselang=x-xss`: confirmed the crash condition is live (element present + `new Intl.RelativeTimeFormat('x-xss')` genuinely throws), yet no `RangeError` in console, the fallback timestamp is preserved, and the previously-broken **preferences panel now opens and fully mounts**. No i18n escaping regressions observed. Also confirmed an arbitrary `?uselang=zzzz-not-a-lang` (no flag) reaches the same throwing path.
- The NotificationItem fix is verified at the unit level (real `Intl` throwing through the actual Vue render path); not exercised in-browser, as reaching a live notification row needs a logged-in user with Echo notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
