### PR TITLE
feat(header): ✨ allow positioning the site header at the top on mobile

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -22,6 +22,16 @@ $wgCitizenHeaderPosition = 'left';
 
 **Values**: `'left'`, `'right'`, `'top'`, `'bottom'`
 
+### `$wgCitizenHeaderPositionMobile`
+
+Determines where the site header appears below the desktop breakpoint, tablets included. Side placements do not fit small screens, so only the top and bottom edges are supported.
+
+```php [LocalSettings.php]
+$wgCitizenHeaderPositionMobile = 'bottom';
+```
+
+**Values**: `'top'`, `'bottom'`
+
 ### `$wgCitizenThemeDefault`
 
 Sets the default color theme for new visitors.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -230,6 +230,7 @@
 	"citizen-command-palette-queryaction-fulltext-search-description": "Search the full text of all pages",
 	"citizen-command-palette-queryaction-page-edit-description": "Create or edit page",
 
+	"citizen-config-headerpositionmobile": "Position of the site header on the mobile and tablet layout (below the desktop breakpoint). Accepts 'top' or 'bottom'; any other value falls back to 'bottom'.",
 	"citizen-config-preview": "Version-scoped switch for the Citizen preview channel. Set to the upcoming major release number (currently 4) to preview it before release; 0 or any other value keeps the stable experience.",
 	"citizen-config-usenewtoken": "Opt-in switch for the new color token pipeline. Defaults to false; set to true to enable. The new pipeline becomes the default — and legacy is removed — in the next major Citizen release."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -217,6 +217,7 @@
 	"citizen-command-palette-mode-user-placeholder": "Placeholder text shown in the command palette input when the user search mode is active.",
 	"citizen-command-palette-queryaction-fulltext-search-description": "Description for the fulltext search in the command palette",
 	"citizen-command-palette-queryaction-page-edit-description": "Description for the page edit action in the command palette",
+	"citizen-config-headerpositionmobile": "Description for the {{Help|HeaderPositionMobile}} config option. Used in extension registration metadata.",
 	"citizen-config-preview": "Description for the {{Help|Preview}} config option. Used in extension registration metadata.",
 	"citizen-config-usenewtoken": "Description for the {{Help|UseNewToken}} config option. Used in extension registration metadata."
 }

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -156,6 +156,13 @@ class SkinCitizen extends SkinMustache {
 		}
 		$classes[] = 'citizen-header-position-' . $headerPosition;
 
+		// Header position (mobile and tablet)
+		$headerPositionMobile = $config->get( 'CitizenHeaderPositionMobile' );
+		if ( !in_array( $headerPositionMobile, [ 'top', 'bottom' ], true ) ) {
+			$headerPositionMobile = 'bottom';
+		}
+		$classes[] = 'citizen-header-position-mobile-' . $headerPositionMobile;
+
 		$attrs['class'] = trim( $attrs['class'] . ' ' . implode( ' ', $classes ) );
 		return $attrs;
 	}

--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -33,6 +33,18 @@
 	left: 0;
 	max-height: var( --header-card-maxheight );
 
+	// Cards flip below the header when it sits at the top edge on
+	// mobile/tablet. citizen-header-position-mobile-top stays in the
+	// markup at desktop widths too, but is inert there — desktop
+	// positioning is driven by the separate citizen-header-position-*
+	// class (Dropdown.less/Drawer.less), so scope this to mobile only.
+	@media ( max-width: @max-width-breakpoint-tablet ) {
+		.citizen-header-position-mobile-top & {
+			top: 100%;
+			bottom: unset;
+		}
+	}
+
 	@media ( min-width: @min-width-breakpoint-tablet ) {
 		& when (@position =start) {
 			right: unset;

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -171,9 +171,20 @@
 
 			&.citizen-sticky-header-visible {
 				.citizen-sticky-header-container {
-					transform: translate3d( 0, -100%, 0 );
+					// The extra --header-size-block-start travel matters only for a
+					// top mobile header: parked at plain -100% the bar would sit in
+					// the band the hidden header vacates. The token is 0px in every
+					// other placement, so this reduces to -100% there.
+					transform: translate3d( 0, calc( -100% - var( --header-size-block-start ) ), 0 );
 				}
 			}
+		}
+
+		// Top mobile header slides up instead of down. (No sticky-bar rule
+		// needed here — its base transform above already travels past the
+		// header via --header-size-block-start.)
+		&.citizen-header-position-mobile-top .citizen-scroll--down .citizen-header {
+			transform: translate3d( 0, -100%, 0 );
 		}
 	}
 }

--- a/resources/skins.citizen.styles/components/Header.less
+++ b/resources/skins.citizen.styles/components/Header.less
@@ -97,7 +97,7 @@
 			inset: 0;
 			z-index: @z-index-bottom;
 			content: '';
-			.mixin-citizen-frosted-glass;
+			.mixin-citizen-frosted-glass( 0 );
 		}
 	}
 }

--- a/resources/skins.citizen.styles/components/Header.less
+++ b/resources/skins.citizen.styles/components/Header.less
@@ -18,6 +18,13 @@
 	border-inline-start-width: var( --header-border-inline-start-width );
 	border-inline-end-width: var( --header-border-inline-end-width );
 
+	// A top mobile header sits under the device cutout, not the home bar
+	@media ( max-width: @max-width-breakpoint-tablet ) {
+		.citizen-header-position-mobile-top & {
+			padding: ~'max( env( safe-area-inset-top ), var( --space-xs ) ) max( env( safe-area-inset-right ), var( --space-xs ) ) var( --space-xs ) max( env( safe-area-inset-left ), var( --space-xs ) )';
+		}
+	}
+
 	&__item {
 		display: flex;
 		align-items: center;

--- a/resources/skins.citizen.styles/components/StickyHeader.less
+++ b/resources/skins.citizen.styles/components/StickyHeader.less
@@ -33,13 +33,15 @@
 		left: 0;
 		z-index: @z-index-sticky;
 		visibility: hidden;
+		// Clear the site header when it occupies the top edge —
+		// --header-size-block-start is 0px in every other placement
+		margin-top: var( --header-size-block-start );
 		transform: translateY( -100% );
 		transition-timing-function: var( --transition-timing-function-ease-out );
 		transition-duration: var( --transition-duration-medium );
 		transition-property: transform, visibility;
 
 		@media ( min-width: @min-width-breakpoint-desktop ) {
-			margin-top: var( --header-size-block-start );
 			margin-right: var( --header-size-inline-end );
 			margin-left: var( --header-size-inline-start );
 		}

--- a/resources/skins.citizen.styles/layout.less
+++ b/resources/skins.citizen.styles/layout.less
@@ -37,6 +37,17 @@
 	margin-top: var( --space-xl );
 }
 
+// The desktop padding-block rule below stops at the desktop breakpoint, so
+// reserve the top edge here for a mobile top header (reads the token, which
+// is 0px in every other placement). The bottom edge needs no equivalent:
+// with autohide on the bottom header overlays content only transiently, and
+// with autohide off the footer margin ( Footer.less ) reserves it.
+@media ( max-width: @max-width-breakpoint-tablet ) {
+	.citizen-page-container {
+		padding-block-start: var( --header-size-block-start );
+	}
+}
+
 @media ( min-width: @min-width-breakpoint-desktop ) {
 	.citizen-page-container {
 		// Reserve space for header

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -163,7 +163,8 @@
 	--header-border-inline-start-width: 0px;
 	--header-border-inline-end-width: 0px;
 
-	// Always default to bottom in mobile for now
+	// Mobile and tablet placement — bottom unless the wiki opts into top
+	// via $wgCitizenHeaderPositionMobile
 	@media ( max-width: @max-width-breakpoint-tablet ) {
 		--header-direction: row;
 		--header-inset-inline-start: 0px;
@@ -172,6 +173,18 @@
 		--header-inset-block-start: auto;
 		--header-inset-block-end: 0px;
 		--header-border-block-start-width: var( --border-width-base );
+	}
+
+	&.citizen-header-position-mobile-top {
+		@media ( max-width: @max-width-breakpoint-tablet ) {
+			--header-size-block-start: var( --header-size );
+			--header-size-block-end: 0px;
+			--header-inset-block-start: 0px;
+			--header-inset-block-end: auto;
+			--header-border-block-start-width: 0px;
+			--header-border-block-end-width: var( --border-width-base );
+			.mixin-citizen-card-expand( down );
+		}
 	}
 
 	&.citizen-header-position {

--- a/skin.json
+++ b/skin.json
@@ -1112,6 +1112,12 @@
 			"descriptionmsg": "citizen-config-headerposition",
 			"public": true
 		},
+		"HeaderPositionMobile": {
+			"value": "bottom",
+			"description": "Position of the header on the mobile and tablet layout (below the desktop breakpoint). Possible values: 'top' and 'bottom'",
+			"descriptionmsg": "citizen-config-headerpositionmobile",
+			"public": true
+		},
 		"Preview": {
 			"value": 0,
 			"description": "Version-scoped switch for the Citizen preview channel. Set to the upcoming major release number (currently 4) to preview it ahead of release — during this cycle that enables the new color token pipeline. 0 or any other value keeps the stable experience, so a stale setting never enrolls the wiki in a later cycle.",

--- a/skinStyles/extensions/CookieWarning/ext.CookieWarning.styles.less
+++ b/skinStyles/extensions/CookieWarning/ext.CookieWarning.styles.less
@@ -13,6 +13,9 @@
 
 .mw-cookiewarning-container {
 	right: 0;
+	// Sit above the site header whenever it occupies the bottom edge —
+	// --header-size-block-end is 0px in every other placement
+	bottom: var( --header-size-block-end );
 	display: grid;
 	grid-template-columns: 1fr;
 	gap: var( --space-sm );
@@ -33,10 +36,6 @@
 		.citizen-header-position-left & {
 			left: var( --header-size-inline-start );
 		}
-	}
-
-	.citizen-header-position-bottom & {
-		bottom: var( --header-size-block-end );
 	}
 
 	.mw-cookiewarning-text {

--- a/tests/phpunit/integration/SkinCitizenTest.php
+++ b/tests/phpunit/integration/SkinCitizenTest.php
@@ -141,6 +141,36 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 		$this->assertStringContainsString( 'skin-theme-clientpref-black', $attrs['class'] );
 	}
 
+	public function testHeaderPositionMobileDefault(): void {
+		$skin = $this->createSkinInstance();
+
+		$attrs = $skin->getHtmlElementAttributes();
+
+		$this->assertStringContainsString( 'citizen-header-position-mobile-bottom', $attrs['class'] );
+	}
+
+	public function testHeaderPositionMobileTop(): void {
+		$this->overrideConfigValues( [
+			'CitizenHeaderPositionMobile' => 'top',
+		] );
+		$skin = $this->createSkinInstance();
+
+		$attrs = $skin->getHtmlElementAttributes();
+
+		$this->assertStringContainsString( 'citizen-header-position-mobile-top', $attrs['class'] );
+	}
+
+	public function testHeaderPositionMobileInvalidValue(): void {
+		$this->overrideConfigValues( [
+			'CitizenHeaderPositionMobile' => 'left',
+		] );
+		$skin = $this->createSkinInstance();
+
+		$attrs = $skin->getHtmlElementAttributes();
+
+		$this->assertStringContainsString( 'citizen-header-position-mobile-bottom', $attrs['class'] );
+	}
+
 	public function testCollapsibleSectionsBodyClass(): void {
 		$title = Title::newFromText( 'CollapsibleSectionsTest' );
 		RequestContext::resetMain();


### PR DESCRIPTION
## Summary

Adds `$wgCitizenHeaderPositionMobile` (`'bottom'` default, `'top'` opt-in) so wikis can place the site header at the top edge on mobile and tablet layouts, complementing the desktop-only `$wgCitizenHeaderPosition`. Invalid values fall back to `'bottom'`.

```php
$wgCitizenHeaderPositionMobile = 'top';
```

PHP emits a `citizen-header-position-mobile-{top|bottom}` class on the `html` element; the top placement flips the header token cascade, offsets the page content, stacks the sticky title bar below the header, anchors header cards downward, hides the header upward on scroll, and swaps the safe-area padding to the top edge. Bottom remains the no-class default, so cached HTML degrades safely in both skew directions and no preview-channel gating is needed.

## Ride-along fixes

- **fix(CookieWarning):** the banner's bottom offset was keyed to the *desktop* position class, so on mobile the banner of a left/right/top-desktop wiki collided with the bottom header. It now reads the regime-aware `--header-size-block-end` token unconditionally.
- **fix(header):** the narrow-viewport frosted glass inherited the mixin's surface-1 default, visibly shifting the header background across the desktop breakpoint (conspicuous once the header stays on the same edge). It now uses surface-0, matching the header's own background and the sticky header glass.

## Verification

- 169/169 PHPUnit (3 new tests for the config), 1018/1018 Vitest, PHPCS/Phan/stylelint/i18n/md lints clean against the known baseline
- Browser matrix: `top`/`bottom`/unset × initial render, scroll hide/show choreography, sticky bar stacking, ToC anchor offsets, drawer/user-menu/preferences/search cards; desktop non-regression for all four `$wgCitizenHeaderPosition` values with the mobile config held at `top`
- `?uselang=x-xss` pass clean; cache-posture check (class stripped from `html`) renders the shipped bottom default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to position the mobile/tablet header at the top or bottom.
  * Invalid values automatically fall back to the bottom position.
  * Updated mobile and tablet layouts, navigation behavior, popups, and animations to support top-positioned headers.
  * Improved safe-area handling for devices with display cutouts.

* **Bug Fixes**
  * Improved spacing for sticky headers and cookie warnings across header positions.
  * Added coverage for default, top, and invalid configuration values.

* **Documentation**
  * Documented the new configuration option and its supported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->