### PR TITLE
feat(preferences): ✨ redesign the theme picker (preview)

### DIFF
--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -179,7 +179,7 @@ The picker grid keeps the built-in column count unless you set `columns` to matc
 Add a block to `MediaWiki:Citizen.css` keyed to your theme's value, starting with a `color-scheme` declaration — the comments walk through the rest:
 
 ```css
-:root.skin-theme-clientpref-ocean {
+.skin-theme-clientpref-ocean {
     color-scheme: dark;
 
     /* Dark baseline for effects light-dark() can't express — copy as-is */
@@ -193,6 +193,8 @@ Add a block to `MediaWiki:Citizen.css` keyed to your theme's value, starting wit
     --color-neutral-oklch__h: 220;
 }
 ```
+
+Use the bare `.skin-theme-clientpref-<value>` class (no `:root` prefix) — that is what lets the preferences panel paint a true-color preview of your theme.
 
 Every property you don't override falls through to the default palette's [`light-dark()` pairs](../guide/migrating-to-citizen-4.md#light-and-dark-are-one-declaration-now) — color values that carry a light and a dark side and resolve per `color-scheme`. A dark theme starts from the built-in dark palette, a light theme (`color-scheme: light`) from the light palette, and you sculpt from there. The hue channels are the most useful knobs — `--color-primary-oklch__h` alone rebrands the accent, and `--color-neutral-oklch__h` tints the surfaces to match; see [Rebranding the primary color](../guide/migrating-to-citizen-4.md#rebranding-the-primary-color) for how the two relate.
 

--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -165,14 +165,13 @@ Add your theme to the `skin-theme` options in `MediaWiki:Citizen-preferences.jso
         { "value": "night", "labelMsg": "citizen-theme-night-label" },
         { "value": "black", "labelMsg": "citizen-theme-black-label" },
         { "value": "ocean", "label": "Ocean" }
-      ],
-      "columns": 5
+      ]
     }
   }
 }
 ```
 
-The picker grid keeps the built-in column count unless you set `columns` to match your option count — leave it out and your fifth theme wraps onto a row of its own. Use `label` for a plain-text name, or `labelMsg` with an interface message (e.g. `MediaWiki:Ocean-theme-label`) on multilingual wikis. Theme values may contain letters and numbers only.
+The picker sizes itself, so you don't set a column count. Use `label` for a plain-text name, or `labelMsg` with an interface message (e.g. `MediaWiki:Ocean-theme-label`) on multilingual wikis. Theme values may contain letters and numbers only.
 
 #### Define the theme in CSS
 
@@ -204,8 +203,8 @@ One limitation to know about: a few dark-mode extras are keyed to the built-in t
 To make your theme the default for new visitors, set `$wgCitizenThemeDefault = 'ocean';`. Keep the theme registered in the picker too — the preferences panel can't show a selection for a value it doesn't know about.
 :::
 
-::: warning
-The theme picker's preview swatch can't read your CSS, so custom themes preview with an adaptive light/dark swatch rather than your palette.
+::: tip
+On Citizen 4 the preview is live: because your theme uses the bare `.skin-theme-clientpref-<value>` class, the preferences panel paints each circle in the theme's real colors, so what you see in the picker matches what visitors get.
 :::
 
 ## Performance considerations

--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -171,7 +171,7 @@ Add your theme to the `skin-theme` options in `MediaWiki:Citizen-preferences.jso
 }
 ```
 
-The picker sizes itself, so you don't set a column count. Use `label` for a plain-text name, or `labelMsg` with an interface message (e.g. `MediaWiki:Ocean-theme-label`) on multilingual wikis. Theme values may contain letters and numbers only.
+Use `label` for a plain-text name, or `labelMsg` with an interface message (e.g. `MediaWiki:Ocean-theme-label`). Theme values may contain letters and numbers only.
 
 #### Define the theme in CSS
 
@@ -200,11 +200,11 @@ Every property you don't override falls through to the default palette's [`light
 One limitation to know about: a few dark-mode extras are keyed to the built-in themes by name — the image dimming preference, and dark-mode fixes for some extensions — so they don't fire for custom themes. If your theme needs one of them, replicate it in your theme's CSS block.
 
 ::: tip
-To make your theme the default for new visitors, set `$wgCitizenThemeDefault = 'ocean';`. On Citizen 4 the preferences panel surfaces an unregistered default as its own entry — its value, title-cased — so visitors always see the active theme selected. Registering it in the picker is still worth doing: it earns a proper localized name and a permanent spot in the picker for everyone, not just people who already have it active.
+To make your theme the default for new visitors, set `$wgCitizenThemeDefault = 'ocean';`. The preferences panel surfaces an unregistered default as its own entry — its value, title-cased — so visitors always see the active theme selected. Registering it in the picker is still worth doing: it earns a proper localized name and a permanent spot in the picker for everyone, not just people who already have it active.
 :::
 
 ::: tip
-On Citizen 4 the preview is live: because your theme uses the bare `.skin-theme-clientpref-<value>` class, the preferences panel paints each circle in the theme's real colors, so what you see in the picker matches what visitors get. Identity rebrands made at `:root` — the OKLCH hue knobs described in [Rebranding the primary color](../guide/migrating-to-citizen-4.md#rebranding-the-primary-color) — flow into the previews automatically. If you override other tokens globally beyond those knobs, target `:root, .citizen-theme-preview` so the previews pick them up too.
+The preview is live: because your theme uses the bare `.skin-theme-clientpref-<value>` class, the preferences panel paints each circle in the theme's real colors, so what you see in the picker matches what visitors get. Identity rebrands made at `:root` — the OKLCH hue knobs described in [Rebranding the primary color](../guide/migrating-to-citizen-4.md#rebranding-the-primary-color) — flow into the previews automatically. If you override other tokens globally beyond those knobs, target `:root, .citizen-theme-preview` so the previews pick them up too.
 :::
 
 ## Performance considerations

--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -204,7 +204,7 @@ To make your theme the default for new visitors, set `$wgCitizenThemeDefault = '
 :::
 
 ::: tip
-On Citizen 4 the preview is live: because your theme uses the bare `.skin-theme-clientpref-<value>` class, the preferences panel paints each circle in the theme's real colors, so what you see in the picker matches what visitors get.
+On Citizen 4 the preview is live: because your theme uses the bare `.skin-theme-clientpref-<value>` class, the preferences panel paints each circle in the theme's real colors, so what you see in the picker matches what visitors get. Identity rebrands made at `:root` — the OKLCH hue knobs described in [Rebranding the primary color](../guide/migrating-to-citizen-4.md#rebranding-the-primary-color) — flow into the previews automatically. If you override other tokens globally beyond those knobs, target `:root, .citizen-theme-preview` so the previews pick them up too.
 :::
 
 ## Performance considerations

--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -200,11 +200,7 @@ Every property you don't override falls through to the default palette's [`light
 One limitation to know about: a few dark-mode extras are keyed to the built-in themes by name — the image dimming preference, and dark-mode fixes for some extensions — so they don't fire for custom themes. If your theme needs one of them, replicate it in your theme's CSS block.
 
 ::: tip
-To make your theme the default for new visitors, set `$wgCitizenThemeDefault = 'ocean';`. The preferences panel surfaces an unregistered default as its own entry — its value, title-cased — so visitors always see the active theme selected. Registering it in the picker is still worth doing: it earns a proper localized name and a permanent spot in the picker for everyone, not just people who already have it active.
-:::
-
-::: tip
-The preview is live: because your theme uses the bare `.skin-theme-clientpref-<value>` class, the preferences panel paints each circle in the theme's real colors, so what you see in the picker matches what visitors get. Identity rebrands made at `:root` — the OKLCH hue knobs described in [Rebranding the primary color](../guide/migrating-to-citizen-4.md#rebranding-the-primary-color) — flow into the previews automatically. If you override other tokens globally beyond those knobs, target `:root, .citizen-theme-preview` so the previews pick them up too.
+Set `$wgCitizenThemeDefault = 'ocean';` to make your theme the default for new visitors.
 :::
 
 ## Performance considerations

--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -200,7 +200,7 @@ Every property you don't override falls through to the default palette's [`light
 One limitation to know about: a few dark-mode extras are keyed to the built-in themes by name — the image dimming preference, and dark-mode fixes for some extensions — so they don't fire for custom themes. If your theme needs one of them, replicate it in your theme's CSS block.
 
 ::: tip
-To make your theme the default for new visitors, set `$wgCitizenThemeDefault = 'ocean';`. Keep the theme registered in the picker too — the preferences panel can't show a selection for a value it doesn't know about.
+To make your theme the default for new visitors, set `$wgCitizenThemeDefault = 'ocean';`. On Citizen 4 the preferences panel surfaces an unregistered default as its own entry — its value, title-cased — so visitors always see the active theme selected. Registering it in the picker is still worth doing: it earns a proper localized name and a permanent spot in the picker for everyone, not just people who already have it active.
 :::
 
 ::: tip

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,6 +72,7 @@
 	"citizen-preferences-section-behavior": "Behavior",
 
 	"citizen-theme-name": "Color",
+	"citizen-theme-name-v4": "Theme",
 	"citizen-theme-description": "Switch between light and dark mode",
 	"citizen-theme-day-label": "Light",
 	"citizen-theme-night-label": "Dark",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -74,6 +74,7 @@
 	"citizen-preferences-section-appearance": "Görünüm",
 	"citizen-preferences-section-behavior": "Label for the behavior section in the preferences panel",
 	"citizen-theme-name": "Heading label for setting that allows you to change theme.",
+	"citizen-theme-name-v4": "Label for the theme preference in the Citizen 4 preferences panel. Replaces {{msg-mw|citizen-theme-name}} once Citizen 4 ships.\n{{Identical|Theme}}",
 	"citizen-theme-description": "Description for theme.",
 	"citizen-theme-day-label": "Label for light/day theme.",
 	"citizen-theme-night-label": "Label for dark/night theme.",

--- a/resources/skins.citizen.preferences/App.vue
+++ b/resources/skins.citizen.preferences/App.vue
@@ -113,6 +113,18 @@ function getThemeColorScheme( value ) {
 	return 'light dark';
 }
 
+/**
+ * Capitalize the first letter of a theme value for a display label.
+ * Theme values are already [a-zA-Z0-9]+ (clientPrefs enforces this), so the
+ * result is safe to render as escaped text.
+ *
+ * @param {string} value
+ * @return {string}
+ */
+function titleCase( value ) {
+	return value.charAt( 0 ).toUpperCase() + value.slice( 1 );
+}
+
 // @vue/component
 module.exports = exports = defineComponent( {
 	name: 'App',
@@ -132,6 +144,22 @@ module.exports = exports = defineComponent( {
 		// always claims skin-theme, and delete this const. RadioGroup.vue
 		// itself stays: it still renders wiki-defined radio preferences.
 		const isV4 = document.documentElement.classList.contains( 'citizen-v4' );
+
+		// A theme applied to <html> but absent from the picker options
+		// (e.g. an unregistered default) is surfaced as a real, selectable
+		// card so the panel shows the true selection. Captured once so it
+		// persists even after switching to another theme.
+		const themeOptionValues = new Set(
+			( ( config.preferences[ 'skin-theme' ] &&
+				config.preferences[ 'skin-theme' ].options ) || [] )
+				.map( ( opt ) => opt.value )
+		);
+		const activeTheme = clientPrefs.get( 'skin-theme' );
+		const syntheticTheme = (
+			isV4 && typeof activeTheme === 'string' &&
+			!themeOptionValues.has( activeTheme )
+		) ? { value: activeTheme, label: titleCase( activeTheme ) } : null;
+
 		const values = reactive( {} );
 		const visibilities = reactive( {} );
 
@@ -153,6 +181,14 @@ module.exports = exports = defineComponent( {
 			const allowedValues = new Set(
 				prefConfig.options.map( ( opt ) => opt.value )
 			);
+			// On Citizen 4 the theme applied to <html> is authoritative
+			// even when it isn't a registered option (e.g. an unregistered
+			// $wgCitizenThemeDefault): surface it as the selection instead
+			// of snapping to the first theme.
+			if ( featureName === 'skin-theme' && isV4 && typeof storedValue === 'string' ) {
+				values[ featureName ] = storedValue;
+				return;
+			}
 			values[ featureName ] = (
 				typeof storedValue === 'string' && allowedValues.has( storedValue )
 			) ? storedValue : prefConfig.options[ 0 ].value;
@@ -212,6 +248,13 @@ module.exports = exports = defineComponent( {
 								}
 								return option;
 							} );
+
+							if (
+								featureName === 'skin-theme' && syntheticTheme &&
+								!options.some( ( o ) => o.value === syntheticTheme.value )
+							) {
+								options.push( syntheticTheme );
+							}
 
 							const pref = {
 								featureName,

--- a/resources/skins.citizen.preferences/App.vue
+++ b/resources/skins.citizen.preferences/App.vue
@@ -54,6 +54,13 @@
 							:selected="values[ pref.featureName ]"
 							@update:selected="setValue( pref.featureName, $event )"
 						></cdx-select>
+						<theme-picker
+							v-else-if="pref.featureName === 'skin-theme' && isV4"
+							:model-value="values[ pref.featureName ]"
+							:options="pref.options"
+							:feature-name="pref.featureName"
+							@update:model-value="setValue( pref.featureName, $event )"
+						></theme-picker>
 						<radio-group
 							v-else
 							:model-value="values[ pref.featureName ]"
@@ -74,6 +81,7 @@ const { defineComponent, computed, inject, reactive, ref, watch } = require( 'vu
 const { NormalizedPreferencesConfig } = require( './types.js' );
 const { CdxField, CdxSelect, CdxToggleSwitch } = mw.loader.require( 'skins.citizen.preferences.codex' );
 const RadioGroup = require( './RadioGroup.vue' );
+const ThemePicker = require( './ThemePicker.vue' );
 const useVisibility = require( './useVisibility.js' );
 const { resolveLabel } = require( './configRegistry.js' );
 const clientPrefs = require( './clientPrefs.polyfill.js' )();
@@ -84,6 +92,9 @@ const clientPrefs = require( './clientPrefs.polyfill.js' )();
  * tokens (--color-surface-0, --color-base) to resolve to the correct
  * side per preview — without swapping classes or reading computed
  * styles.
+ *
+ * citizen-v4-remove — legacy-only. The v4 ThemePicker paints the real
+ * theme via its class, so this whole function dies at the 4.0 flip.
  *
  * @param {string} value - Theme value, e.g. 'os', 'day', 'night', 'black'
  * @return {string}
@@ -109,11 +120,18 @@ module.exports = exports = defineComponent( {
 		CdxField,
 		CdxSelect,
 		CdxToggleSwitch,
-		RadioGroup
+		RadioGroup,
+		ThemePicker
 	},
 	setup() {
 		/** @type {NormalizedPreferencesConfig} */
 		const config = inject( 'preferencesConfig' );
+		// The v4 theme picker (ThemePicker) replaces the legacy RadioGroup
+		// swatch grid for skin-theme. citizen-v4-remove — at the 4.0 flip,
+		// drop the `&& isV4` from ThemePicker's template condition so it
+		// always claims skin-theme, and delete this const. RadioGroup.vue
+		// itself stays: it still renders wiki-defined radio preferences.
+		const isV4 = document.documentElement.classList.contains( 'citizen-v4' );
 		const values = reactive( {} );
 		const visibilities = reactive( {} );
 
@@ -185,7 +203,10 @@ module.exports = exports = defineComponent( {
 									value: opt.value,
 									label: resolveLabel( opt, 'label' )
 								};
-								if ( featureName === 'skin-theme' ) {
+								// Legacy swatch hint only — the v4 ThemePicker paints
+								// the real theme, so it needs no colorScheme.
+								// citizen-v4-remove
+								if ( featureName === 'skin-theme' && !isV4 ) {
 									option.colorScheme =
 										getThemeColorScheme( opt.value );
 								}
@@ -235,7 +256,8 @@ module.exports = exports = defineComponent( {
 			sections,
 			values,
 			visibilities,
-			setValue
+			setValue,
+			isV4
 		};
 	}
 } );

--- a/resources/skins.citizen.preferences/ThemePicker.vue
+++ b/resources/skins.citizen.preferences/ThemePicker.vue
@@ -1,0 +1,144 @@
+<template>
+	<div class="citizen-preferences-themepicker">
+		<div
+			class="citizen-preferences-themepicker__grid"
+			@mouseleave="hovered = null"
+		>
+			<cdx-radio
+				v-for="option in options"
+				:key="option.value"
+				:model-value="modelValue"
+				:input-value="option.value"
+				:name="featureName"
+				@update:model-value="$emit( 'update:modelValue', $event )"
+				@mouseenter="hovered = option.value"
+			>
+				<span
+					class="citizen-preferences-themecircle"
+					:class="option.value === 'os' ?
+						'citizen-preferences-themecircle--adaptive' :
+						'skin-theme-clientpref-' + option.value"
+				></span>
+				<span class="citizen-preferences-themepicker__srlabel">{{ option.label }}</span>
+			</cdx-radio>
+		</div>
+		<div
+			class="citizen-preferences-themepicker__readout"
+			aria-hidden="true"
+		>
+			{{ readoutLabel }}
+		</div>
+	</div>
+</template>
+
+<script>
+const { defineComponent, ref, computed, watch } = require( 'vue' );
+const { CdxRadio } = mw.loader.require( 'skins.citizen.preferences.codex' );
+
+// @vue/component
+module.exports = exports = defineComponent( {
+	name: 'ThemePicker',
+	components: { CdxRadio },
+	props: {
+		modelValue: { type: String, required: true },
+		options: { type: Array, required: true },
+		featureName: { type: String, required: true }
+	},
+	emits: [ 'update:modelValue' ],
+	setup( props ) {
+		const hovered = ref( null );
+		// A selection change (including keyboard arrow-key navigation, which
+		// doesn't fire mouseenter/leave) must win over a stuck hover so the
+		// readout always reflects the current choice.
+		watch( () => props.modelValue, () => {
+			hovered.value = null;
+		} );
+		const readoutLabel = computed( () => {
+			const value = hovered.value !== null ? hovered.value : props.modelValue;
+			const option = props.options.find( ( o ) => o.value === value );
+			return option ? option.label : '';
+		} );
+		return { hovered, readoutLabel };
+	}
+} );
+</script>
+
+<style lang="less">
+@import 'mediawiki.skin.variables.less';
+@import '../mixins.less';
+
+.citizen-preferences-themepicker {
+	&__grid {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var( --space-sm );
+	}
+
+	// The circle is the control's visual; hide Codex's native radio dot
+	// and reset wrapper/label spacing.
+	.cdx-radio__icon {
+		display: none;
+	}
+
+	// The whole radio is one small circular control: keep the pointer
+	// cursor across all of it — Codex's invisible input overlay and label
+	// wrappers otherwise reset the cursor over parts of the circle.
+	.cdx-radio,
+	.cdx-radio * {
+		cursor: pointer;
+	}
+
+	.cdx-radio {
+		margin-bottom: 0;
+	}
+
+	.cdx-radio__wrapper {
+		gap: 0;
+	}
+
+	.cdx-label {
+		padding: 0;
+	}
+
+	// Visually hidden, but present in the accessibility tree so each radio
+	// has an accessible name even though no label is shown.
+	&__srlabel {
+		.mixin-citizen-screen-reader-only();
+	}
+
+	&__readout {
+		min-height: 1.25em;
+		margin-top: var( --space-sm );
+		font-size: var( --font-size-small );
+		color: var( --color-subtle );
+	}
+}
+
+.citizen-preferences-themecircle {
+	display: block;
+	width: @min-size-interactive-touch;
+	height: @min-size-interactive-touch;
+	// The circle wears the theme's clientpref class, so these tokens
+	// resolve to that theme's real surface + accent.
+	background: conic-gradient( from 0deg, var( --color-surface-0 ) 0 50%, var( --color-progressive ) 50% 100% );
+	border-radius: var( --border-radius-circle );
+	// Keep a light-surface circle visible against a light panel.
+	box-shadow: inset 0 0 0 1px var( --border-color-subtle );
+
+	// os / Auto — adaptive: a static light/dark split (a live media query
+	// can't be shown in a static swatch).
+	&--adaptive {
+		background: conic-gradient( from -45deg, var( --color-white ) 0 50%, var( --color-neutral-1000 ) 50% 100% );
+	}
+
+	.cdx-radio:has( .cdx-radio__input:checked ) & {
+		outline: 2px solid var( --color-progressive );
+		outline-offset: 2px;
+	}
+
+	.cdx-radio:has( .cdx-radio__input:focus-visible ) & {
+		outline: 2px solid var( --color-progressive );
+		outline-offset: 2px;
+	}
+}
+</style>

--- a/resources/skins.citizen.preferences/ThemePicker.vue
+++ b/resources/skins.citizen.preferences/ThemePicker.vue
@@ -14,7 +14,7 @@
 				@mouseenter="hovered = option.value"
 			>
 				<span
-					class="citizen-preferences-themecircle"
+					class="citizen-preferences-themecircle citizen-theme-preview"
 					:class="option.value === 'os' ?
 						'citizen-preferences-themecircle--adaptive' :
 						'skin-theme-clientpref-' + option.value"
@@ -67,8 +67,30 @@ module.exports = exports = defineComponent( {
 @import 'mediawiki.skin.variables.less';
 @import '../mixins.less';
 
+// The circles re-derive every token to the theme they preview
+// (themePreview.less), but the hairline ring and the selected/focus
+// outline are panel chrome and must follow the CURRENT theme instead.
+// Registering these relay properties as `<color>` absolutizes them —
+// palette and light-dark side — where they are declared (the grid,
+// outside the preview scope), so they inherit into the circles as
+// concrete ambient colors. Browsers without `@property` still relay
+// the ambient pair, resolved per-circle scheme.
+@property --citizen-themepicker-ambient-border {
+	syntax: '<color>';
+	inherits: true;
+	initial-value: transparent;
+}
+
+@property --citizen-themepicker-ambient-accent {
+	syntax: '<color>';
+	inherits: true;
+	initial-value: transparent;
+}
+
 .citizen-preferences-themepicker {
 	&__grid {
+		--citizen-themepicker-ambient-border: var( --border-color-subtle );
+		--citizen-themepicker-ambient-accent: var( --color-progressive );
 		display: flex;
 		flex-wrap: wrap;
 		gap: var( --space-sm );
@@ -118,12 +140,16 @@ module.exports = exports = defineComponent( {
 	display: block;
 	width: @min-size-interactive-touch;
 	height: @min-size-interactive-touch;
-	// The circle wears the theme's clientpref class, so these tokens
-	// resolve to that theme's real surface + accent.
+	// The circle wears `citizen-theme-preview` (the token scope in
+	// themePreview.less, which re-derives every token locally) plus the
+	// theme's clientpref class, so these tokens resolve to that theme's
+	// real surface + accent.
 	background: conic-gradient( from 0deg, var( --color-surface-0 ) 0 50%, var( --color-progressive ) 50% 100% );
 	border-radius: var( --border-radius-circle );
-	// Keep a light-surface circle visible against a light panel.
-	box-shadow: inset 0 0 0 1px var( --border-color-subtle );
+	// Panel chrome, not preview content: the ambient relay (declared on
+	// the grid) keeps the ring in the current theme's colors, and keeps
+	// a light-surface circle visible against a light panel.
+	box-shadow: inset 0 0 0 1px var( --citizen-themepicker-ambient-border );
 
 	// os / Auto — adaptive: a static light/dark split (a live media query
 	// can't be shown in a static swatch).
@@ -131,13 +157,9 @@ module.exports = exports = defineComponent( {
 		background: conic-gradient( from -45deg, var( --color-white ) 0 50%, var( --color-neutral-1000 ) 50% 100% );
 	}
 
-	.cdx-radio:has( .cdx-radio__input:checked ) & {
-		outline: 2px solid var( --color-progressive );
-		outline-offset: 2px;
-	}
-
+	.cdx-radio:has( .cdx-radio__input:checked ) &,
 	.cdx-radio:has( .cdx-radio__input:focus-visible ) & {
-		outline: 2px solid var( --color-progressive );
+		outline: 2px solid var( --citizen-themepicker-ambient-accent );
 		outline-offset: 2px;
 	}
 }

--- a/resources/skins.citizen.preferences/ThemePicker.vue
+++ b/resources/skins.citizen.preferences/ThemePicker.vue
@@ -137,10 +137,16 @@ module.exports = exports = defineComponent( {
 
 	// The whole radio is one small circular control: keep the pointer
 	// cursor across all of it — Codex's invisible input overlay and label
-	// wrappers otherwise reset the cursor over parts of the circle.
+	// wrappers otherwise reset the cursor over parts of the circle. The
+	// selected one is a no-op to click, so it gets no pointer affordance.
 	.cdx-radio,
 	.cdx-radio * {
 		cursor: pointer;
+	}
+
+	.cdx-radio:has( .cdx-radio__input:checked ),
+	.cdx-radio:has( .cdx-radio__input:checked ) * {
+		cursor: default;
 	}
 
 	.cdx-radio {

--- a/resources/skins.citizen.preferences/ThemePicker.vue
+++ b/resources/skins.citizen.preferences/ThemePicker.vue
@@ -87,14 +87,26 @@ module.exports = exports = defineComponent( {
 @import '../mixins.less';
 
 // The circles re-derive every token to the theme they preview
-// (themePreview.less), but the hairline ring and the selected/focus
-// outline are panel chrome and must follow the CURRENT theme instead.
-// Registering these relay properties as `<color>` absolutizes them —
-// palette and light-dark side — where they are declared (the grid,
-// outside the preview scope), so they inherit into the circles as
-// concrete ambient colors. Browsers without `@property` still relay
-// the ambient pair, resolved per-circle scheme.
+// (themePreview.less), but the hairline ring and the hover/active/
+// selected/focus outline are panel chrome and must follow the CURRENT
+// theme instead. Registering these relay properties as `<color>`
+// absolutizes them — palette and light-dark side — where they are
+// declared (the grid, outside the preview scope), so they inherit into
+// the circles as concrete ambient colors. Browsers without `@property`
+// still relay the ambient pair, resolved per-circle scheme.
 @property --citizen-themepicker-ambient-border {
+	syntax: '<color>';
+	inherits: true;
+	initial-value: transparent;
+}
+
+@property --citizen-themepicker-ambient-border-hover {
+	syntax: '<color>';
+	inherits: true;
+	initial-value: transparent;
+}
+
+@property --citizen-themepicker-ambient-border-active {
 	syntax: '<color>';
 	inherits: true;
 	initial-value: transparent;
@@ -108,7 +120,9 @@ module.exports = exports = defineComponent( {
 
 .citizen-preferences-themepicker {
 	&__grid {
-		--citizen-themepicker-ambient-border: var( --border-color-subtle );
+		--citizen-themepicker-ambient-border: var( --border-color-interactive );
+		--citizen-themepicker-ambient-border-hover: var( --border-color-interactive--hover );
+		--citizen-themepicker-ambient-border-active: var( --border-color-interactive--active );
 		--citizen-themepicker-ambient-accent: var( --color-progressive );
 		display: flex;
 		flex-wrap: wrap;
@@ -159,16 +173,23 @@ module.exports = exports = defineComponent( {
 	display: block;
 	width: @min-size-interactive-touch;
 	height: @min-size-interactive-touch;
+	// Always-on outline, transparent at rest: the hover/active/selected
+	// states only swap its color, so nothing pops in or shifts. Like the
+	// ring below, it is panel chrome, not preview content — the ambient
+	// relays (declared on the grid) keep it in the current theme's colors.
+	outline: 2px solid transparent;
+	outline-offset: 2px;
 	// The circle wears `citizen-theme-preview` (the token scope in
 	// themePreview.less, which re-derives every token locally) plus the
 	// theme's clientpref class, so these tokens resolve to that theme's
 	// real surface + accent.
 	background: conic-gradient( from 0deg, var( --color-surface-0 ) 0 50%, var( --color-progressive ) 50% 100% );
 	border-radius: var( --border-radius-circle );
-	// Panel chrome, not preview content: the ambient relay (declared on
-	// the grid) keeps the ring in the current theme's colors, and keeps
-	// a light-surface circle visible against a light panel.
+	// The hairline ring keeps a light-surface circle visible against a
+	// light panel.
 	box-shadow: inset 0 0 0 1px var( --citizen-themepicker-ambient-border );
+	transition-duration: var( --transition-duration-base );
+	transition-property: outline-color, border-radius;
 
 	// os / Auto — adaptive: a static light/dark split (a live media query
 	// can't be shown in a static swatch).
@@ -176,10 +197,22 @@ module.exports = exports = defineComponent( {
 		background: conic-gradient( from -45deg, var( --color-white ) 0 50%, var( --color-neutral-1000 ) 50% 100% );
 	}
 
+	.cdx-radio:hover & {
+		outline-color: var( --citizen-themepicker-ambient-border-hover );
+		border-radius: var( --border-radius-large );
+	}
+
+	.cdx-radio:active & {
+		outline-color: var( --citizen-themepicker-ambient-border-active );
+		border-radius: var( --border-radius-large );
+	}
+
+	// :has() outranks the hover/active rules, so the selection stays
+	// accent-colored while hovered or pressed.
 	.cdx-radio:has( .cdx-radio__input:checked ) &,
 	.cdx-radio:has( .cdx-radio__input:focus-visible ) & {
-		outline: 2px solid var( --citizen-themepicker-ambient-accent );
-		outline-offset: 2px;
+		outline-color: var( --citizen-themepicker-ambient-accent );
+		border-radius: var( --border-radius-large );
 	}
 }
 </style>

--- a/resources/skins.citizen.preferences/ThemePicker.vue
+++ b/resources/skins.citizen.preferences/ThemePicker.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="citizen-preferences-themepicker">
+	<div
+		ref="rootEl"
+		class="citizen-preferences-themepicker"
+	>
 		<div
 			class="citizen-preferences-themepicker__grid"
 			@mouseleave="hovered = null"
@@ -32,8 +35,9 @@
 </template>
 
 <script>
-const { defineComponent, ref, computed, watch } = require( 'vue' );
+const { defineComponent, ref, computed, watch, onMounted } = require( 'vue' );
 const { CdxRadio } = mw.loader.require( 'skins.citizen.preferences.codex' );
+const { measureIdentityBaseline } = require( './themePreviewBaseline.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
@@ -46,6 +50,7 @@ module.exports = exports = defineComponent( {
 	},
 	emits: [ 'update:modelValue' ],
 	setup( props ) {
+		const rootEl = ref( null );
 		const hovered = ref( null );
 		// A selection change (including keyboard arrow-key navigation, which
 		// doesn't fire mouseenter/leave) must win over a stuck hover so the
@@ -58,7 +63,21 @@ module.exports = exports = defineComponent( {
 			const option = props.options.find( ( o ) => o.value === value );
 			return option ? option.label : '';
 		} );
-		return { hovered, readoutLabel };
+		// Publish the wiki's identity-knob baseline (defaults plus any
+		// admin rebrand at :root) on the picker root: the circles'
+		// theme-preview scope (themePreview.less) declares its knobs as
+		// var( --citizen-preview-<knob>, <default> ), so these inline
+		// properties inherit into every circle as the pre-theme baseline.
+		onMounted( () => {
+			const baseline = measureIdentityBaseline();
+			for ( const knob in baseline ) {
+				rootEl.value.style.setProperty(
+					'--citizen-preview-' + knob.slice( 2 ),
+					baseline[ knob ]
+				);
+			}
+		} );
+		return { rootEl, hovered, readoutLabel };
 	}
 } );
 </script>

--- a/resources/skins.citizen.preferences/defaultConfig.js
+++ b/resources/skins.citizen.preferences/defaultConfig.js
@@ -32,9 +32,13 @@ function getDefaultConfig() {
 				section: 'appearance',
 				options: themeOptions,
 				type: 'radio',
+				// Legacy RadioGroup reads columns; the v4 ThemePicker ignores it.
 				columns: themeOptions.length,
-				labelMsg: 'citizen-theme-name',
-				descriptionMsg: 'citizen-theme-description',
+				// v4 relabels this to just "Theme" and drops the description.
+				// The legacy arm (labelMsg/descriptionMsg below) is deleted at
+				// the 4.0 flip when this conditional collapses to the v4 value.
+				labelMsg: isV4 ? 'citizen-theme-name-v4' : 'citizen-theme-name',
+				...( isV4 ? {} : { descriptionMsg: 'citizen-theme-description' } ),
 				visibilityCondition: 'always'
 			},
 			'citizen-feature-custom-font-size': {

--- a/resources/skins.citizen.preferences/themePreview.less
+++ b/resources/skins.citizen.preferences/themePreview.less
@@ -1,0 +1,59 @@
+/**
+ * Theme-preview token scope.
+ *
+ * A CSS custom property substitutes its var() references where it is
+ * DECLARED, so tokens derived at :root inherit into descendants
+ * pre-baked with :root's primitives — a nested preview element that
+ * overrides primitives via its theme class cannot change them. This
+ * scope re-emits the full base token layer so any element wearing
+ * `citizen-theme-preview` re-derives every token locally; its theme
+ * class (0,1,0) then beats this :where() scope (0,0,0) exactly like
+ * theme classes beat the base tokens on :root.
+ *
+ * Must stay inside @layer citizen-tokens: unlayered declarations would
+ * beat the layered theme classes and invert the cascade.
+ */
+
+@import ( reference ) '../variables.less';
+@import ( reference ) '../skins.citizen.tokens/tokens-codex.less';
+@import ( reference ) '../skins.citizen.tokens.new/primitives-codex.less';
+@import ( reference ) '../skins.citizen.tokens.new/primitives-citizen.less';
+@import ( reference ) '../skins.citizen.tokens.new/background-color.less';
+@import ( reference ) '../skins.citizen.tokens.new/border-color.less';
+@import ( reference ) '../skins.citizen.tokens.new/color.less';
+@import ( reference ) '../skins.citizen.tokens.new/box-shadow.less';
+@import ( reference ) '../skins.citizen.tokens.new/surface.less';
+@import ( reference ) '../skins.citizen.tokens.new/syntax-color.less';
+@import ( reference ) '../skins.citizen.tokens.new/opacity.less';
+@import ( reference ) '../skins.citizen.tokens.new/font.less';
+@import ( reference ) '../skins.citizen.tokens.new/misc.less';
+
+@layer citizen-tokens {
+	:where( .citizen-theme-preview ) {
+		color-scheme: light;
+
+		.new-primitives-codex-decls();
+		.new-primitives-citizen-decls();
+		.new-background-color-decls();
+		.new-border-color-decls();
+		.new-color-decls();
+		.new-box-shadow-decls();
+		.new-surface-decls();
+		.new-syntax-color-decls();
+		.new-opacity-decls();
+		.new-font-decls();
+		.new-misc-decls();
+
+		// Identity-knob bridge: an admin's :root rebrand can't inherit
+		// past this scope's local defaults, so these six knobs accept a
+		// measured baseline (set by the preferences panel) and fall back
+		// to the defaults above. Declared after the decls mixins so they
+		// win over the mixin-emitted plain knob values.
+		--color-primary-oklch__h: var( --citizen-preview-color-primary-oklch__h, @color-primary-oklch__h-default );
+		--color-neutral-oklch__h: var( --citizen-preview-color-neutral-oklch__h, var( --color-primary-oklch__h ) );
+		--color-progressive-oklch__h: var( --citizen-preview-color-progressive-oklch__h, var( --color-primary-oklch__h ) );
+		--color-progressive-hsl__h: var( --citizen-preview-color-progressive-hsl__h, @color-progressive-hsl__h-default );
+		--color-progressive-hsl__s: var( --citizen-preview-color-progressive-hsl__s, @color-progressive-hsl__s-default );
+		--color-progressive-hsl__l: var( --citizen-preview-color-progressive-hsl__l, @color-progressive-hsl__l-default );
+	}
+}

--- a/resources/skins.citizen.preferences/themePreview.less
+++ b/resources/skins.citizen.preferences/themePreview.less
@@ -46,9 +46,10 @@
 
 		// Identity-knob bridge: an admin's :root rebrand can't inherit
 		// past this scope's local defaults, so these six knobs accept a
-		// measured baseline (set by the preferences panel) and fall back
-		// to the defaults above. Declared after the decls mixins so they
-		// win over the mixin-emitted plain knob values.
+		// measured baseline (measured by themePreviewBaseline.js,
+		// published by ThemePicker.vue on the picker root) and fall
+		// back to the defaults above. Declared after the decls mixins
+		// so they win over the mixin-emitted plain knob values.
 		--color-primary-oklch__h: var( --citizen-preview-color-primary-oklch__h, @color-primary-oklch__h-default );
 		--color-neutral-oklch__h: var( --citizen-preview-color-neutral-oklch__h, var( --color-primary-oklch__h ) );
 		--color-progressive-oklch__h: var( --citizen-preview-color-progressive-oklch__h, var( --color-primary-oklch__h ) );

--- a/resources/skins.citizen.preferences/themePreviewBaseline.js
+++ b/resources/skins.citizen.preferences/themePreviewBaseline.js
@@ -1,0 +1,60 @@
+/**
+ * Identity knobs bridged into the theme-preview token scope
+ * (themePreview.less). The ThemePicker republishes their measured
+ * baseline as `--citizen-preview-<knob-without-dashes>` custom
+ * properties, which the preview scope's knob declarations consume via
+ * var() fallback.
+ *
+ * @type {string[]}
+ */
+const IDENTITY_KNOBS = [
+	'--color-primary-oklch__h',
+	'--color-neutral-oklch__h',
+	'--color-progressive-oklch__h',
+	'--color-progressive-hsl__h',
+	'--color-progressive-hsl__s',
+	'--color-progressive-hsl__l'
+];
+
+let cached = null;
+
+/**
+ * Measure the wiki's identity-knob baseline: the values the knobs have
+ * WITHOUT the active theme's overrides — i.e. defaults plus any admin
+ * rebrand from MediaWiki:Citizen.css. The active theme class is
+ * removed for one synchronous computed-style read and restored before
+ * the browser can paint, so nothing flickers.
+ *
+ * @return {Object.<string,string>} knob name -> baseline value
+ */
+function measureIdentityBaseline() {
+	if ( cached ) {
+		return cached;
+	}
+	const html = document.documentElement;
+	const themeClass = Array.prototype.find.call(
+		html.classList,
+		( cls ) => cls.startsWith( 'skin-theme-clientpref-' )
+	);
+	if ( themeClass ) {
+		html.classList.remove( themeClass );
+	}
+	const baseline = {};
+	try {
+		const styles = getComputedStyle( html );
+		for ( const knob of IDENTITY_KNOBS ) {
+			const value = styles.getPropertyValue( knob ).trim();
+			if ( value ) {
+				baseline[ knob ] = value;
+			}
+		}
+	} finally {
+		if ( themeClass ) {
+			html.classList.add( themeClass );
+		}
+	}
+	cached = baseline;
+	return cached;
+}
+
+module.exports = { measureIdentityBaseline, IDENTITY_KNOBS };

--- a/resources/skins.citizen.tokens.new/background-color.less
+++ b/resources/skins.citizen.tokens.new/background-color.less
@@ -2,89 +2,93 @@
  * background-color tokens
  * https://doc.wikimedia.org/codex/main/design-tokens/color.html#background-color
  */
+.new-background-color-decls() {
+	// Solid backgrounds
+	--background-color-base: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
+	--background-color-base-fixed: var( --color-white );
+	--background-color-neutral: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
+	--background-color-neutral-subtle: light-dark( var( --color-neutral-50 ), var( --color-neutral-900 ) );
+	--background-color-interactive: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
+	--background-color-interactive--hover: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
+	--background-color-interactive--active: light-dark( var( --color-neutral-300 ), var( --color-neutral-600 ) );
+	--background-color-interactive-subtle: light-dark( var( --color-neutral-50 ), var( --color-neutral-900 ) );
+	--background-color-interactive-subtle--hover: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
+	--background-color-interactive-subtle--active: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
+	--background-color-disabled: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
+	--background-color-disabled-subtle: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
+	--background-color-notice-subtle: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
+	--background-color-inverted: light-dark( var( --color-neutral-1000 ), var( --color-neutral-50 ) );
+
+	// Icon backgrounds — Citizen extension consumed by skinStyles
+	// (e.g. SemanticMediaWiki). Alpha rides the icon opacity ramp.
+	// Escapes kept for parity with the legacy pipeline's declarations.
+	--background-color-icon: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base ) ), rgba( 255, 255, 255, var( --opacity-icon-base ) ) )';
+	--background-color-icon--hover: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--hover ) ), rgba( 255, 255, 255, var( --opacity-icon-base--hover ) ) )';
+	--background-color-icon--active: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--active ) ), rgba( 255, 255, 255, var( --opacity-icon-base--active ) ) )';
+
+	// Filled state backgrounds — theme-invariant per Codex (filled
+	// buttons stay saturated). Not aliased to --color-progressive/-destructive:
+	// those are theme-variant text colors, and chaining would drag fills
+	// lighter in dark mode.
+	--background-color-progressive: var( --color-primary-700 );
+	--background-color-progressive--hover: var( --color-primary-800 );
+	--background-color-progressive--active: var( --color-primary-900 );
+	--background-color-progressive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
+	--background-color-destructive: var( --color-red-700 );
+	--background-color-destructive--hover: var( --color-red-800 );
+	--background-color-destructive--active: var( --color-red-900 );
+	--background-color-destructive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
+
+	// Codex 2.x splits bg.error from bg.destructive — error uses
+	// the lighter red-500/600/700 stops.
+	--background-color-error: var( --color-red-500 );
+	--background-color-error--hover: var( --color-red-600 );
+	--background-color-error--active: var( --color-red-700 );
+
+	// Subtle state backgrounds
+	--background-color-progressive-subtle: light-dark( var( --color-primary-50 ), var( --color-primary-1000 ) );
+	--background-color-progressive-subtle--hover: light-dark( var( --color-primary-100 ), var( --color-primary-900 ) );
+	--background-color-progressive-subtle--active: light-dark( var( --color-primary-200 ), var( --color-primary-800 ) );
+	--background-color-destructive-subtle: light-dark( var( --color-red-50 ), var( --color-red-1000 ) );
+	--background-color-destructive-subtle--hover: light-dark( var( --color-red-100 ), var( --color-red-900 ) );
+	--background-color-destructive-subtle--active: light-dark( var( --color-red-200 ), var( --color-red-800 ) );
+	--background-color-error-subtle: light-dark( var( --color-red-50 ), var( --color-red-1000 ) );
+	--background-color-error-subtle--hover: light-dark( var( --color-red-100 ), var( --color-red-900 ) );
+	--background-color-error-subtle--active: light-dark( var( --color-red-200 ), var( --color-red-800 ) );
+	--background-color-warning-subtle: light-dark( var( --color-yellow-50 ), var( --color-yellow-1000 ) );
+	--background-color-success-subtle: light-dark( var( --color-green-50 ), var( --color-green-1000 ) );
+
+	// Diff highlights — Citizen uses MW convention (green added,
+	// red removed), aliased to the matching subtle bg.
+	--background-color-content-added: var( --background-color-success-subtle );
+	--background-color-content-removed: var( --background-color-destructive-subtle );
+
+	// Find-on-page / search-result highlight (Codex 2.5.1)
+	--background-color-target-text: light-dark( var( --color-orange-50 ), var( --color-orange-900 ) );
+
+	// Button-quiet overlays
+	--background-color-button-quiet--hover: light-dark( rgba( 0, 24, 73, 0.027 ), rgba( 255, 255, 255, 0.04 ) );
+	--background-color-button-quiet--active: light-dark( rgba( 0, 24, 73, 0.082 ), rgba( 255, 255, 255, 0.08 ) );
+
+	// Backdrop frosted overlay. Each branch is a complete color-mix
+	// expression so light-dark() picks one of two finished colors
+	// (color-mix can't span a light-dark() pair).
+	--background-color-backdrop-light: light-dark( ~'color-mix( in oklch, var( --color-neutral-50 ) calc( var( --backdrop-opacity ) * 100% ), transparent )', ~'color-mix( in oklch, var( --color-neutral-1000 ) calc( var( --backdrop-opacity ) * 100% ), transparent )' );
+	--background-color-backdrop-dark: rgba( 0, 0, 0, var( --backdrop-opacity ) );
+
+	// Theme-invariant bg utilities
+	--background-color-transparent: transparent;
+	--background-color-input-binary--checked: var( --color-progressive );
+	--background-color-tab-list-item-framed--hover: rgba( 255, 255, 255, 0.3 );
+	--background-color-tab-list-item-framed--active: rgba( 255, 255, 255, 0.65 );
+}
+
 .new-background-color() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// Solid backgrounds
-		--background-color-base: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
-		--background-color-base-fixed: var( --color-white );
-		--background-color-neutral: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
-		--background-color-neutral-subtle: light-dark( var( --color-neutral-50 ), var( --color-neutral-900 ) );
-		--background-color-interactive: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
-		--background-color-interactive--hover: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
-		--background-color-interactive--active: light-dark( var( --color-neutral-300 ), var( --color-neutral-600 ) );
-		--background-color-interactive-subtle: light-dark( var( --color-neutral-50 ), var( --color-neutral-900 ) );
-		--background-color-interactive-subtle--hover: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
-		--background-color-interactive-subtle--active: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
-		--background-color-disabled: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
-		--background-color-disabled-subtle: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
-		--background-color-notice-subtle: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
-		--background-color-inverted: light-dark( var( --color-neutral-1000 ), var( --color-neutral-50 ) );
-
-		// Icon backgrounds — Citizen extension consumed by skinStyles
-		// (e.g. SemanticMediaWiki). Alpha rides the icon opacity ramp.
-		// Escapes kept for parity with the legacy pipeline's declarations.
-		--background-color-icon: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base ) ), rgba( 255, 255, 255, var( --opacity-icon-base ) ) )';
-		--background-color-icon--hover: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--hover ) ), rgba( 255, 255, 255, var( --opacity-icon-base--hover ) ) )';
-		--background-color-icon--active: ~'light-dark( rgba( 0, 0, 0, var( --opacity-icon-base--active ) ), rgba( 255, 255, 255, var( --opacity-icon-base--active ) ) )';
-
-		// Filled state backgrounds — theme-invariant per Codex (filled
-		// buttons stay saturated). Not aliased to --color-progressive/-destructive:
-		// those are theme-variant text colors, and chaining would drag fills
-		// lighter in dark mode.
-		--background-color-progressive: var( --color-primary-700 );
-		--background-color-progressive--hover: var( --color-primary-800 );
-		--background-color-progressive--active: var( --color-primary-900 );
-		--background-color-progressive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
-		--background-color-destructive: var( --color-red-700 );
-		--background-color-destructive--hover: var( --color-red-800 );
-		--background-color-destructive--active: var( --color-red-900 );
-		--background-color-destructive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
-
-		// Codex 2.x splits bg.error from bg.destructive — error uses
-		// the lighter red-500/600/700 stops.
-		--background-color-error: var( --color-red-500 );
-		--background-color-error--hover: var( --color-red-600 );
-		--background-color-error--active: var( --color-red-700 );
-
-		// Subtle state backgrounds
-		--background-color-progressive-subtle: light-dark( var( --color-primary-50 ), var( --color-primary-1000 ) );
-		--background-color-progressive-subtle--hover: light-dark( var( --color-primary-100 ), var( --color-primary-900 ) );
-		--background-color-progressive-subtle--active: light-dark( var( --color-primary-200 ), var( --color-primary-800 ) );
-		--background-color-destructive-subtle: light-dark( var( --color-red-50 ), var( --color-red-1000 ) );
-		--background-color-destructive-subtle--hover: light-dark( var( --color-red-100 ), var( --color-red-900 ) );
-		--background-color-destructive-subtle--active: light-dark( var( --color-red-200 ), var( --color-red-800 ) );
-		--background-color-error-subtle: light-dark( var( --color-red-50 ), var( --color-red-1000 ) );
-		--background-color-error-subtle--hover: light-dark( var( --color-red-100 ), var( --color-red-900 ) );
-		--background-color-error-subtle--active: light-dark( var( --color-red-200 ), var( --color-red-800 ) );
-		--background-color-warning-subtle: light-dark( var( --color-yellow-50 ), var( --color-yellow-1000 ) );
-		--background-color-success-subtle: light-dark( var( --color-green-50 ), var( --color-green-1000 ) );
-
-		// Diff highlights — Citizen uses MW convention (green added,
-		// red removed), aliased to the matching subtle bg.
-		--background-color-content-added: var( --background-color-success-subtle );
-		--background-color-content-removed: var( --background-color-destructive-subtle );
-
-		// Find-on-page / search-result highlight (Codex 2.5.1)
-		--background-color-target-text: light-dark( var( --color-orange-50 ), var( --color-orange-900 ) );
-
-		// Button-quiet overlays
-		--background-color-button-quiet--hover: light-dark( rgba( 0, 24, 73, 0.027 ), rgba( 255, 255, 255, 0.04 ) );
-		--background-color-button-quiet--active: light-dark( rgba( 0, 24, 73, 0.082 ), rgba( 255, 255, 255, 0.08 ) );
-
-		// Backdrop frosted overlay. Each branch is a complete color-mix
-		// expression so light-dark() picks one of two finished colors
-		// (color-mix can't span a light-dark() pair).
-		--background-color-backdrop-light: light-dark( ~'color-mix( in oklch, var( --color-neutral-50 ) calc( var( --backdrop-opacity ) * 100% ), transparent )', ~'color-mix( in oklch, var( --color-neutral-1000 ) calc( var( --backdrop-opacity ) * 100% ), transparent )' );
-		--background-color-backdrop-dark: rgba( 0, 0, 0, var( --backdrop-opacity ) );
-
-		// Theme-invariant bg utilities
-		--background-color-transparent: transparent;
-		--background-color-input-binary--checked: var( --color-progressive );
-		--background-color-tab-list-item-framed--hover: rgba( 255, 255, 255, 0.3 );
-		--background-color-tab-list-item-framed--active: rgba( 255, 255, 255, 0.65 );
+		.new-background-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/background-color.less
+++ b/resources/skins.citizen.tokens.new/background-color.less
@@ -6,8 +6,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// Solid backgrounds
 		--background-color-base: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
 		--background-color-base-fixed: var( --color-white );

--- a/resources/skins.citizen.tokens.new/border-color.less
+++ b/resources/skins.citizen.tokens.new/border-color.less
@@ -6,8 +6,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// Chrome borders. Routed through gray-N (achromatic) rather than
 		// neutral-N (tinted) so borders read as pure structure regardless
 		// of theme. Citizen uses softer stops than Codex spec — see

--- a/resources/skins.citizen.tokens.new/border-color.less
+++ b/resources/skins.citizen.tokens.new/border-color.less
@@ -2,73 +2,77 @@
  * border-color tokens
  * https://doc.wikimedia.org/codex/main/design-tokens/color.html#border-color
  */
+.new-border-color-decls() {
+	// Chrome borders. Routed through gray-N (achromatic) rather than
+	// neutral-N (tinted) so borders read as pure structure regardless
+	// of theme. Citizen uses softer stops than Codex spec — see
+	// scripts/codex-deviations.json.
+	--border-color-base: light-dark( var( --color-gray-200 ), var( --color-gray-800 ) );
+	--border-color-emphasized: light-dark( var( --color-gray-900 ), var( --color-gray-100 ) );
+	--border-color-subtle: light-dark( var( --color-gray-100 ), var( --color-gray-900 ) );
+	--border-color-muted: light-dark( var( --color-gray-50 ), var( --color-gray-1000 ) );
+	// Interactive progresses 300 → 400 → 500 in light (each step
+	// darker, more visible against light bg) and 700 → 600 → 500
+	// in dark (each step lighter, more visible against dark bg).
+	// Active lands at gray-500 in both modes — mid-gray reads
+	// equally well on either canvas.
+	--border-color-interactive: light-dark( var( --color-gray-300 ), var( --color-gray-700 ) );
+	--border-color-interactive--hover: light-dark( var( --color-gray-400 ), var( --color-gray-600 ) );
+	--border-color-interactive--active: light-dark( var( --color-gray-500 ), var( --color-gray-500 ) );
+	--border-color-disabled: light-dark( var( --color-gray-100 ), var( --color-gray-900 ) );
+	--border-color-divider: light-dark( var( --color-gray-200 ), var( --color-gray-800 ) );
+	--border-color-inverted: light-dark( var( --color-white ), var( --color-gray-1000 ) );
+	--border-color-inverted-fixed: var( --color-white );
+
+	// Progressive borders
+	--border-color-progressive: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
+	--border-color-progressive--hover: light-dark( var( --color-primary-800 ), var( --color-primary-400 ) );
+	--border-color-progressive--active: light-dark( var( --color-primary-900 ), var( --color-primary-300 ) );
+	--border-color-progressive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
+
+	// State borders — Citizen deviation: softer outlines. Rest sits
+	// at *-100 (light) / *-950 (dark, Citizen extension), progressing
+	// toward visibility on hover/active. State communication still
+	// flows through bg-*-subtle + icon + text. In filled-button
+	// contexts the border reads as a darker shadow rim rather than
+	// Codex's lighter outline — accepted trade-off.
+	--border-color-error: light-dark( var( --color-red-100 ), var( --color-red-950 ) );
+	--border-color-error--hover: light-dark( var( --color-red-200 ), var( --color-red-900 ) );
+	--border-color-error--active: light-dark( var( --color-red-300 ), var( --color-red-800 ) );
+	--border-color-warning: light-dark( var( --color-yellow-100 ), var( --color-yellow-950 ) );
+	--border-color-warning--hover: light-dark( var( --color-yellow-200 ), var( --color-yellow-900 ) );
+	--border-color-warning--active: light-dark( var( --color-yellow-300 ), var( --color-yellow-800 ) );
+	--border-color-success: light-dark( var( --color-green-100 ), var( --color-green-950 ) );
+	--border-color-destructive: light-dark( var( --color-red-100 ), var( --color-red-950 ) );
+	--border-color-destructive--hover: light-dark( var( --color-red-200 ), var( --color-red-900 ) );
+	--border-color-destructive--active: light-dark( var( --color-red-300 ), var( --color-red-800 ) );
+	--border-color-destructive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
+
+	// Diff highlights — Citizen uses MW convention (green added,
+	// red removed) over Codex's -999 stops. Theme-invariant.
+	--border-color-content-added: var( --color-green-500 );
+	--border-color-content-removed: var( --color-red-500 );
+
+	// Notice / transparent
+	--border-color-notice: var( --color-neutral-500 );
+	--border-color-transparent: transparent;
+
+	// Input borders — alias chains (resolve theme-variantly through
+	// --border-color-interactive and --border-color-progressive--*).
+	--border-color-input--hover: var( --border-color-interactive );
+	--border-color-input-binary: var( --border-color-interactive );
+	--border-color-input-binary--hover: var( --border-color-progressive--hover );
+	--border-color-input-binary--active: var( --border-color-progressive--active );
+	--border-color-input-binary--focus: var( --border-color-progressive--focus );
+	--border-color-input-binary--checked: var( --border-color-progressive );
+}
+
 .new-border-color() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// Chrome borders. Routed through gray-N (achromatic) rather than
-		// neutral-N (tinted) so borders read as pure structure regardless
-		// of theme. Citizen uses softer stops than Codex spec — see
-		// scripts/codex-deviations.json.
-		--border-color-base: light-dark( var( --color-gray-200 ), var( --color-gray-800 ) );
-		--border-color-emphasized: light-dark( var( --color-gray-900 ), var( --color-gray-100 ) );
-		--border-color-subtle: light-dark( var( --color-gray-100 ), var( --color-gray-900 ) );
-		--border-color-muted: light-dark( var( --color-gray-50 ), var( --color-gray-1000 ) );
-		// Interactive progresses 300 → 400 → 500 in light (each step
-		// darker, more visible against light bg) and 700 → 600 → 500
-		// in dark (each step lighter, more visible against dark bg).
-		// Active lands at gray-500 in both modes — mid-gray reads
-		// equally well on either canvas.
-		--border-color-interactive: light-dark( var( --color-gray-300 ), var( --color-gray-700 ) );
-		--border-color-interactive--hover: light-dark( var( --color-gray-400 ), var( --color-gray-600 ) );
-		--border-color-interactive--active: light-dark( var( --color-gray-500 ), var( --color-gray-500 ) );
-		--border-color-disabled: light-dark( var( --color-gray-100 ), var( --color-gray-900 ) );
-		--border-color-divider: light-dark( var( --color-gray-200 ), var( --color-gray-800 ) );
-		--border-color-inverted: light-dark( var( --color-white ), var( --color-gray-1000 ) );
-		--border-color-inverted-fixed: var( --color-white );
-
-		// Progressive borders
-		--border-color-progressive: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
-		--border-color-progressive--hover: light-dark( var( --color-primary-800 ), var( --color-primary-400 ) );
-		--border-color-progressive--active: light-dark( var( --color-primary-900 ), var( --color-primary-300 ) );
-		--border-color-progressive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
-
-		// State borders — Citizen deviation: softer outlines. Rest sits
-		// at *-100 (light) / *-950 (dark, Citizen extension), progressing
-		// toward visibility on hover/active. State communication still
-		// flows through bg-*-subtle + icon + text. In filled-button
-		// contexts the border reads as a darker shadow rim rather than
-		// Codex's lighter outline — accepted trade-off.
-		--border-color-error: light-dark( var( --color-red-100 ), var( --color-red-950 ) );
-		--border-color-error--hover: light-dark( var( --color-red-200 ), var( --color-red-900 ) );
-		--border-color-error--active: light-dark( var( --color-red-300 ), var( --color-red-800 ) );
-		--border-color-warning: light-dark( var( --color-yellow-100 ), var( --color-yellow-950 ) );
-		--border-color-warning--hover: light-dark( var( --color-yellow-200 ), var( --color-yellow-900 ) );
-		--border-color-warning--active: light-dark( var( --color-yellow-300 ), var( --color-yellow-800 ) );
-		--border-color-success: light-dark( var( --color-green-100 ), var( --color-green-950 ) );
-		--border-color-destructive: light-dark( var( --color-red-100 ), var( --color-red-950 ) );
-		--border-color-destructive--hover: light-dark( var( --color-red-200 ), var( --color-red-900 ) );
-		--border-color-destructive--active: light-dark( var( --color-red-300 ), var( --color-red-800 ) );
-		--border-color-destructive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
-
-		// Diff highlights — Citizen uses MW convention (green added,
-		// red removed) over Codex's -999 stops. Theme-invariant.
-		--border-color-content-added: var( --color-green-500 );
-		--border-color-content-removed: var( --color-red-500 );
-
-		// Notice / transparent
-		--border-color-notice: var( --color-neutral-500 );
-		--border-color-transparent: transparent;
-
-		// Input borders — alias chains (resolve theme-variantly through
-		// --border-color-interactive and --border-color-progressive--*).
-		--border-color-input--hover: var( --border-color-interactive );
-		--border-color-input-binary: var( --border-color-interactive );
-		--border-color-input-binary--hover: var( --border-color-progressive--hover );
-		--border-color-input-binary--active: var( --border-color-progressive--active );
-		--border-color-input-binary--focus: var( --border-color-progressive--focus );
-		--border-color-input-binary--checked: var( --border-color-progressive );
+		.new-border-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/box-shadow.less
+++ b/resources/skins.citizen.tokens.new/box-shadow.less
@@ -6,8 +6,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		--box-shadow-color-base: var( --box-shadow-color-alpha-base );
 		--box-shadow-color-alpha-base: light-dark( ~'oklch( 12% 0.01 var( --color-primary-oklch__h ) / var( --shadow-opacity ) )', ~'oklch( 6% 0.01 var( --color-primary-oklch__h ) / var( --shadow-opacity ) )' );
 		--box-shadow-color-progressive--active: var( --color-progressive--active );

--- a/resources/skins.citizen.tokens.new/box-shadow.less
+++ b/resources/skins.citizen.tokens.new/box-shadow.less
@@ -2,21 +2,25 @@
  * box-shadow tokens
  * https://doc.wikimedia.org/codex/main/design-tokens/box-shadow.html
  */
+.new-box-shadow-decls() {
+	--box-shadow-color-base: var( --box-shadow-color-alpha-base );
+	--box-shadow-color-alpha-base: light-dark( ~'oklch( 12% 0.01 var( --color-primary-oklch__h ) / var( --shadow-opacity ) )', ~'oklch( 6% 0.01 var( --color-primary-oklch__h ) / var( --shadow-opacity ) )' );
+	--box-shadow-color-progressive--active: var( --color-progressive--active );
+	--box-shadow-color-progressive--focus: var( --color-progressive );
+	--box-shadow-color-progressive-selected: var( --color-progressive );
+	--box-shadow-color-progressive-selected--hover: var( --color-progressive--hover );
+	--box-shadow-color-progressive-selected--active: var( --color-progressive--active );
+	--box-shadow-color-destructive--focus: var( --color-progressive );
+	--box-shadow-color-inverted: var( --color-white );
+	--box-shadow-color-transparent: transparent;
+}
+
 .new-box-shadow() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		--box-shadow-color-base: var( --box-shadow-color-alpha-base );
-		--box-shadow-color-alpha-base: light-dark( ~'oklch( 12% 0.01 var( --color-primary-oklch__h ) / var( --shadow-opacity ) )', ~'oklch( 6% 0.01 var( --color-primary-oklch__h ) / var( --shadow-opacity ) )' );
-		--box-shadow-color-progressive--active: var( --color-progressive--active );
-		--box-shadow-color-progressive--focus: var( --color-progressive );
-		--box-shadow-color-progressive-selected: var( --color-progressive );
-		--box-shadow-color-progressive-selected--hover: var( --color-progressive--hover );
-		--box-shadow-color-progressive-selected--active: var( --color-progressive--active );
-		--box-shadow-color-destructive--focus: var( --color-progressive );
-		--box-shadow-color-inverted: var( --color-white );
-		--box-shadow-color-transparent: transparent;
+		.new-box-shadow-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/color.less
+++ b/resources/skins.citizen.tokens.new/color.less
@@ -2,84 +2,88 @@
  * color tokens (text & icon)
  * https://doc.wikimedia.org/codex/main/design-tokens/color.html#color
  */
+.new-color-decls() {
+	// Body text. Citizen deviation: dark-mode body text dimmer than
+	// Codex spec (gray-100/-50, ~94%/98% L) for a softer reading feel.
+	// Light mode aligns with Codex.
+	--color-base: light-dark( var( --color-neutral-900 ), var( --color-neutral-300 ) );
+	--color-base--hover: light-dark( var( --color-neutral-700 ), var( --color-neutral-200 ) );
+	--color-base--subtle: light-dark( var( --color-neutral-600 ), var( --color-neutral-400 ) );
+	--color-base-fixed: var( --color-gray-900 );
+	--color-emphasized: light-dark( var( --color-neutral-1000 ), var( --color-neutral-50 ) );
+	--color-subtle: light-dark( var( --color-neutral-600 ), var( --color-neutral-400 ) );
+	--color-placeholder: light-dark( var( --color-neutral-500 ), var( --color-neutral-500 ) );
+	--color-disabled: light-dark( var( --color-neutral-400 ), var( --color-neutral-600 ) );
+	--color-disabled-emphasized: light-dark( var( --color-neutral-400 ), var( --color-neutral-500 ) );
+	--color-neutral: light-dark( var( --color-neutral-700 ), var( --color-neutral-300 ) );
+	--color-notice: light-dark( var( --color-neutral-700 ), var( --color-neutral-400 ) );
+	--color-inverted: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
+	--color-inverted-fixed: var( --color-white );
+	// Citizen extension — used as foreground on filled progressive
+	// surfaces (where Codex would otherwise use --color-inverted).
+	--color-inverted-primary: var( --color-white );
+
+	// Progressive accent
+	--color-progressive: light-dark( var( --color-primary-700 ), var( --color-primary-400 ) );
+	--color-progressive--hover: light-dark( var( --color-primary-800 ), var( --color-primary-300 ) );
+	--color-progressive--active: light-dark( var( --color-primary-900 ), var( --color-primary-200 ) );
+	// color-*--focus is theme-invariant per Codex; the bg-/border-
+	// versions ARE theme-variant.
+	--color-progressive--focus: var( --color-primary-700 );
+
+	// Destructive / state text
+	--color-destructive: light-dark( var( --color-red-700 ), var( --color-red-400 ) );
+	--color-destructive--hover: light-dark( var( --color-red-800 ), var( --color-red-300 ) );
+	--color-destructive--active: light-dark( var( --color-red-900 ), var( --color-red-200 ) );
+	--color-destructive--focus: var( --color-progressive--focus );
+	--color-error: var( --color-destructive );
+	--color-error--hover: var( --color-destructive--hover );
+	--color-error--active: var( --color-destructive--active );
+	--color-warning: light-dark( var( --color-yellow-700 ), var( --color-yellow-400 ) );
+	--color-success: light-dark( var( --color-green-700 ), var( --color-green-400 ) );
+
+	// Visited / diff — Citizen routes through the progressive accent
+	// and MW diff convention (green added, red removed) instead of
+	// Codex's purple/maroon and -999 highlight stops.
+	--color-visited: var( --color-progressive );
+	--color-visited--hover: var( --color-progressive--hover );
+	--color-visited--active: var( --color-progressive--active );
+	--color-destructive--visited: var( --color-destructive );
+	--color-destructive--visited--hover: var( --color-destructive--hover );
+	--color-destructive--visited--active: var( --color-destructive--active );
+	--color-content-added: var( --color-success );
+	--color-content-removed: var( --color-destructive );
+
+	// Link / red-link aliases
+	--color-link: var( --color-progressive );
+	--color-link--hover: var( --color-progressive--hover );
+	--color-link--active: var( --color-progressive--active );
+	--color-link--focus: var( --color-progressive--focus );
+	--color-link--visited: var( --color-visited );
+	--color-link--visited--hover: var( --color-visited--hover );
+	--color-link--visited--active: var( --color-visited--active );
+	--color-link-red: var( --color-destructive );
+	--color-link-red--hover: var( --color-destructive--hover );
+	--color-link-red--active: var( --color-destructive--active );
+	--color-link-red--focus: var( --color-destructive--focus );
+	--color-link-red--visited: var( --color-destructive--visited );
+	--color-link-red--visited--hover: var( --color-destructive--visited--hover );
+	--color-link-red--visited--active: var( --color-destructive--visited--active );
+
+	// Icon
+	--color-icon-progressive: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
+	--color-icon-error: var( --color-red-500 );
+	--color-icon-warning: var( --color-yellow-500 );
+	--color-icon-success: var( --color-green-500 );
+	--color-icon-notice: var( --color-neutral-500 );
+}
+
 .new-color() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// Body text. Citizen deviation: dark-mode body text dimmer than
-		// Codex spec (gray-100/-50, ~94%/98% L) for a softer reading feel.
-		// Light mode aligns with Codex.
-		--color-base: light-dark( var( --color-neutral-900 ), var( --color-neutral-300 ) );
-		--color-base--hover: light-dark( var( --color-neutral-700 ), var( --color-neutral-200 ) );
-		--color-base--subtle: light-dark( var( --color-neutral-600 ), var( --color-neutral-400 ) );
-		--color-base-fixed: var( --color-gray-900 );
-		--color-emphasized: light-dark( var( --color-neutral-1000 ), var( --color-neutral-50 ) );
-		--color-subtle: light-dark( var( --color-neutral-600 ), var( --color-neutral-400 ) );
-		--color-placeholder: light-dark( var( --color-neutral-500 ), var( --color-neutral-500 ) );
-		--color-disabled: light-dark( var( --color-neutral-400 ), var( --color-neutral-600 ) );
-		--color-disabled-emphasized: light-dark( var( --color-neutral-400 ), var( --color-neutral-500 ) );
-		--color-neutral: light-dark( var( --color-neutral-700 ), var( --color-neutral-300 ) );
-		--color-notice: light-dark( var( --color-neutral-700 ), var( --color-neutral-400 ) );
-		--color-inverted: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
-		--color-inverted-fixed: var( --color-white );
-		// Citizen extension — used as foreground on filled progressive
-		// surfaces (where Codex would otherwise use --color-inverted).
-		--color-inverted-primary: var( --color-white );
-
-		// Progressive accent
-		--color-progressive: light-dark( var( --color-primary-700 ), var( --color-primary-400 ) );
-		--color-progressive--hover: light-dark( var( --color-primary-800 ), var( --color-primary-300 ) );
-		--color-progressive--active: light-dark( var( --color-primary-900 ), var( --color-primary-200 ) );
-		// color-*--focus is theme-invariant per Codex; the bg-/border-
-		// versions ARE theme-variant.
-		--color-progressive--focus: var( --color-primary-700 );
-
-		// Destructive / state text
-		--color-destructive: light-dark( var( --color-red-700 ), var( --color-red-400 ) );
-		--color-destructive--hover: light-dark( var( --color-red-800 ), var( --color-red-300 ) );
-		--color-destructive--active: light-dark( var( --color-red-900 ), var( --color-red-200 ) );
-		--color-destructive--focus: var( --color-progressive--focus );
-		--color-error: var( --color-destructive );
-		--color-error--hover: var( --color-destructive--hover );
-		--color-error--active: var( --color-destructive--active );
-		--color-warning: light-dark( var( --color-yellow-700 ), var( --color-yellow-400 ) );
-		--color-success: light-dark( var( --color-green-700 ), var( --color-green-400 ) );
-
-		// Visited / diff — Citizen routes through the progressive accent
-		// and MW diff convention (green added, red removed) instead of
-		// Codex's purple/maroon and -999 highlight stops.
-		--color-visited: var( --color-progressive );
-		--color-visited--hover: var( --color-progressive--hover );
-		--color-visited--active: var( --color-progressive--active );
-		--color-destructive--visited: var( --color-destructive );
-		--color-destructive--visited--hover: var( --color-destructive--hover );
-		--color-destructive--visited--active: var( --color-destructive--active );
-		--color-content-added: var( --color-success );
-		--color-content-removed: var( --color-destructive );
-
-		// Link / red-link aliases
-		--color-link: var( --color-progressive );
-		--color-link--hover: var( --color-progressive--hover );
-		--color-link--active: var( --color-progressive--active );
-		--color-link--focus: var( --color-progressive--focus );
-		--color-link--visited: var( --color-visited );
-		--color-link--visited--hover: var( --color-visited--hover );
-		--color-link--visited--active: var( --color-visited--active );
-		--color-link-red: var( --color-destructive );
-		--color-link-red--hover: var( --color-destructive--hover );
-		--color-link-red--active: var( --color-destructive--active );
-		--color-link-red--focus: var( --color-destructive--focus );
-		--color-link-red--visited: var( --color-destructive--visited );
-		--color-link-red--visited--hover: var( --color-destructive--visited--hover );
-		--color-link-red--visited--active: var( --color-destructive--visited--active );
-
-		// Icon
-		--color-icon-progressive: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
-		--color-icon-error: var( --color-red-500 );
-		--color-icon-warning: var( --color-yellow-500 );
-		--color-icon-success: var( --color-green-500 );
-		--color-icon-notice: var( --color-neutral-500 );
+		.new-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/color.less
+++ b/resources/skins.citizen.tokens.new/color.less
@@ -6,8 +6,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// Body text. Citizen deviation: dark-mode body text dimmer than
 		// Codex spec (gray-100/-50, ~94%/98% L) for a softer reading feel.
 		// Light mode aligns with Codex.

--- a/resources/skins.citizen.tokens.new/font.less
+++ b/resources/skins.citizen.tokens.new/font.less
@@ -2,20 +2,24 @@
  * font tokens
  * https://doc.wikimedia.org/codex/main/design-tokens/font.html
  */
+.new-font-decls() {
+	// Codex — emits font-size, font-weight, line-height, etc.
+	// Mixin lives in the legacy module's tokens-codex.less (shared
+	// between modes — eligible for a future shared-font module).
+	.cdx-mode-medium();
+
+	// Citizen extension. Theme-variant; dark override in
+	// dark-overrides.less. Drives Roboto Flex's `GRAD` axis to
+	// reduce optical bloom on dark backgrounds.
+	--font-grade: 25;
+}
+
 .new-font() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// Codex — emits font-size, font-weight, line-height, etc.
-		// Mixin lives in the legacy module's tokens-codex.less (shared
-		// between modes — eligible for a future shared-font module).
-		.cdx-mode-medium();
-
-		// Citizen extension. Theme-variant; dark override in
-		// dark-overrides.less. Drives Roboto Flex's `GRAD` axis to
-		// reduce optical bloom on dark backgrounds.
-		--font-grade: 25;
+		.new-font-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/font.less
+++ b/resources/skins.citizen.tokens.new/font.less
@@ -6,8 +6,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// Codex — emits font-size, font-weight, line-height, etc.
 		// Mixin lives in the legacy module's tokens-codex.less (shared
 		// between modes — eligible for a future shared-font module).

--- a/resources/skins.citizen.tokens.new/misc.less
+++ b/resources/skins.citizen.tokens.new/misc.less
@@ -5,6 +5,14 @@
  * but no /design-tokens/filter.html page) — plus Citizen back-compat
  * aliases.
  */
+
+// Default HSL fallback-pipeline knobs — single source of truth, shared
+// with the theme-preview knob bridge in
+// skins.citizen.preferences/themePreview.less.
+@color-progressive-hsl__h-default: 220;
+@color-progressive-hsl__s-default: 60%;
+@color-progressive-hsl__l-default: 50%;
+
 .new-misc-decls() {
 	// Codex — outline (https://doc.wikimedia.org/codex/main/design-tokens/outline.html)
 	// Inlined as a light-dark() pair (rather than aliased to
@@ -37,9 +45,9 @@
 	// __l is theme-variant — dark override in dark-overrides.less.
 	// Drop alongside the legacy pipeline.
 	--color-progressive-oklch__h: var( --color-primary-oklch__h );
-	--color-progressive-hsl__h: 220;
-	--color-progressive-hsl__s: 60%;
-	--color-progressive-hsl__l: 50%;
+	--color-progressive-hsl__h: @color-progressive-hsl__h-default;
+	--color-progressive-hsl__s: @color-progressive-hsl__s-default;
+	--color-progressive-hsl__l: @color-progressive-hsl__l-default;
 }
 
 .new-misc() {

--- a/resources/skins.citizen.tokens.new/misc.less
+++ b/resources/skins.citizen.tokens.new/misc.less
@@ -9,8 +9,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// Codex — outline (https://doc.wikimedia.org/codex/main/design-tokens/outline.html)
 		// Inlined as a light-dark() pair (rather than aliased to
 		// --border-color-progressive--focus) so the audit reads the

--- a/resources/skins.citizen.tokens.new/misc.less
+++ b/resources/skins.citizen.tokens.new/misc.less
@@ -5,45 +5,49 @@
  * but no /design-tokens/filter.html page) — plus Citizen back-compat
  * aliases.
  */
+.new-misc-decls() {
+	// Codex — outline (https://doc.wikimedia.org/codex/main/design-tokens/outline.html)
+	// Inlined as a light-dark() pair (rather than aliased to
+	// --border-color-progressive--focus) so the audit reads the
+	// primitives directly.
+	--outline-color-progressive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
+
+	// Codex — mix-blend-mode
+	--mix-blend-mode-base: normal;
+	--mix-blend-mode-blend: multiply;
+
+	// Codex — accent-color
+	--accent-color-base: var( --color-progressive );
+
+	// Codex — filter (no dedicated doc page; tokens live in
+	// application.json). Citizen-extended with --filter-invert*
+	// for image dimming and --backdrop-filter-* for frosted glass.
+	// --filter-invert is theme-variant; dark override in
+	// dark-overrides.less.
+	--filter-invert-icon: 0;
+	--filter-invert-primary-button-icon: 1;
+	--filter-invert: none;
+	--filter-invert-primary: invert( 1 ) hue-rotate( 180deg );
+	--backdrop-filter-blur: blur( 2px );
+	--backdrop-filter-frosted-glass: ~'blur( 16px ) saturate( 140% )';
+
+	// Citizen extensions — legacy aliases. mixins.less still
+	// consumes --color-progressive-oklch__h. The HSL trio feeds
+	// tokens-citizen.less's deprecated --color-primary__h/__s/__l.
+	// __l is theme-variant — dark override in dark-overrides.less.
+	// Drop alongside the legacy pipeline.
+	--color-progressive-oklch__h: var( --color-primary-oklch__h );
+	--color-progressive-hsl__h: 220;
+	--color-progressive-hsl__s: 60%;
+	--color-progressive-hsl__l: 50%;
+}
+
 .new-misc() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// Codex — outline (https://doc.wikimedia.org/codex/main/design-tokens/outline.html)
-		// Inlined as a light-dark() pair (rather than aliased to
-		// --border-color-progressive--focus) so the audit reads the
-		// primitives directly.
-		--outline-color-progressive--focus: light-dark( var( --color-primary-700 ), var( --color-primary-500 ) );
-
-		// Codex — mix-blend-mode
-		--mix-blend-mode-base: normal;
-		--mix-blend-mode-blend: multiply;
-
-		// Codex — accent-color
-		--accent-color-base: var( --color-progressive );
-
-		// Codex — filter (no dedicated doc page; tokens live in
-		// application.json). Citizen-extended with --filter-invert*
-		// for image dimming and --backdrop-filter-* for frosted glass.
-		// --filter-invert is theme-variant; dark override in
-		// dark-overrides.less.
-		--filter-invert-icon: 0;
-		--filter-invert-primary-button-icon: 1;
-		--filter-invert: none;
-		--filter-invert-primary: invert( 1 ) hue-rotate( 180deg );
-		--backdrop-filter-blur: blur( 2px );
-		--backdrop-filter-frosted-glass: ~'blur( 16px ) saturate( 140% )';
-
-		// Citizen extensions — legacy aliases. mixins.less still
-		// consumes --color-progressive-oklch__h. The HSL trio feeds
-		// tokens-citizen.less's deprecated --color-primary__h/__s/__l.
-		// __l is theme-variant — dark override in dark-overrides.less.
-		// Drop alongside the legacy pipeline.
-		--color-progressive-oklch__h: var( --color-primary-oklch__h );
-		--color-progressive-hsl__h: 220;
-		--color-progressive-hsl__s: 60%;
-		--color-progressive-hsl__l: 50%;
+		.new-misc-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/opacity.less
+++ b/resources/skins.citizen.tokens.new/opacity.less
@@ -2,30 +2,34 @@
  * opacity tokens
  * https://doc.wikimedia.org/codex/main/design-tokens/opacity.html
  */
+.new-opacity-decls() {
+	// Codex (with Citizen-added --active stop, sitting between
+	// hover and selected — consumed by --background-color-icon--active
+	// in background-color.less).
+	--opacity-icon-base: 0.6;
+	--opacity-icon-base--hover: 0.74;
+	--opacity-icon-base--active: 0.87;
+	--opacity-icon-base--selected: 1;
+	--opacity-icon-base--disabled: 0.51;
+	--opacity-icon-placeholder: 0.51;
+	--opacity-icon-subtle: 0.67;
+
+	// Citizen extensions. --opacity-glass is theme-variant; dark
+	// override in dark-overrides.less. --backdrop-opacity drives
+	// --background-color-backdrop-* in background-color.less.
+	// --shadow-opacity drives --box-shadow-color-alpha-base in
+	// box-shadow.less (also theme-variant).
+	--opacity-glass: 0.9;
+	--backdrop-opacity: 0.65;
+	--shadow-opacity: 0.03;
+}
+
 .new-opacity() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// Codex (with Citizen-added --active stop, sitting between
-		// hover and selected — consumed by --background-color-icon--active
-		// in background-color.less).
-		--opacity-icon-base: 0.6;
-		--opacity-icon-base--hover: 0.74;
-		--opacity-icon-base--active: 0.87;
-		--opacity-icon-base--selected: 1;
-		--opacity-icon-base--disabled: 0.51;
-		--opacity-icon-placeholder: 0.51;
-		--opacity-icon-subtle: 0.67;
-
-		// Citizen extensions. --opacity-glass is theme-variant; dark
-		// override in dark-overrides.less. --backdrop-opacity drives
-		// --background-color-backdrop-* in background-color.less.
-		// --shadow-opacity drives --box-shadow-color-alpha-base in
-		// box-shadow.less (also theme-variant).
-		--opacity-glass: 0.9;
-		--backdrop-opacity: 0.65;
-		--shadow-opacity: 0.03;
+		.new-opacity-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/opacity.less
+++ b/resources/skins.citizen.tokens.new/opacity.less
@@ -6,8 +6,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// Codex (with Citizen-added --active stop, sitting between
 		// hover and selected — consumed by --background-color-icon--active
 		// in background-color.less).

--- a/resources/skins.citizen.tokens.new/primitives-citizen.less
+++ b/resources/skins.citizen.tokens.new/primitives-citizen.less
@@ -8,58 +8,62 @@
  *
  * Theme-invariant. Theme mixins remap which stop becomes which semantic.
  */
+.new-primitives-citizen-decls() {
+	// Retheming knobs — override in MediaWiki:Citizen.css to retheme.
+	// --color-primary-oklch__h:  accent hue (links, buttons, focus rings).
+	// --color-neutral-oklch__h:  chrome tint hue. Defaults to the accent
+	//                            hue for a coordinated tint; set to a
+	//                            different value (or hold at a fixed
+	//                            achromatic-feeling hue) to decouple
+	//                            chrome from accent — e.g. gray chrome
+	//                            with a colorful accent.
+	--color-primary-oklch__h: 262.29;
+	--color-neutral-oklch__h: var( --color-primary-oklch__h );
+
+	// Primary tracks Codex blue's L profile. Peak chroma sits at
+	// -700 (the Wikimedia brand-anchor stop, blue-700 = #36c) —
+	// not the typical -500. Chroma curve climbs and decays
+	// smoothly around the -700 peak (no kinks). -1000 retuned
+	// to ~16% L for canvas-relative subtlety in dark — see
+	// chromatic -1000 note in primitives-codex.less.
+	--color-primary-50: oklch( 95% 0.024 var( --color-primary-oklch__h ) );
+	--color-primary-100: oklch( 92% 0.04 var( --color-primary-oklch__h ) );
+	--color-primary-200: oklch( 86% 0.06 var( --color-primary-oklch__h ) );
+	--color-primary-300: oklch( 80% 0.085 var( --color-primary-oklch__h ) );
+	--color-primary-400: oklch( 72% 0.108 var( --color-primary-oklch__h ) );
+	--color-primary-500: oklch( 62% 0.13 var( --color-primary-oklch__h ) );
+	--color-primary-600: oklch( 58% 0.152 var( --color-primary-oklch__h ) );
+	--color-primary-700: oklch( 53% 0.17 var( --color-primary-oklch__h ) );
+	--color-primary-800: oklch( 47% 0.15 var( --color-primary-oklch__h ) );
+	--color-primary-900: oklch( 34% 0.105 var( --color-primary-oklch__h ) );
+	--color-primary-1000: oklch( 16% 0.05 var( --color-primary-oklch__h ) );
+
+	// Neutral is the tinted-gray ramp meant to replace most uses
+	// of Codex gray in Citizen. L tracks Codex gray exactly. Hue
+	// defaults to the accent (chrome carries a hint of the accent
+	// tint) but can be decoupled via --color-neutral-oklch__h.
+	// Chroma is intentionally low (peak 0.04) so chrome reads as
+	// gray-with-a-hint rather than fully tinted — closer to
+	// Monet's neutral-variant tier.
+	--color-neutral-50: oklch( 98% 0.005 var( --color-neutral-oklch__h ) );
+	--color-neutral-100: oklch( 94% 0.012 var( --color-neutral-oklch__h ) );
+	--color-neutral-200: oklch( 90% 0.02 var( --color-neutral-oklch__h ) );
+	--color-neutral-300: oklch( 84% 0.028 var( --color-neutral-oklch__h ) );
+	--color-neutral-400: oklch( 73% 0.035 var( --color-neutral-oklch__h ) );
+	--color-neutral-500: oklch( 51% 0.04 var( --color-neutral-oklch__h ) );
+	--color-neutral-600: oklch( 39% 0.035 var( --color-neutral-oklch__h ) );
+	--color-neutral-700: oklch( 30% 0.028 var( --color-neutral-oklch__h ) );
+	--color-neutral-800: oklch( 22% 0.02 var( --color-neutral-oklch__h ) );
+	--color-neutral-900: oklch( 17% 0.012 var( --color-neutral-oklch__h ) );
+	--color-neutral-1000: oklch( 11% 0.01 var( --color-neutral-oklch__h ) );
+}
+
 .new-primitives-citizen() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// Retheming knobs — override in MediaWiki:Citizen.css to retheme.
-		// --color-primary-oklch__h:  accent hue (links, buttons, focus rings).
-		// --color-neutral-oklch__h:  chrome tint hue. Defaults to the accent
-		//                            hue for a coordinated tint; set to a
-		//                            different value (or hold at a fixed
-		//                            achromatic-feeling hue) to decouple
-		//                            chrome from accent — e.g. gray chrome
-		//                            with a colorful accent.
-		--color-primary-oklch__h: 262.29;
-		--color-neutral-oklch__h: var( --color-primary-oklch__h );
-
-		// Primary tracks Codex blue's L profile. Peak chroma sits at
-		// -700 (the Wikimedia brand-anchor stop, blue-700 = #36c) —
-		// not the typical -500. Chroma curve climbs and decays
-		// smoothly around the -700 peak (no kinks). -1000 retuned
-		// to ~16% L for canvas-relative subtlety in dark — see
-		// chromatic -1000 note in primitives-codex.less.
-		--color-primary-50: oklch( 95% 0.024 var( --color-primary-oklch__h ) );
-		--color-primary-100: oklch( 92% 0.04 var( --color-primary-oklch__h ) );
-		--color-primary-200: oklch( 86% 0.06 var( --color-primary-oklch__h ) );
-		--color-primary-300: oklch( 80% 0.085 var( --color-primary-oklch__h ) );
-		--color-primary-400: oklch( 72% 0.108 var( --color-primary-oklch__h ) );
-		--color-primary-500: oklch( 62% 0.13 var( --color-primary-oklch__h ) );
-		--color-primary-600: oklch( 58% 0.152 var( --color-primary-oklch__h ) );
-		--color-primary-700: oklch( 53% 0.17 var( --color-primary-oklch__h ) );
-		--color-primary-800: oklch( 47% 0.15 var( --color-primary-oklch__h ) );
-		--color-primary-900: oklch( 34% 0.105 var( --color-primary-oklch__h ) );
-		--color-primary-1000: oklch( 16% 0.05 var( --color-primary-oklch__h ) );
-
-		// Neutral is the tinted-gray ramp meant to replace most uses
-		// of Codex gray in Citizen. L tracks Codex gray exactly. Hue
-		// defaults to the accent (chrome carries a hint of the accent
-		// tint) but can be decoupled via --color-neutral-oklch__h.
-		// Chroma is intentionally low (peak 0.04) so chrome reads as
-		// gray-with-a-hint rather than fully tinted — closer to
-		// Monet's neutral-variant tier.
-		--color-neutral-50: oklch( 98% 0.005 var( --color-neutral-oklch__h ) );
-		--color-neutral-100: oklch( 94% 0.012 var( --color-neutral-oklch__h ) );
-		--color-neutral-200: oklch( 90% 0.02 var( --color-neutral-oklch__h ) );
-		--color-neutral-300: oklch( 84% 0.028 var( --color-neutral-oklch__h ) );
-		--color-neutral-400: oklch( 73% 0.035 var( --color-neutral-oklch__h ) );
-		--color-neutral-500: oklch( 51% 0.04 var( --color-neutral-oklch__h ) );
-		--color-neutral-600: oklch( 39% 0.035 var( --color-neutral-oklch__h ) );
-		--color-neutral-700: oklch( 30% 0.028 var( --color-neutral-oklch__h ) );
-		--color-neutral-800: oklch( 22% 0.02 var( --color-neutral-oklch__h ) );
-		--color-neutral-900: oklch( 17% 0.012 var( --color-neutral-oklch__h ) );
-		--color-neutral-1000: oklch( 11% 0.01 var( --color-neutral-oklch__h ) );
+		.new-primitives-citizen-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/primitives-citizen.less
+++ b/resources/skins.citizen.tokens.new/primitives-citizen.less
@@ -12,8 +12,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// Retheming knobs — override in MediaWiki:Citizen.css to retheme.
 		// --color-primary-oklch__h:  accent hue (links, buttons, focus rings).
 		// --color-neutral-oklch__h:  chrome tint hue. Defaults to the accent

--- a/resources/skins.citizen.tokens.new/primitives-citizen.less
+++ b/resources/skins.citizen.tokens.new/primitives-citizen.less
@@ -8,6 +8,11 @@
  *
  * Theme-invariant. Theme mixins remap which stop becomes which semantic.
  */
+
+// Default accent hue — single source of truth, shared with the
+// theme-preview knob bridge in skins.citizen.preferences/themePreview.less.
+@color-primary-oklch__h-default: 262.29;
+
 .new-primitives-citizen-decls() {
 	// Retheming knobs — override in MediaWiki:Citizen.css to retheme.
 	// --color-primary-oklch__h:  accent hue (links, buttons, focus rings).
@@ -17,7 +22,7 @@
 	//                            achromatic-feeling hue) to decouple
 	//                            chrome from accent — e.g. gray chrome
 	//                            with a colorful accent.
-	--color-primary-oklch__h: 262.29;
+	--color-primary-oklch__h: @color-primary-oklch__h-default;
 	--color-neutral-oklch__h: var( --color-primary-oklch__h );
 
 	// Primary tracks Codex blue's L profile. Peak chroma sits at

--- a/resources/skins.citizen.tokens.new/primitives-codex.less
+++ b/resources/skins.citizen.tokens.new/primitives-codex.less
@@ -11,158 +11,162 @@
  *
  * Source: https://github.com/wikimedia/design-codex/blob/v2.5.1/packages/codex-design-tokens/src/themes/wikimedia-ui.json
  */
+.new-primitives-codex-decls() {
+	// ----- Achromatic -----
+	--color-white: #fff;
+	--color-black: #000;
+
+	// ----- Gray -----
+	--color-gray-50: #f8f9fa;
+	--color-gray-100: #eaecf0;
+	--color-gray-200: #dadde3;
+	--color-gray-300: #c8ccd1;
+	--color-gray-400: #a2a9b1;
+	--color-gray-500: #72777d;
+	--color-gray-600: #54595d;
+	--color-gray-700: #404244;
+	--color-gray-800: #27292d;
+	--color-gray-900: #202122;
+	--color-gray-1000: #101418;
+
+	// Chromatic -1000 stops are retuned to ~16% L (vs Codex ~26%)
+	// to sit ~5% L above Citizen's deeper neutral-1000 canvas,
+	// matching the visual weight of bg-neutral-subtle.
+	//
+	// -950 stops (red, yellow, green) are Citizen extensions for
+	// the soft state-border tier in dark mode. ~25% L with reduced
+	// chroma — sits ~14% L above the canvas with low saturation,
+	// reading at the same visual weight as a chrome border. Codex
+	// itself doesn't have -950 stops.
+
+	// ----- Red (constant H=10, magenta-leaning) -----
+	--color-red-50: oklch( 95% 0.015 10 );
+	--color-red-100: oklch( 92% 0.03 10 );
+	--color-red-200: oklch( 88% 0.052 10 );
+	--color-red-300: oklch( 81% 0.095 10 );
+	--color-red-400: oklch( 73% 0.155 10 );
+	--color-red-500: oklch( 65% 0.195 10 );
+	--color-red-600: oklch( 59% 0.2 10 );
+	--color-red-700: oklch( 54% 0.18 10 );
+	--color-red-800: oklch( 48% 0.16 10 );
+	--color-red-900: oklch( 35% 0.135 10 );
+	--color-red-950: oklch( 25% 0.075 10 );
+	--color-red-1000: oklch( 16% 0.05 10 );
+
+	// ----- Orange -----
+	--color-orange-50: #ffead4;
+	--color-orange-100: #ffdcb8;
+	--color-orange-200: #ffc894;
+	--color-orange-300: #ffa758;
+	--color-orange-400: #f97f26;
+	--color-orange-500: #d46926;
+	--color-orange-600: #bb5c26;
+	--color-orange-700: #a95226;
+	--color-orange-800: #8e4424;
+	--color-orange-900: #572c19;
+	--color-orange-1000: oklch( 16% 0.043 42 );
+
+	// ----- Yellow (intentional drift: H=95 → H=46) -----
+	--color-yellow-50: oklch( 96% 0.021 95 );
+	--color-yellow-100: oklch( 92% 0.058 92 );
+	--color-yellow-200: oklch( 87% 0.115 88 );
+	--color-yellow-300: oklch( 80% 0.153 82 );
+	--color-yellow-400: oklch( 71% 0.164 75 );
+	--color-yellow-500: oklch( 62% 0.165 67 );
+	--color-yellow-600: oklch( 57% 0.157 60 );
+	--color-yellow-700: oklch( 53% 0.146 54 );
+	--color-yellow-800: oklch( 47% 0.125 50 );
+	--color-yellow-900: oklch( 33% 0.105 47 );
+	--color-yellow-950: oklch( 25% 0.06 46 );
+	--color-yellow-1000: oklch( 16% 0.032 46 );
+
+	// ----- Lime -----
+	--color-lime-50: #e3f2e4;
+	--color-lime-100: #d1e9d2;
+	--color-lime-200: #b9debc;
+	--color-lime-300: #94cb9a;
+	--color-lime-400: #5db26c;
+	--color-lime-500: #259948;
+	--color-lime-600: #1f893f;
+	--color-lime-700: #1f7a39;
+	--color-lime-800: #1f6631;
+	--color-lime-900: #183f20;
+	--color-lime-1000: oklch( 16% 0.041 148 );
+
+	// ----- Green (constant H=165, cooler/blue-leaning) -----
+	--color-green-50: oklch( 95% 0.021 165 );
+	--color-green-100: oklch( 91% 0.051 165 );
+	--color-green-200: oklch( 86% 0.089 165 );
+	--color-green-300: oklch( 79% 0.13 165 );
+	--color-green-400: oklch( 69% 0.153 165 );
+	--color-green-500: oklch( 61% 0.149 165 );
+	--color-green-600: oklch( 56% 0.127 165 );
+	--color-green-700: oklch( 51% 0.105 165 );
+	--color-green-800: oklch( 46% 0.086 165 );
+	--color-green-900: oklch( 33% 0.073 165 );
+	--color-green-950: oklch( 25% 0.05 165 );
+	--color-green-1000: oklch( 16% 0.03 165 );
+
+	// ----- Blue -----
+	// blue-700 is the canonical Wikimedia accent (#36c).
+	--color-blue-50: #e8eeff;
+	--color-blue-100: #d9e2ff;
+	--color-blue-200: #b6d4fb;
+	--color-blue-300: #a6bbf5;
+	--color-blue-400: #88a3e8;
+	--color-blue-500: #6485d1;
+	--color-blue-600: #4b77d6;
+	--color-blue-700: #36c;
+	--color-blue-800: #3056a9;
+	--color-blue-900: #233566;
+	--color-blue-1000: oklch( 16% 0.052 271 );
+
+	// ----- Purple -----
+	--color-purple-50: #f0ecf6;
+	--color-purple-100: #e6e0f0;
+	--color-purple-200: #d9d0e9;
+	--color-purple-300: #c5b9dd;
+	--color-purple-400: #a799cd;
+	--color-purple-500: #8d7ebd;
+	--color-purple-600: #7a6db7;
+	--color-purple-700: #6a60b0;
+	--color-purple-800: #534fa3;
+	--color-purple-900: #353262;
+	--color-purple-1000: oklch( 16% 0.05 288 );
+
+	// ----- Pink -----
+	--color-pink-50: #f5ebf2;
+	--color-pink-100: #eedeea;
+	--color-pink-200: #e6cede;
+	--color-pink-300: #d9b4cd;
+	--color-pink-400: #c690b4;
+	--color-pink-500: #b5739e;
+	--color-pink-600: #ac5c90;
+	--color-pink-700: #9b527f;
+	--color-pink-800: #82456a;
+	--color-pink-900: #4e2c40;
+	--color-pink-1000: oklch( 16% 0.034 347 );
+
+	// ----- Maroon -----
+	--color-maroon-50: #f6ebeb;
+	--color-maroon-100: #f0dedd;
+	--color-maroon-200: #e8cecd;
+	--color-maroon-300: #dcb5b3;
+	--color-maroon-400: #c99391;
+	--color-maroon-500: #b57775;
+	--color-maroon-600: #ac6262;
+	--color-maroon-700: #9f5555;
+	--color-maroon-800: #854848;
+	--color-maroon-900: #512e2e;
+	--color-maroon-1000: oklch( 16% 0.03 23 );
+}
+
 .new-primitives-codex() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		// ----- Achromatic -----
-		--color-white: #fff;
-		--color-black: #000;
-
-		// ----- Gray -----
-		--color-gray-50: #f8f9fa;
-		--color-gray-100: #eaecf0;
-		--color-gray-200: #dadde3;
-		--color-gray-300: #c8ccd1;
-		--color-gray-400: #a2a9b1;
-		--color-gray-500: #72777d;
-		--color-gray-600: #54595d;
-		--color-gray-700: #404244;
-		--color-gray-800: #27292d;
-		--color-gray-900: #202122;
-		--color-gray-1000: #101418;
-
-		// Chromatic -1000 stops are retuned to ~16% L (vs Codex ~26%)
-		// to sit ~5% L above Citizen's deeper neutral-1000 canvas,
-		// matching the visual weight of bg-neutral-subtle.
-		//
-		// -950 stops (red, yellow, green) are Citizen extensions for
-		// the soft state-border tier in dark mode. ~25% L with reduced
-		// chroma — sits ~14% L above the canvas with low saturation,
-		// reading at the same visual weight as a chrome border. Codex
-		// itself doesn't have -950 stops.
-
-		// ----- Red (constant H=10, magenta-leaning) -----
-		--color-red-50: oklch( 95% 0.015 10 );
-		--color-red-100: oklch( 92% 0.03 10 );
-		--color-red-200: oklch( 88% 0.052 10 );
-		--color-red-300: oklch( 81% 0.095 10 );
-		--color-red-400: oklch( 73% 0.155 10 );
-		--color-red-500: oklch( 65% 0.195 10 );
-		--color-red-600: oklch( 59% 0.2 10 );
-		--color-red-700: oklch( 54% 0.18 10 );
-		--color-red-800: oklch( 48% 0.16 10 );
-		--color-red-900: oklch( 35% 0.135 10 );
-		--color-red-950: oklch( 25% 0.075 10 );
-		--color-red-1000: oklch( 16% 0.05 10 );
-
-		// ----- Orange -----
-		--color-orange-50: #ffead4;
-		--color-orange-100: #ffdcb8;
-		--color-orange-200: #ffc894;
-		--color-orange-300: #ffa758;
-		--color-orange-400: #f97f26;
-		--color-orange-500: #d46926;
-		--color-orange-600: #bb5c26;
-		--color-orange-700: #a95226;
-		--color-orange-800: #8e4424;
-		--color-orange-900: #572c19;
-		--color-orange-1000: oklch( 16% 0.043 42 );
-
-		// ----- Yellow (intentional drift: H=95 → H=46) -----
-		--color-yellow-50: oklch( 96% 0.021 95 );
-		--color-yellow-100: oklch( 92% 0.058 92 );
-		--color-yellow-200: oklch( 87% 0.115 88 );
-		--color-yellow-300: oklch( 80% 0.153 82 );
-		--color-yellow-400: oklch( 71% 0.164 75 );
-		--color-yellow-500: oklch( 62% 0.165 67 );
-		--color-yellow-600: oklch( 57% 0.157 60 );
-		--color-yellow-700: oklch( 53% 0.146 54 );
-		--color-yellow-800: oklch( 47% 0.125 50 );
-		--color-yellow-900: oklch( 33% 0.105 47 );
-		--color-yellow-950: oklch( 25% 0.06 46 );
-		--color-yellow-1000: oklch( 16% 0.032 46 );
-
-		// ----- Lime -----
-		--color-lime-50: #e3f2e4;
-		--color-lime-100: #d1e9d2;
-		--color-lime-200: #b9debc;
-		--color-lime-300: #94cb9a;
-		--color-lime-400: #5db26c;
-		--color-lime-500: #259948;
-		--color-lime-600: #1f893f;
-		--color-lime-700: #1f7a39;
-		--color-lime-800: #1f6631;
-		--color-lime-900: #183f20;
-		--color-lime-1000: oklch( 16% 0.041 148 );
-
-		// ----- Green (constant H=165, cooler/blue-leaning) -----
-		--color-green-50: oklch( 95% 0.021 165 );
-		--color-green-100: oklch( 91% 0.051 165 );
-		--color-green-200: oklch( 86% 0.089 165 );
-		--color-green-300: oklch( 79% 0.13 165 );
-		--color-green-400: oklch( 69% 0.153 165 );
-		--color-green-500: oklch( 61% 0.149 165 );
-		--color-green-600: oklch( 56% 0.127 165 );
-		--color-green-700: oklch( 51% 0.105 165 );
-		--color-green-800: oklch( 46% 0.086 165 );
-		--color-green-900: oklch( 33% 0.073 165 );
-		--color-green-950: oklch( 25% 0.05 165 );
-		--color-green-1000: oklch( 16% 0.03 165 );
-
-		// ----- Blue -----
-		// blue-700 is the canonical Wikimedia accent (#36c).
-		--color-blue-50: #e8eeff;
-		--color-blue-100: #d9e2ff;
-		--color-blue-200: #b6d4fb;
-		--color-blue-300: #a6bbf5;
-		--color-blue-400: #88a3e8;
-		--color-blue-500: #6485d1;
-		--color-blue-600: #4b77d6;
-		--color-blue-700: #36c;
-		--color-blue-800: #3056a9;
-		--color-blue-900: #233566;
-		--color-blue-1000: oklch( 16% 0.052 271 );
-
-		// ----- Purple -----
-		--color-purple-50: #f0ecf6;
-		--color-purple-100: #e6e0f0;
-		--color-purple-200: #d9d0e9;
-		--color-purple-300: #c5b9dd;
-		--color-purple-400: #a799cd;
-		--color-purple-500: #8d7ebd;
-		--color-purple-600: #7a6db7;
-		--color-purple-700: #6a60b0;
-		--color-purple-800: #534fa3;
-		--color-purple-900: #353262;
-		--color-purple-1000: oklch( 16% 0.05 288 );
-
-		// ----- Pink -----
-		--color-pink-50: #f5ebf2;
-		--color-pink-100: #eedeea;
-		--color-pink-200: #e6cede;
-		--color-pink-300: #d9b4cd;
-		--color-pink-400: #c690b4;
-		--color-pink-500: #b5739e;
-		--color-pink-600: #ac5c90;
-		--color-pink-700: #9b527f;
-		--color-pink-800: #82456a;
-		--color-pink-900: #4e2c40;
-		--color-pink-1000: oklch( 16% 0.034 347 );
-
-		// ----- Maroon -----
-		--color-maroon-50: #f6ebeb;
-		--color-maroon-100: #f0dedd;
-		--color-maroon-200: #e8cecd;
-		--color-maroon-300: #dcb5b3;
-		--color-maroon-400: #c99391;
-		--color-maroon-500: #b57775;
-		--color-maroon-600: #ac6262;
-		--color-maroon-700: #9f5555;
-		--color-maroon-800: #854848;
-		--color-maroon-900: #512e2e;
-		--color-maroon-1000: oklch( 16% 0.03 23 );
+		.new-primitives-codex-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/primitives-codex.less
+++ b/resources/skins.citizen.tokens.new/primitives-codex.less
@@ -15,8 +15,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		// ----- Achromatic -----
 		--color-white: #fff;
 		--color-black: #000;

--- a/resources/skins.citizen.tokens.new/surface.less
+++ b/resources/skins.citizen.tokens.new/surface.less
@@ -5,20 +5,24 @@
  * Codex's bg-* tier hierarchy. surface-0 mirrors background-color-base;
  * surfaces 1+ step into tinted neutrals for elevation.
  */
+.new-surface-decls() {
+	--color-surface-0: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
+	--color-surface-1: light-dark( var( --color-neutral-50 ), var( --color-neutral-900 ) );
+	--color-surface-1--hover: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
+	--color-surface-1--active: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
+	--color-surface-2: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
+	--color-surface-2--hover: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
+	--color-surface-2--active: light-dark( var( --color-neutral-300 ), var( --color-neutral-600 ) );
+	--color-surface-3: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
+	--color-surface-4: light-dark( var( --color-neutral-300 ), var( --color-neutral-600 ) );
+}
+
 .new-surface() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		--color-surface-0: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
-		--color-surface-1: light-dark( var( --color-neutral-50 ), var( --color-neutral-900 ) );
-		--color-surface-1--hover: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
-		--color-surface-1--active: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
-		--color-surface-2: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );
-		--color-surface-2--hover: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
-		--color-surface-2--active: light-dark( var( --color-neutral-300 ), var( --color-neutral-600 ) );
-		--color-surface-3: light-dark( var( --color-neutral-200 ), var( --color-neutral-700 ) );
-		--color-surface-4: light-dark( var( --color-neutral-300 ), var( --color-neutral-600 ) );
+		.new-surface-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/surface.less
+++ b/resources/skins.citizen.tokens.new/surface.less
@@ -9,8 +9,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		--color-surface-0: light-dark( var( --color-white ), var( --color-neutral-1000 ) );
 		--color-surface-1: light-dark( var( --color-neutral-50 ), var( --color-neutral-900 ) );
 		--color-surface-1--hover: light-dark( var( --color-neutral-100 ), var( --color-neutral-800 ) );

--- a/resources/skins.citizen.tokens.new/syntax-color.less
+++ b/resources/skins.citizen.tokens.new/syntax-color.less
@@ -5,23 +5,27 @@
  * inside light-dark() resolve to literal hex at compile time, then
  * the browser picks one at use time.
  */
+.new-syntax-color-decls() {
+	--color-syntax-red: light-dark( @color-syntax-red, @color-syntax-red-dark );
+	--color-syntax-orange: light-dark( @color-syntax-orange, @color-syntax-orange-dark );
+	--color-syntax-yellow: light-dark( @color-syntax-yellow, @color-syntax-yellow-dark );
+	--color-syntax-green: light-dark( @color-syntax-green, @color-syntax-green-dark );
+	--color-syntax-cyan: light-dark( @color-syntax-cyan, @color-syntax-cyan-dark );
+	--color-syntax-blue: light-dark( @color-syntax-blue, @color-syntax-blue-dark );
+	--color-syntax-paleblue: light-dark( @color-syntax-paleblue, @color-syntax-paleblue-dark );
+	--color-syntax-purple: light-dark( @color-syntax-purple, @color-syntax-purple-dark );
+	--color-syntax-brown: light-dark( @color-syntax-brown, @color-syntax-brown-dark );
+	--color-syntax-pink: light-dark( @color-syntax-pink, @color-syntax-pink-dark );
+	--color-syntax-violet: light-dark( @color-syntax-violet, @color-syntax-violet-dark );
+	--color-syntax-grey: @color-syntax-grey;
+}
+
 .new-syntax-color() {
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
 	:where( :root.citizen-v4 ),
 	:where( :root.citizen-token-new ) {
-		--color-syntax-red: light-dark( @color-syntax-red, @color-syntax-red-dark );
-		--color-syntax-orange: light-dark( @color-syntax-orange, @color-syntax-orange-dark );
-		--color-syntax-yellow: light-dark( @color-syntax-yellow, @color-syntax-yellow-dark );
-		--color-syntax-green: light-dark( @color-syntax-green, @color-syntax-green-dark );
-		--color-syntax-cyan: light-dark( @color-syntax-cyan, @color-syntax-cyan-dark );
-		--color-syntax-blue: light-dark( @color-syntax-blue, @color-syntax-blue-dark );
-		--color-syntax-paleblue: light-dark( @color-syntax-paleblue, @color-syntax-paleblue-dark );
-		--color-syntax-purple: light-dark( @color-syntax-purple, @color-syntax-purple-dark );
-		--color-syntax-brown: light-dark( @color-syntax-brown, @color-syntax-brown-dark );
-		--color-syntax-pink: light-dark( @color-syntax-pink, @color-syntax-pink-dark );
-		--color-syntax-violet: light-dark( @color-syntax-violet, @color-syntax-violet-dark );
-		--color-syntax-grey: @color-syntax-grey;
+		.new-syntax-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/syntax-color.less
+++ b/resources/skins.citizen.tokens.new/syntax-color.less
@@ -9,8 +9,8 @@
 	// The second selector is the pre-rename generation class, kept for
 	// one minor so compiled CSS keeps matching cached HTML.
 	// citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		--color-syntax-red: light-dark( @color-syntax-red, @color-syntax-red-dark );
 		--color-syntax-orange: light-dark( @color-syntax-orange, @color-syntax-orange-dark );
 		--color-syntax-yellow: light-dark( @color-syntax-yellow, @color-syntax-yellow-dark );

--- a/resources/skins.citizen.tokens.new/themes/black.less
+++ b/resources/skins.citizen.tokens.new/themes/black.less
@@ -10,11 +10,10 @@
 @import ( reference ) '../dark-overrides.less';
 
 .new-theme-black() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:root.citizen-v4.skin-theme-clientpref-black,
-	:root.citizen-token-new.skin-theme-clientpref-black {
+	// Bare clientpref class so the palette applies on <html> and on a
+	// nested ThemePicker chip. The token module is load-gated, so this rule
+	// never leaks outside the new pipeline.
+	.skin-theme-clientpref-black {
 		color-scheme: dark;
 		.new-dark-overrides();
 

--- a/resources/skins.citizen.tokens.new/tokens.less
+++ b/resources/skins.citizen.tokens.new/tokens.less
@@ -55,16 +55,20 @@
 		color-scheme: light;
 	}
 
-	// citizen-v4-remove — second selector is the pre-rename class
-	:root.citizen-v4.skin-theme-clientpref-night,
-	:root.citizen-token-new.skin-theme-clientpref-night {
+	// Built-in theme rules use the bare clientpref class so they apply on
+	// both <html> and a nested preview element (the ThemePicker chip). The
+	// token module is load-gated, so the rules never leak outside it and
+	// need no generation-class prefix.
+	.skin-theme-clientpref-day {
+		color-scheme: light;
+	}
+
+	.skin-theme-clientpref-night {
 		color-scheme: dark;
 		.new-dark-overrides();
 	}
 
-	// citizen-v4-remove — second selector is the pre-rename class
-	:root.citizen-v4.skin-theme-clientpref-os,
-	:root.citizen-token-new.skin-theme-clientpref-os {
+	.skin-theme-clientpref-os {
 		color-scheme: light dark;
 
 		@media ( prefers-color-scheme: dark ) {

--- a/resources/skins.citizen.tokens.new/tokens.less
+++ b/resources/skins.citizen.tokens.new/tokens.less
@@ -50,8 +50,8 @@
 	// In each group the second selector is the pre-rename generation
 	// class, kept for one minor so compiled CSS keeps matching cached
 	// HTML. citizen-v4-remove
-	:root.citizen-v4,
-	:root.citizen-token-new {
+	:where( :root.citizen-v4 ),
+	:where( :root.citizen-token-new ) {
 		color-scheme: light;
 	}
 

--- a/skin.json
+++ b/skin.json
@@ -316,6 +316,7 @@
 				"citizen-theme-black-label",
 				"citizen-theme-day-label",
 				"citizen-theme-name",
+				"citizen-theme-name-v4",
 				"citizen-theme-night-label",
 				"citizen-theme-os-label",
 				"preferences"

--- a/skin.json
+++ b/skin.json
@@ -326,6 +326,9 @@
 				"mediawiki.storage",
 				"mediawiki.util",
 				"vue"
+			],
+			"styles": [
+				"resources/skins.citizen.preferences/themePreview.less"
 			]
 		},
 		"skins.citizen.share.codex": {

--- a/skin.json
+++ b/skin.json
@@ -260,6 +260,7 @@
 				"resources/skins.citizen.preferences/init.js",
 				"resources/skins.citizen.preferences/App.vue",
 				"resources/skins.citizen.preferences/RadioGroup.vue",
+				"resources/skins.citizen.preferences/ThemePicker.vue",
 				"resources/skins.citizen.preferences/useVisibility.js",
 				"resources/skins.citizen.preferences/defaultConfig.js",
 				"resources/skins.citizen.preferences/configRegistry.js",

--- a/skin.json
+++ b/skin.json
@@ -261,6 +261,7 @@
 				"resources/skins.citizen.preferences/App.vue",
 				"resources/skins.citizen.preferences/RadioGroup.vue",
 				"resources/skins.citizen.preferences/ThemePicker.vue",
+				"resources/skins.citizen.preferences/themePreviewBaseline.js",
 				"resources/skins.citizen.preferences/useVisibility.js",
 				"resources/skins.citizen.preferences/defaultConfig.js",
 				"resources/skins.citizen.preferences/configRegistry.js",

--- a/tests/vitest/skins.citizen.preferences/App.test.js
+++ b/tests/vitest/skins.citizen.preferences/App.test.js
@@ -287,24 +287,57 @@ describe( 'App', () => {
 			document.documentElement.classList.remove( 'citizen-v4' );
 		} );
 
-		it( 'should preview the black theme swatch with a dark color scheme', () => {
+		it( 'should render ThemePicker for skin-theme under citizen-v4', () => {
 			// Build fresh instead of reusing BASE_CONFIG — the cached base
 			// was built without the citizen-v4 class, so it has the legacy
-			// three-theme shape. mountApp resets the classList, but the
-			// config is already built by then.
+			// three-theme shape.
 			const v4Config = normalizeConfig( getDefaultConfig() );
 
-			const wrapper = mountApp( ALL_PREF_CLASSES, v4Config );
+			// citizen-v4 must be IN the class list: setClassList overwrites
+			// className, wiping the class the describe's beforeEach added, and
+			// App.vue reads isV4 from the root class at mount.
+			const wrapper = mountApp( [ 'citizen-v4', ...ALL_PREF_CLASSES ], v4Config );
 
-			const radios = wrapper.findAllComponents( { name: 'CdxRadio' } );
-			const blackRadio = radios.find(
-				( c ) => c.props( 'inputValue' ) === 'black'
-			);
-			expect( blackRadio ).toBeTruthy();
-			const preview = blackRadio.find(
-				'.citizen-preferences-card__preview--theme'
-			);
-			expect( preview.attributes( 'style' ) ).toContain( 'color-scheme: dark' );
+			expect( wrapper.findAllComponents( { name: 'ThemePicker' } ) ).toHaveLength( 1 );
+			expect( wrapper.findAllComponents( { name: 'RadioGroup' } ) ).toHaveLength( 0 );
+		} );
+
+		it( 'should render a custom radio pref as RadioGroup, not ThemePicker', () => {
+			// `radio` is a general preference type: a wiki can register a
+			// custom radio pref that is not the theme picker. Only skin-theme
+			// should route through ThemePicker; everything else uses RadioGroup.
+			const v4Config = normalizeConfig( getDefaultConfig() );
+			v4Config.preferences[ 'test-radio' ] = {
+				section: 'appearance',
+				type: 'radio',
+				options: [
+					{ value: 'a', label: 'A' },
+					{ value: 'b', label: 'B' },
+					{ value: 'c', label: 'C' }
+				],
+				label: 'Test Radio',
+				visibilityCondition: 'always'
+			};
+
+			const wrapper = mountApp( [ 'citizen-v4', ...ALL_PREF_CLASSES ], v4Config );
+
+			// Only skin-theme routes through ThemePicker.
+			expect( wrapper.findAllComponents( { name: 'ThemePicker' } ) ).toHaveLength( 1 );
+			// The custom radio pref falls through to RadioGroup.
+			const radioGroups = wrapper.findAllComponents( { name: 'RadioGroup' } );
+			expect( radioGroups ).toHaveLength( 1 );
+			expect( radioGroups[ 0 ].props( 'featureName' ) ).toBe( 'test-radio' );
+		} );
+
+		it( 'should preview the black theme as a chip wearing its theme class', () => {
+			// Under v4 the ThemePicker paints the real theme: each chip wears
+			// the bare .skin-theme-clientpref-<value> class instead of the
+			// legacy inline color-scheme swatch.
+			const v4Config = normalizeConfig( getDefaultConfig() );
+
+			const wrapper = mountApp( [ 'citizen-v4', ...ALL_PREF_CLASSES ], v4Config );
+
+			expect( wrapper.find( '.skin-theme-clientpref-black' ).exists() ).toBe( true );
 		} );
 	} );
 

--- a/tests/vitest/skins.citizen.preferences/App.test.js
+++ b/tests/vitest/skins.citizen.preferences/App.test.js
@@ -339,6 +339,47 @@ describe( 'App', () => {
 
 			expect( wrapper.find( '.skin-theme-clientpref-black' ).exists() ).toBe( true );
 		} );
+
+		describe( 'unregistered active theme (citizen-v4)', () => {
+			it( 'shows a synthetic, selected card for an unregistered theme', () => {
+				const v4Config = normalizeConfig( getDefaultConfig() );
+				const classes = [ 'citizen-v4', ...ALL_PREF_CLASSES.map( ( cls ) =>
+					cls.replace( 'skin-theme-clientpref-os', 'skin-theme-clientpref-ocean' ) ) ];
+
+				const wrapper = mountApp( classes, v4Config );
+
+				const picker = wrapper.findComponent( { name: 'ThemePicker' } );
+				const oceanOption = picker.props( 'options' ).find( ( o ) => o.value === 'ocean' );
+				expect( oceanOption ).toEqual( { value: 'ocean', label: 'Ocean' } );
+				expect( picker.props( 'modelValue' ) ).toBe( 'ocean' );
+			} );
+
+			it( 'adds no synthetic card when the active theme is registered', () => {
+				const v4Config = normalizeConfig( getDefaultConfig() );
+
+				const wrapper = mountApp( [ 'citizen-v4', ...ALL_PREF_CLASSES ], v4Config );
+
+				const picker = wrapper.findComponent( { name: 'ThemePicker' } );
+				expect( picker.props( 'options' ).map( ( o ) => o.value ) )
+					.toEqual( [ 'os', 'day', 'night', 'black' ] );
+			} );
+
+			it( 'does not duplicate the card when the theme is registered at runtime', async () => {
+				const config = reactive( normalizeConfig( getDefaultConfig() ) );
+				const classes = [ 'citizen-v4', ...ALL_PREF_CLASSES.map( ( cls ) =>
+					cls.replace( 'skin-theme-clientpref-os', 'skin-theme-clientpref-ocean' ) ) ];
+				const wrapper = mountApp( classes, config );
+
+				// A synthetic 'ocean' card is showing; register a real 'ocean'
+				// option after mount — the dedupe guard must collapse the two.
+				config.preferences[ 'skin-theme' ].options.push( { value: 'ocean', label: 'Ocean' } );
+				await wrapper.vm.$nextTick();
+
+				const picker = wrapper.findComponent( { name: 'ThemePicker' } );
+				const oceanOptions = picker.props( 'options' ).filter( ( o ) => o.value === 'ocean' );
+				expect( oceanOptions ).toHaveLength( 1 );
+			} );
+		} );
 	} );
 
 	describe( 'initialization', () => {

--- a/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
+++ b/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+const { mount } = require( '@vue/test-utils' );
+const mw = require( '../mocks/mw.js' );
+globalThis.mw = mw;
+
+mw.loader.require = vi.fn( () => ( {
+	CdxRadio: {
+		name: 'CdxRadio',
+		template: '<div class="cdx-radio"><input type="radio" /><slot /></div>',
+		props: [ 'modelValue', 'inputValue', 'name' ],
+		emits: [ 'update:modelValue' ]
+	}
+} ) );
+
+let ThemePicker;
+
+const OPTIONS = [
+	{ value: 'os', label: 'Auto' },
+	{ value: 'day', label: 'Light' },
+	{ value: 'night', label: 'Dark' },
+	{ value: 'black', label: 'Black' }
+];
+
+function mountThemePicker( propsOverrides = {} ) {
+	return mount( ThemePicker, {
+		props: {
+			modelValue: 'os',
+			options: OPTIONS,
+			featureName: 'skin-theme',
+			...propsOverrides
+		}
+	} );
+}
+
+beforeAll( async () => {
+	const mod = await import( '../../../resources/skins.citizen.preferences/ThemePicker.vue' );
+	ThemePicker = mod.default;
+} );
+
+afterEach( () => {
+	vi.restoreAllMocks();
+} );
+
+describe( 'ThemePicker', () => {
+	it( 'renders a CdxRadio per option', () => {
+		const wrapper = mountThemePicker();
+
+		expect( wrapper.findAllComponents( { name: 'CdxRadio' } ) ).toHaveLength( 4 );
+	} );
+
+	it( 'wears the theme class on non-os circles', () => {
+		const wrapper = mountThemePicker();
+
+		const circles = wrapper.findAll( '.citizen-preferences-themecircle' );
+		expect( circles[ 1 ].classes() ).toContain( 'skin-theme-clientpref-day' );
+		expect( circles[ 2 ].classes() ).toContain( 'skin-theme-clientpref-night' );
+		expect( circles[ 3 ].classes() ).toContain( 'skin-theme-clientpref-black' );
+	} );
+
+	it( 'renders the os circle as an adaptive split, not a theme class', () => {
+		const wrapper = mountThemePicker();
+
+		const osCircle = wrapper.findAll( '.citizen-preferences-themecircle' )[ 0 ];
+		expect( osCircle.classes() ).toContain( 'citizen-preferences-themecircle--adaptive' );
+		expect( osCircle.classes() ).not.toContain( 'skin-theme-clientpref-os' );
+	} );
+
+	it( 'gives each option a screen-reader label', () => {
+		const wrapper = mountThemePicker();
+
+		const labels = wrapper.findAll( '.citizen-preferences-themepicker__srlabel' );
+		expect( labels.map( ( l ) => l.text() ) ).toEqual( [ 'Auto', 'Light', 'Dark', 'Black' ] );
+	} );
+
+	it( 'readout shows the selected theme by default', () => {
+		const wrapper = mountThemePicker( { modelValue: 'night' } );
+
+		const readout = wrapper.find( '.citizen-preferences-themepicker__readout' );
+		expect( readout.text() ).toBe( 'Dark' );
+	} );
+
+	it( 'readout previews a theme on hover and reverts on mouseleave', async () => {
+		const wrapper = mountThemePicker( { modelValue: 'os' } );
+		const readout = wrapper.find( '.citizen-preferences-themepicker__readout' );
+
+		expect( readout.text() ).toBe( 'Auto' );
+
+		await wrapper.findAllComponents( { name: 'CdxRadio' } )[ 3 ].trigger( 'mouseenter' );
+		expect( readout.text() ).toBe( 'Black' );
+
+		await wrapper.find( '.citizen-preferences-themepicker__grid' ).trigger( 'mouseleave' );
+		expect( readout.text() ).toBe( 'Auto' );
+	} );
+
+	it( 'readout follows a selection change made while hovering (keyboard)', async () => {
+		const wrapper = mountThemePicker(); // modelValue 'os' -> 'Auto'
+		const readout = wrapper.find( '.citizen-preferences-themepicker__readout' );
+
+		await wrapper.findAllComponents( { name: 'CdxRadio' } )[ 3 ].trigger( 'mouseenter' );
+		expect( readout.text() ).toBe( 'Black' );
+
+		await wrapper.setProps( { modelValue: 'day' } );
+		expect( readout.text() ).toBe( 'Light' );
+	} );
+
+	it( 'emits update:modelValue when a radio changes', () => {
+		const wrapper = mountThemePicker();
+
+		wrapper.findAllComponents( { name: 'CdxRadio' } )[ 2 ].vm.$emit( 'update:modelValue', 'night' );
+
+		expect( wrapper.emitted( 'update:modelValue' )[ 0 ] ).toEqual( [ 'night' ] );
+	} );
+
+	describe( 'CdxRadio forwarding', () => {
+		it( 'forwards modelValue to every CdxRadio', () => {
+			const wrapper = mountThemePicker( { modelValue: 'night' } );
+
+			wrapper.findAllComponents( { name: 'CdxRadio' } ).forEach( ( radio ) => {
+				expect( radio.props( 'modelValue' ) ).toBe( 'night' );
+			} );
+		} );
+
+		it( 'forwards each option value as inputValue and featureName as name', () => {
+			const wrapper = mountThemePicker();
+
+			const radios = wrapper.findAllComponents( { name: 'CdxRadio' } );
+			expect( radios.map( ( r ) => r.props( 'inputValue' ) ) )
+				.toEqual( [ 'os', 'day', 'night', 'black' ] );
+			radios.forEach( ( radio ) => {
+				expect( radio.props( 'name' ) ).toBe( 'skin-theme' );
+			} );
+		} );
+	} );
+} );

--- a/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
+++ b/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
@@ -13,6 +13,14 @@ mw.loader.require = vi.fn( () => ( {
 	}
 } ) );
 
+// Knob values served to the baseline measurement (themePreviewBaseline.js).
+// The module caches its one getComputedStyle read at module level, so the
+// spy below must serve these for whichever mount happens to fill the cache.
+const BASELINE_KNOBS = {
+	'--color-primary-oklch__h': '30',
+	'--color-progressive-hsl__h': '210'
+};
+
 let ThemePicker;
 
 const OPTIONS = [
@@ -36,6 +44,12 @@ function mountThemePicker( propsOverrides = {} ) {
 beforeAll( async () => {
 	const mod = await import( '../../../resources/skins.citizen.preferences/ThemePicker.vue' );
 	ThemePicker = mod.default;
+} );
+
+beforeEach( () => {
+	vi.spyOn( window, 'getComputedStyle' ).mockImplementation( () => ( {
+		getPropertyValue: ( name ) => BASELINE_KNOBS[ name ] || ''
+	} ) );
 } );
 
 afterEach( () => {
@@ -74,6 +88,18 @@ describe( 'ThemePicker', () => {
 		circles.forEach( ( circle ) => {
 			expect( circle.classes() ).toContain( 'citizen-theme-preview' );
 		} );
+	} );
+
+	it( 'publishes the measured identity baseline on the picker root', () => {
+		const wrapper = mountThemePicker();
+
+		const style = wrapper.find( '.citizen-preferences-themepicker' ).element.style;
+		expect(
+			style.getPropertyValue( '--citizen-preview-color-primary-oklch__h' )
+		).toBe( '30' );
+		expect(
+			style.getPropertyValue( '--citizen-preview-color-progressive-hsl__h' )
+		).toBe( '210' );
 	} );
 
 	it( 'gives each option a screen-reader label', () => {

--- a/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
+++ b/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
@@ -66,6 +66,16 @@ describe( 'ThemePicker', () => {
 		expect( osCircle.classes() ).not.toContain( 'skin-theme-clientpref-os' );
 	} );
 
+	it( 'wears the theme-preview token scope on every circle', () => {
+		const wrapper = mountThemePicker();
+
+		const circles = wrapper.findAll( '.citizen-preferences-themecircle' );
+		expect( circles ).toHaveLength( 4 );
+		circles.forEach( ( circle ) => {
+			expect( circle.classes() ).toContain( 'citizen-theme-preview' );
+		} );
+	} );
+
 	it( 'gives each option a screen-reader label', () => {
 		const wrapper = mountThemePicker();
 

--- a/tests/vitest/skins.citizen.preferences/defaultConfig.test.js
+++ b/tests/vitest/skins.citizen.preferences/defaultConfig.test.js
@@ -110,6 +110,14 @@ describe( 'defaultConfig', () => {
 			expect( config.preferences ).not.toHaveProperty( 'citizen-feature-pure-black' );
 			expect( Object.keys( config.preferences ) ).toHaveLength( 6 );
 		} );
+
+		it( 'should label the theme pref "Theme" with no description', () => {
+			const config = getDefaultConfig();
+
+			const themePref = config.preferences[ 'skin-theme' ];
+			expect( themePref.labelMsg ).toBe( 'citizen-theme-name-v4' );
+			expect( themePref.descriptionMsg ).toBeUndefined();
+		} );
 	} );
 
 	describe( 'legacy world', () => {
@@ -120,6 +128,14 @@ describe( 'defaultConfig', () => {
 			expect( themePref.options ).toHaveLength( 3 );
 			expect( themePref.columns ).toBe( 3 );
 			expect( config.preferences ).toHaveProperty( 'citizen-feature-pure-black' );
+		} );
+
+		it( 'should keep the "Color" label and description', () => {
+			const config = getDefaultConfig();
+
+			const themePref = config.preferences[ 'skin-theme' ];
+			expect( themePref.labelMsg ).toBe( 'citizen-theme-name' );
+			expect( themePref.descriptionMsg ).toBe( 'citizen-theme-description' );
 		} );
 	} );
 } );

--- a/tests/vitest/skins.citizen.preferences/themePreviewBaseline.test.js
+++ b/tests/vitest/skins.citizen.preferences/themePreviewBaseline.test.js
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+const MODULE_PATH = '../../../resources/skins.citizen.preferences/themePreviewBaseline.js';
+
+/**
+ * The module caches its measurement at module level, so each test
+ * imports a fresh copy via vi.resetModules() + dynamic import.
+ *
+ * @return {Promise<Object>}
+ */
+async function importFresh() {
+	vi.resetModules();
+	const mod = await import( MODULE_PATH );
+	return mod.default || mod;
+}
+
+/**
+ * Stub getComputedStyle to serve the given knob values and record what
+ * the root's classList contained at read time.
+ *
+ * @param {Object.<string,string>} values knob name -> served value
+ * @return {{ spy: Object, classListAtRead: Array }}
+ */
+function stubComputedStyle( values ) {
+	const classListAtRead = [];
+	const spy = vi.spyOn( window, 'getComputedStyle' ).mockImplementation( () => {
+		classListAtRead.push( Array.from( document.documentElement.classList ) );
+		return {
+			getPropertyValue: ( name ) => (
+				Object.prototype.hasOwnProperty.call( values, name ) ? values[ name ] : ''
+			)
+		};
+	} );
+	return { spy, classListAtRead };
+}
+
+afterEach( () => {
+	vi.restoreAllMocks();
+	document.documentElement.className = '';
+} );
+
+describe( 'themePreviewBaseline', () => {
+	it( 'exports the six identity knobs the preview scope bridges', async () => {
+		const { IDENTITY_KNOBS } = await importFresh();
+
+		expect( IDENTITY_KNOBS ).toEqual( [
+			'--color-primary-oklch__h',
+			'--color-neutral-oklch__h',
+			'--color-progressive-oklch__h',
+			'--color-progressive-hsl__h',
+			'--color-progressive-hsl__s',
+			'--color-progressive-hsl__l'
+		] );
+	} );
+
+	it( 'measures the knobs, trimming values and omitting empty ones', async () => {
+		document.documentElement.className = 'citizen-v4';
+		stubComputedStyle( {
+			'--color-primary-oklch__h': ' 30 ',
+			'--color-progressive-hsl__s': '60%'
+		} );
+		const { measureIdentityBaseline } = await importFresh();
+
+		const baseline = measureIdentityBaseline();
+
+		expect( baseline ).toEqual( {
+			'--color-primary-oklch__h': '30',
+			'--color-progressive-hsl__s': '60%'
+		} );
+	} );
+
+	it( 'removes the active theme class for the read and restores it after', async () => {
+		document.documentElement.className = 'citizen-v4 skin-theme-clientpref-night';
+		const { classListAtRead } = stubComputedStyle( {
+			'--color-primary-oklch__h': '262.29'
+		} );
+		const { measureIdentityBaseline } = await importFresh();
+
+		measureIdentityBaseline();
+
+		expect( classListAtRead ).toHaveLength( 1 );
+		expect( classListAtRead[ 0 ] ).not.toContain( 'skin-theme-clientpref-night' );
+		expect( classListAtRead[ 0 ] ).toContain( 'citizen-v4' );
+		expect(
+			document.documentElement.classList.contains( 'skin-theme-clientpref-night' )
+		).toBe( true );
+	} );
+
+	it( 'restores the theme class even when the read throws', async () => {
+		document.documentElement.className = 'citizen-v4 skin-theme-clientpref-black';
+		vi.spyOn( window, 'getComputedStyle' ).mockImplementation( () => {
+			throw new Error( 'boom' );
+		} );
+		const { measureIdentityBaseline } = await importFresh();
+
+		expect( () => measureIdentityBaseline() ).toThrow( 'boom' );
+
+		expect(
+			document.documentElement.classList.contains( 'skin-theme-clientpref-black' )
+		).toBe( true );
+	} );
+
+	it( 'caches the measurement so a second call does not re-read', async () => {
+		document.documentElement.className = 'citizen-v4 skin-theme-clientpref-day';
+		const { spy } = stubComputedStyle( {
+			'--color-primary-oklch__h': '262.29'
+		} );
+		const { measureIdentityBaseline } = await importFresh();
+
+		const first = measureIdentityBaseline();
+		const second = measureIdentityBaseline();
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( second ).toBe( first );
+	} );
+
+	it( 'measures without touching classes when no theme class is present', async () => {
+		document.documentElement.className = 'citizen-v4';
+		const { classListAtRead } = stubComputedStyle( {
+			'--color-neutral-oklch__h': '220'
+		} );
+		const { measureIdentityBaseline } = await importFresh();
+
+		const baseline = measureIdentityBaseline();
+
+		expect( baseline ).toEqual( { '--color-neutral-oklch__h': '220' } );
+		expect( classListAtRead[ 0 ] ).toEqual( [ 'citizen-v4' ] );
+		expect( document.documentElement.className ).toBe( 'citizen-v4' );
+	} );
+} );


### PR DESCRIPTION
## Summary

Redesigns the Citizen 4 theme picker (closes #1640). All user-facing changes are gated on the preview channel (`citizen-v4`); the legacy picker is frozen and untouched.

- **"Theme", not "Color"** — the preference is renamed and the stale "switch between light and dark mode" description is dropped (v4 only).
- **Compact circular swatches** — each theme is a 44px (`@min-size-interactive-touch`) conic-gradient circle (surface | accent halves; Auto renders as a light/dark split). The grid wraps naturally, so the hand-synced `columns` bookkeeping is gone and any number of wiki-registered themes fits. Theme names live in a live readout line (hovered theme, falling back to the selection) instead of per-circle labels, so long custom names never break the layout; each circle keeps a screen-reader-only label.
- **True-color previews** — the base token layer drops to zero specificity (`:where()`), built-in theme rules become bare `.skin-theme-clientpref-<value>` classes, and the lazy preferences module re-emits the token declarations at `:where( .citizen-theme-preview )` inside `@layer citizen-tokens`. Each circle re-derives every token to the theme it previews: Black is finally distinct from Dark, wiki-defined themes preview their real palette with zero extra authoring, and the active page theme no longer tints the other circles.
- **Wiki branding flows into previews** — the panel measures the wiki's identity knobs (defaults + any `:root` rebrand from `MediaWiki:Citizen.css`, minus the active theme) once at mount and feeds them to the circles, so a rebranded wiki's default themes preview in its brand colors. Circle chrome (hairline ring, selected/focus outline) deliberately follows the *current* theme via `@property`-registered relay colors — only the circle fill is the preview.
- **Unregistered defaults surface honestly** — a `$wgCitizenThemeDefault` value that isn't registered in the picker now appears as a real, selectable, title-cased entry (previewing its true palette if its CSS block exists) instead of the panel falsely showing "Auto".

The theme-authoring contract change (`:root.skin-theme-clientpref-X` → bare `.skin-theme-clientpref-X`) and docs updates ride along; both contracts are preview-only, so this is the cheap moment to change them.

## Test plan

- [x] Vitest: 1018/1018 (includes new ThemePicker, baseline-measurement, and App routing/synthetic-entry tests); stylelint / banana / markdownlint clean
- [x] Compiled token CSS verified byte-identical across the mixin refactor (`lessc` harness, `cmp`)
- [x] Live browser verification on the dev wiki (preview channel on): Black circle renders `oklch(0 0 0)` ≠ Dark; a two-knob wiki theme previews its real palette end-to-end; page-theme switching doesn't contaminate other circles; `:root` rebrand flows into default circles while a theme's own class still wins; unregistered default shows as selected "Ocean" entry; readout follows hover, touch, and keyboard selection
- [x] Legacy path verified frozen at `citizenpreview=0` (RadioGroup, "Color", three options)
- [x] `?uselang=x-xss` clean (no script execution; all new messages render escaped)
- [x] Each of the 8 commits is independently green (suite + lints) for clean bisecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnegbGnkoC2Jry9yD17FpS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual theme picker for Citizen V4, with circular previews, hover labels, and accessible controls.
  * Active themes not listed in the configured options now remain visible as selected choices.
  * Theme previews now accurately reflect theme colors and interface styling.
  * Added dedicated theme preference labeling for Citizen V4.

* **Documentation**
  * Updated theme creation guidance for picker registration and CSS selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->