### PR TITLE
refactor(preview): remove the post-3.18 transition shims

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -231,6 +231,5 @@
 	"citizen-command-palette-queryaction-page-edit-description": "Create or edit page",
 
 	"citizen-config-headerpositionmobile": "Position of the site header on the mobile and tablet layout (below the desktop breakpoint). Accepts 'top' or 'bottom'; any other value falls back to 'bottom'.",
-	"citizen-config-preview": "Version-scoped switch for the Citizen preview channel. Set to the upcoming major release number (currently 4) to preview it before release; 0 or any other value keeps the stable experience.",
-	"citizen-config-usenewtoken": "Opt-in switch for the new color token pipeline. Defaults to false; set to true to enable. The new pipeline becomes the default — and legacy is removed — in the next major Citizen release."
+	"citizen-config-preview": "Version-scoped switch for the Citizen preview channel. Set to the upcoming major release number (currently 4) to preview it before release; 0 or any other value keeps the stable experience."
 }

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -206,6 +206,5 @@
 	"citizen-command-palette-mode-user-placeholder": "Buscar usuarios",
 	"citizen-command-palette-queryaction-fulltext-search-description": "Buscar o texto completo en todas as páxinas",
 	"citizen-command-palette-queryaction-page-edit-description": "Crear ou editar unha páxina",
-	"citizen-config-preview": "O interruptor de versión para a canle de vista previa de Citizen. Defíneo no número de versión maior seguinte (actualmente a versión 4) para previsualizala antes do lanzamento; 0 ou calquera outro valor mantén a experiencia estable.",
-	"citizen-config-usenewtoken": "Opción de activación para a nova canle de tokens de cor. O valor predeterminado é «false»; establéceo en «true» para activala. A nova canle converterase na predeterminada (e a antiga eliminarase) na seguinte versión de Citizen."
+	"citizen-config-preview": "O interruptor de versión para a canle de vista previa de Citizen. Defíneo no número de versión maior seguinte (actualmente a versión 4) para previsualizala antes do lanzamento; 0 ou calquera outro valor mantén a experiencia estable."
 }

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -204,6 +204,5 @@
 	"citizen-command-palette-mode-user-noresults-title": "Necun usator correspondente",
 	"citizen-command-palette-mode-user-placeholder": "Cercar usatores",
 	"citizen-command-palette-queryaction-fulltext-search-description": "Cercar in le texto complete de tote le paginas",
-	"citizen-command-palette-queryaction-page-edit-description": "Crear o modificar pagina",
-	"citizen-config-usenewtoken": "Option pro activar le nove serie de tokens de color. Es predefinite como false; mitte a ver pro activar. Le nove serie devenira le predefinition (e le ancian essera eliminate) in le proxime version major de Citizen."
+	"citizen-command-palette-queryaction-page-edit-description": "Crear o modificar pagina"
 }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -215,6 +215,5 @@
 	"citizen-command-palette-mode-user-placeholder": "사용자 검색",
 	"citizen-command-palette-queryaction-fulltext-search-description": "모든 문서의 전체 텍스트를 검색",
 	"citizen-command-palette-queryaction-page-edit-description": "문서를 생성 또는 편집",
-	"citizen-config-preview": "Citizen 미리 보기 채널에 대한 버전별 스위치입니다. 출시 전 미리 보기를 원하시면 다음 주요 릴리스 번호(현재 4)로 설정하세요. 0 또는 다른 값으로 설정하면 안정적인 환경을 유지합니다.",
-	"citizen-config-usenewtoken": "새 색상 토큰 파이프라인에 대한 구독 승인 스위치입니다. 기본값은 false입니다. 활성화하려면 true로 설정하세요. 다음 주요 시티즌 릴리스에서는 새 파이프라인이 기본값이 되고 기존 방식은 제거됩니다."
+	"citizen-config-preview": "Citizen 미리 보기 채널에 대한 버전별 스위치입니다. 출시 전 미리 보기를 원하시면 다음 주요 릴리스 번호(현재 4)로 설정하세요. 0 또는 다른 값으로 설정하면 안정적인 환경을 유지합니다."
 }

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -210,6 +210,5 @@
 	"citizen-command-palette-mode-user-placeholder": "Gebruikers zoeken",
 	"citizen-command-palette-queryaction-fulltext-search-description": "In de volledige tekst van alle pagina’s zoeken",
 	"citizen-command-palette-queryaction-page-edit-description": "Pagina aanmaken of bewerken",
-	"citizen-config-preview": "Schakelaar met versiegebonden bereik voor het voorvertoningskanaal van Citizen. Stel in op het nummer van de komende grote versie (momenteel 4) om deze voorafgaand aan de uitgave te bekijken; met 0 of een andere waarde blijft de stabiele versie behouden.",
-	"citizen-config-usenewtoken": "Schakelaar voor het inschakelen van de nieuwe kleurtoken-pipeline. Standaard staat deze op 'false'; zet hem op 'true' om hem in te schakelen. De nieuwe pipeline wordt de standaard en de oude pipeline wordt verwijderd in de volgende grote Citizen-release."
+	"citizen-config-preview": "Schakelaar met versiegebonden bereik voor het voorvertoningskanaal van Citizen. Stel in op het nummer van de komende grote versie (momenteel 4) om deze voorafgaand aan de uitgave te bekijken; met 0 of een andere waarde blijft de stabiele versie behouden."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -218,6 +218,5 @@
 	"citizen-command-palette-queryaction-fulltext-search-description": "Description for the fulltext search in the command palette",
 	"citizen-command-palette-queryaction-page-edit-description": "Description for the page edit action in the command palette",
 	"citizen-config-headerpositionmobile": "Description for the {{Help|HeaderPositionMobile}} config option. Used in extension registration metadata.",
-	"citizen-config-preview": "Description for the {{Help|Preview}} config option. Used in extension registration metadata.",
-	"citizen-config-usenewtoken": "Description for the {{Help|UseNewToken}} config option. Used in extension registration metadata."
+	"citizen-config-preview": "Description for the {{Help|Preview}} config option. Used in extension registration metadata."
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -217,6 +217,5 @@
 	"citizen-command-palette-mode-user-noresults-title": "Участники не найдены",
 	"citizen-command-palette-mode-user-placeholder": "Поиск участников",
 	"citizen-command-palette-queryaction-fulltext-search-description": "Поиск полного текста на всех страницах",
-	"citizen-command-palette-queryaction-page-edit-description": "Создать или редактировать страницу",
-	"citizen-config-usenewtoken": "Переключатель для включения нового конвейера цветовых токенов. По умолчанию — false (выключен); установите значение true для включения. Новый конвейер станет конвейером по умолчанию, а старый будет удалён, в следующем крупном выпуске Citizen."
+	"citizen-command-palette-queryaction-page-edit-description": "Создать или редактировать страницу"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -215,6 +215,5 @@
 	"citizen-command-palette-mode-user-noresults-title": "Eşleşen kullanıcı yok",
 	"citizen-command-palette-mode-user-placeholder": "Kullanıcıları ara",
 	"citizen-command-palette-queryaction-fulltext-search-description": "Tüm sayfaların tam metnini arayın",
-	"citizen-command-palette-queryaction-page-edit-description": "Sayfa oluştur veya düzenle",
-	"citizen-config-usenewtoken": "Yeni renk belirteci işlem hattı için isteğe bağlı seçenek. Varsayılan değer false'tur; etkinleştirmek için true olarak ayarlayın. Yeni işlem hattı, bir sonraki büyük Citizen sürümünde varsayılan hale gelecek ve eski işlem hattı kaldırılacaktır."
+	"citizen-command-palette-queryaction-page-edit-description": "Sayfa oluştur veya düzenle"
 }

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -227,6 +227,5 @@
 	"citizen-command-palette-mode-user-placeholder": "搜索用户",
 	"citizen-command-palette-queryaction-fulltext-search-description": "在所有页面全文搜索",
 	"citizen-command-palette-queryaction-page-edit-description": "创建或编辑页面",
-	"citizen-config-preview": "Citizen预览通道的版本控制开关。设置为即将发布的主版本号（当前为4）即可在正式发布前抢先预览；设置为0或任何其他值则继续体验稳定版本。",
-	"citizen-config-usenewtoken": "启用/禁用新颜色 Token 管道。默认值为 false，设置为 true 即可启用。在下一个 Citizen 主要版本中，新管道将成为默认选项，同时移除旧版管道。"
+	"citizen-config-preview": "Citizen预览通道的版本控制开关。设置为即将发布的主版本号（当前为4）即可在正式发布前抢先预览；设置为0或任何其他值则继续体验稳定版本。"
 }

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -216,6 +216,5 @@
 	"citizen-command-palette-mode-user-noresults-title": "沒有符合的使用者",
 	"citizen-command-palette-mode-user-placeholder": "搜尋使用者",
 	"citizen-command-palette-queryaction-fulltext-search-description": "搜尋所有頁面的全文",
-	"citizen-command-palette-queryaction-page-edit-description": "建立或編輯頁面",
-	"citizen-config-usenewtoken": "請啟用/停用新彩色權仗的管道流程。預設為false；設定為true即可啟用。在下一個Citizen主要版本中，新的流程將成為預設的管道流程，舊流程將被移除。"
+	"citizen-command-palette-queryaction-page-edit-description": "建立或編輯頁面"
 }

--- a/includes/Hooks/SkinHooks.php
+++ b/includes/Hooks/SkinHooks.php
@@ -62,11 +62,9 @@ class SkinHooks implements
 	 * the color-token module and stamp the generation class.
 	 *
 	 * Priority: ?citizenpreview= URL param > citizenpreview cookie >
-	 * $wgCitizenPreview config, with deprecated $wgCitizenUseNewToken
-	 * as a second opt-in signal — no config value suppresses it. An
-	 * explicit URL choice also writes a 24-hour cookie, so a flip takes
-	 * effect on subsequent requests — exactly one token module ships
-	 * per request.
+	 * $wgCitizenPreview config. An explicit URL choice also writes a
+	 * 24-hour cookie, so a flip takes effect on subsequent requests —
+	 * exactly one token module ships per request.
 	 */
 	private static function applyPreviewChannel( OutputPage $out ): void {
 		$request = $out->getRequest();
@@ -82,23 +80,9 @@ class SkinHooks implements
 			);
 		}
 
-		// citizen-v4-remove — deprecated alias notice, drop with the alias
-		if ( $config->get( 'CitizenUseNewToken' ) ) {
-			wfDeprecatedMsg(
-				'$wgCitizenUseNewToken is deprecated; set $wgCitizenPreview = '
-					. PreviewChannel::TARGET_MAJOR . ' instead',
-				'3.18.0',
-				'Citizen'
-			);
-		}
-
 		if ( PreviewChannel::isPreview( $urlVal, $cookieVal, $config ) ) {
 			$out->addModuleStyles( [ 'skins.citizen.tokens.new' ] );
-			$out->addHtmlClasses( [
-				PreviewChannel::HTML_CLASS,
-				// citizen-v4-remove — pre-rename class for cached HTML
-				PreviewChannel::HTML_CLASS_LEGACY,
-			] );
+			$out->addHtmlClasses( [ PreviewChannel::HTML_CLASS ] );
 		} else {
 			// citizen-v4-remove — legacy pipeline, deleted at the 4.0 flip
 			$out->addModuleStyles( [ 'skins.citizen.tokens' ] );

--- a/includes/PreviewChannel.php
+++ b/includes/PreviewChannel.php
@@ -36,22 +36,13 @@ final class PreviewChannel {
 	public const HTML_CLASS = 'citizen-v4';
 
 	/**
-	 * Pre-rename generation class, stamped alongside HTML_CLASS for one
-	 * minor release so CSS keeps matching HTML cached before the rename.
-	 */
-	// citizen-v4-remove — drop in the minor release after 3.18
-	public const HTML_CLASS_LEGACY = 'citizen-token-new';
-
-	/**
 	 * Resolve the channel for one request.
 	 *
-	 * Precedence: URL param > cookie > $wgCitizenPreview >
-	 * $wgCitizenUseNewToken (deprecated alias). At the URL/cookie level
-	 * '0' is an explicit opt-out and TARGET_MAJOR an explicit opt-in;
-	 * any other value (including absent) is inert and falls through.
-	 * Config and the alias are opt-in-only signals — there is no
-	 * config-level opt-out that suppresses the alias; stable is simply
-	 * both keys at their defaults.
+	 * Precedence: URL param > cookie > $wgCitizenPreview. At the
+	 * URL/cookie level '0' is an explicit opt-out and TARGET_MAJOR an
+	 * explicit opt-in; any other value (including absent) is inert and
+	 * falls through. $wgCitizenPreview is an opt-in-only signal — there
+	 * is no config-level opt-out; stable is simply the default.
 	 *
 	 * @param ?string $urlVal Raw ?citizenpreview= value, null if absent
 	 * @param ?string $cookieVal Raw citizenpreview cookie value, null if absent
@@ -63,13 +54,7 @@ final class PreviewChannel {
 			return $explicit;
 		}
 
-		if ( (int)$config->get( 'CitizenPreview' ) === self::TARGET_MAJOR ) {
-			return true;
-		}
-
-		// citizen-v4-remove — deprecated alias, drop with the skin.json entry.
-		// Loose cast for exact parity with the pre-rename behavior.
-		return (bool)$config->get( 'CitizenUseNewToken' );
+		return (int)$config->get( 'CitizenPreview' ) === self::TARGET_MAJOR;
 	}
 
 	/**

--- a/resources/skins.citizen.codex.styles/CdxButton.less
+++ b/resources/skins.citizen.codex.styles/CdxButton.less
@@ -50,9 +50,7 @@
 // Polyfill for Codex 2.x button styles. Remove once the minimum
 // supported MW bundles Codex >= 2.0 (currently MW 1.43 ships
 // Codex 1.14, so this stays as long as we target REL1_43).
-// The second selector is the pre-rename generation class. citizen-v4-remove
-.citizen-v4 .cdx-button,
-.citizen-token-new .cdx-button {
+.citizen-v4 .cdx-button {
 	&:enabled,
 	&.cdx-button--fake-button--enabled {
 		color: var( --color-neutral );

--- a/resources/skins.citizen.tokens.new/background-color.less
+++ b/resources/skins.citizen.tokens.new/background-color.less
@@ -84,11 +84,7 @@
 }
 
 .new-background-color() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-background-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/border-color.less
+++ b/resources/skins.citizen.tokens.new/border-color.less
@@ -68,11 +68,7 @@
 }
 
 .new-border-color() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-border-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/box-shadow.less
+++ b/resources/skins.citizen.tokens.new/box-shadow.less
@@ -16,11 +16,7 @@
 }
 
 .new-box-shadow() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-box-shadow-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/color.less
+++ b/resources/skins.citizen.tokens.new/color.less
@@ -79,11 +79,7 @@
 }
 
 .new-color() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/font.less
+++ b/resources/skins.citizen.tokens.new/font.less
@@ -15,11 +15,7 @@
 }
 
 .new-font() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-font-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/misc.less
+++ b/resources/skins.citizen.tokens.new/misc.less
@@ -39,11 +39,10 @@
 	--backdrop-filter-blur: blur( 2px );
 	--backdrop-filter-frosted-glass: ~'blur( 16px ) saturate( 140% )';
 
-	// Citizen extensions — legacy aliases. mixins.less still
-	// consumes --color-progressive-oklch__h. The HSL trio feeds
-	// tokens-citizen.less's deprecated --color-primary__h/__s/__l.
-	// __l is theme-variant — dark override in dark-overrides.less.
-	// Drop alongside the legacy pipeline.
+	// Citizen extensions — legacy back-compat aliases, dropped alongside
+	// the legacy pipeline. The HSL trio feeds tokens-citizen.less's
+	// deprecated --color-primary__h/__s/__l; __l is theme-variant (dark
+	// override in dark-overrides.less).
 	--color-progressive-oklch__h: var( --color-primary-oklch__h );
 	--color-progressive-hsl__h: @color-progressive-hsl__h-default;
 	--color-progressive-hsl__s: @color-progressive-hsl__s-default;
@@ -51,11 +50,7 @@
 }
 
 .new-misc() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-misc-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/opacity.less
+++ b/resources/skins.citizen.tokens.new/opacity.less
@@ -25,11 +25,7 @@
 }
 
 .new-opacity() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-opacity-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/primitives-citizen.less
+++ b/resources/skins.citizen.tokens.new/primitives-citizen.less
@@ -64,11 +64,7 @@
 }
 
 .new-primitives-citizen() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-primitives-citizen-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/primitives-codex.less
+++ b/resources/skins.citizen.tokens.new/primitives-codex.less
@@ -162,11 +162,7 @@
 }
 
 .new-primitives-codex() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-primitives-codex-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/surface.less
+++ b/resources/skins.citizen.tokens.new/surface.less
@@ -18,11 +18,7 @@
 }
 
 .new-surface() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-surface-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/syntax-color.less
+++ b/resources/skins.citizen.tokens.new/syntax-color.less
@@ -21,11 +21,7 @@
 }
 
 .new-syntax-color() {
-	// The second selector is the pre-rename generation class, kept for
-	// one minor so compiled CSS keeps matching cached HTML.
-	// citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		.new-syntax-color-decls();
 	}
 }

--- a/resources/skins.citizen.tokens.new/tokens.less
+++ b/resources/skins.citizen.tokens.new/tokens.less
@@ -47,11 +47,7 @@
 	.new-font();
 	.new-misc();
 
-	// In each group the second selector is the pre-rename generation
-	// class, kept for one minor so compiled CSS keeps matching cached
-	// HTML. citizen-v4-remove
-	:where( :root.citizen-v4 ),
-	:where( :root.citizen-token-new ) {
+	:where( :root.citizen-v4 ) {
 		color-scheme: light;
 	}
 

--- a/scripts/codex-audit.mjs
+++ b/scripts/codex-audit.mjs
@@ -135,7 +135,7 @@ function parseCitizenSemantics() {
 	// Parse every .less file in the new-token module directory except
 	// the entry (tokens.less) and the primitive files (already handled
 	// by parseCitizenPrimitives). Each category file emits at
-	// :root.citizen-token-new and is parsed for token declarations.
+	// :root.citizen-v4 and is parsed for token declarations.
 	const SKIP = new Set( [ 'tokens.less', 'primitives-codex.less', 'primitives-citizen.less' ] );
 	const files = readdirSync( CITIZEN_TOKENS_DIR )
 		.filter( name => name.endsWith( '.less' ) && !SKIP.has( name ) )

--- a/skin.json
+++ b/skin.json
@@ -1123,12 +1123,6 @@
 			"description": "Version-scoped switch for the Citizen preview channel. Set to the upcoming major release number (currently 4) to preview it ahead of release — during this cycle that enables the new color token pipeline. 0 or any other value keeps the stable experience, so a stale setting never enrolls the wiki in a later cycle.",
 			"descriptionmsg": "citizen-config-preview",
 			"public": true
-		},
-		"UseNewToken": {
-			"value": false,
-			"description": "Deprecated alias for $wgCitizenPreview = 4. Honored through the next minor release and then removed — use $wgCitizenPreview instead.",
-			"descriptionmsg": "citizen-config-usenewtoken",
-			"public": true
 		}
 	},
 	"manifest_version": 2

--- a/tests/phpunit/Unit/PreviewChannelTest.php
+++ b/tests/phpunit/Unit/PreviewChannelTest.php
@@ -15,27 +15,24 @@ use MediaWikiUnitTestCase;
 class PreviewChannelTest extends MediaWikiUnitTestCase {
 
 	/**
-	 * @return iterable<string, array{?string, ?string, mixed, mixed, bool}>
+	 * @return iterable<string, array{?string, ?string, mixed, bool}>
 	 */
 	public static function providePrecedence(): iterable {
-		// [ urlVal, cookieVal, CitizenPreview, CitizenUseNewToken, expected ]
-		yield 'all defaults → stable' => [ null, null, 0, false, false ];
-		yield 'config targets the current major' => [ null, null, 4, false, true ];
-		yield 'config accepts a numeric string' => [ null, null, '4', false, true ];
-		yield 'config for a future cycle is inert' => [ null, null, 5, false, false ];
-		yield 'boolean true config is inert' => [ null, null, true, false, false ];
-		yield 'deprecated alias activates preview' => [ null, null, 0, true, true ];
-		yield 'inert config falls through to alias' => [ null, null, 5, true, true ];
-		yield 'truthy non-boolean alias activates preview' => [ null, null, 0, 1, true ];
-		yield 'cookie opt-out beats active alias' => [ null, '0', 0, true, false ];
-		yield 'cookie opts in over config off' => [ null, '4', 0, false, true ];
-		yield 'cookie opts out over config on' => [ null, '0', 4, false, false ];
-		yield 'legacy cookie value 1 is inert' => [ null, '1', 0, false, false ];
-		yield 'inert cookie falls through to config' => [ null, '5', 4, false, true ];
-		yield 'url opts in over everything' => [ '4', '0', 0, false, true ];
-		yield 'url opts out over everything' => [ '0', '4', 4, true, false ];
-		yield 'garbage url falls through to cookie' => [ 'x', '0', 4, false, false ];
-		yield 'empty url falls through to config' => [ '', null, 4, false, true ];
+		// [ urlVal, cookieVal, CitizenPreview, expected ]
+		yield 'all defaults → stable' => [ null, null, 0, false ];
+		yield 'config targets the current major' => [ null, null, 4, true ];
+		yield 'config accepts a numeric string' => [ null, null, '4', true ];
+		yield 'config for a future cycle is inert' => [ null, null, 5, false ];
+		yield 'boolean true config is inert' => [ null, null, true, false ];
+		yield 'cookie opts out over config off' => [ null, '0', 0, false ];
+		yield 'cookie opts in over config off' => [ null, '4', 0, true ];
+		yield 'cookie opts out over config on' => [ null, '0', 4, false ];
+		yield 'legacy cookie value 1 is inert' => [ null, '1', 0, false ];
+		yield 'inert cookie falls through to config' => [ null, '5', 4, true ];
+		yield 'url opts in over everything' => [ '4', '0', 0, true ];
+		yield 'url opts out over everything' => [ '0', '4', 4, false ];
+		yield 'garbage url falls through to cookie' => [ 'x', '0', 4, false ];
+		yield 'empty url falls through to config' => [ '', null, 4, true ];
 	}
 
 	/**
@@ -45,12 +42,10 @@ class PreviewChannelTest extends MediaWikiUnitTestCase {
 		?string $urlVal,
 		?string $cookieVal,
 		mixed $configVal,
-		mixed $aliasVal,
 		bool $expected
 	): void {
 		$config = new HashConfig( [
 			'CitizenPreview' => $configVal,
-			'CitizenUseNewToken' => $aliasVal,
 		] );
 
 		$actual = PreviewChannel::isPreview( $urlVal, $cookieVal, $config );
@@ -80,6 +75,5 @@ class PreviewChannelTest extends MediaWikiUnitTestCase {
 		$this->assertSame( 4, PreviewChannel::TARGET_MAJOR );
 		$this->assertSame( 'citizenpreview', PreviewChannel::REQUEST_KEY );
 		$this->assertSame( 'citizen-v4', PreviewChannel::HTML_CLASS );
-		$this->assertSame( 'citizen-token-new', PreviewChannel::HTML_CLASS_LEGACY );
 	}
 }

--- a/tests/phpunit/integration/Hooks/SkinHooksTest.php
+++ b/tests/phpunit/integration/Hooks/SkinHooksTest.php
@@ -494,7 +494,6 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 		$out->method( 'getConfig' )->willReturn( new HashConfig( $config + [
 			'CitizenEnablePreferences' => false,
 			'CitizenPreview' => 0,
-			'CitizenUseNewToken' => false,
 		] ) );
 
 		return $out;
@@ -513,7 +512,7 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 		$out->expects( $this->once() )->method( 'addModuleStyles' )
 			->with( [ 'skins.citizen.tokens.new' ] );
 		$out->expects( $this->once() )->method( 'addHtmlClasses' )
-			->with( [ 'citizen-v4', 'citizen-token-new' ] );
+			->with( [ 'citizen-v4' ] );
 
 		$this->newSkinHooks()->onBeforePageDisplay( $out, $this->createCitizenSkinMock() );
 	}
@@ -558,16 +557,6 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 		$this->newSkinHooks()->onBeforePageDisplay( $out, $this->createCitizenSkinMock() );
 
 		$this->assertSame( [], $request->response()->getCookies() );
-	}
-
-	public function testOnBeforePageDisplayAliasConfigActivatesPreviewAndDeprecates(): void {
-		$this->expectDeprecationAndContinue( '/CitizenUseNewToken/' );
-		$request = new FauxRequest();
-		$out = $this->createPreviewOutputPage( $request, [ 'CitizenUseNewToken' => true ] );
-		$out->expects( $this->once() )->method( 'addModuleStyles' )
-			->with( [ 'skins.citizen.tokens.new' ] );
-
-		$this->newSkinHooks()->onBeforePageDisplay( $out, $this->createCitizenSkinMock() );
 	}
 
 	public function testOnBeforePageDisplaySkipsNonCitizen(): void {


### PR DESCRIPTION
Closes #1616.

Now that 3.18 shipped the preview-channel rename (`$wgCitizenUseNewToken`/`citizen-token-new` → `$wgCitizenPreview`/`citizen-v4`), this removes the three one-minor transitional shims that rode along for edge-cache and config compatibility.

## What's removed

- **HTML class** — the pre-rename `citizen-token-new` class stamped alongside `citizen-v4` (`PreviewChannel::HTML_CLASS_LEGACY` + its stamping in `SkinHooks::applyPreviewChannel`). `citizen-v4` is now the sole stamped class.
- **LESS dual-gate selectors** — the `citizen-token-new` selector dropped from all 11 token category mixins, the entry file, and `CdxButton.less`. Each gate is now just `:root.citizen-v4`.
- **Config alias** — `$wgCitizenUseNewToken` removed entirely: the fallthrough in `PreviewChannel::isPreview`, the deprecation notice in `SkinHooks`, the `skin.json` block, and the `citizen-config-usenewtoken` i18n key across all 10 locale files. `$wgCitizenPreview` is now the sole opt-in signal.

Plus two folded-in comment fixes the issue called for: `codex-audit.mjs` (selector name in a comment) and a `misc.less` legacy-alias comment (dropped a stale claim about `mixins.less`).

## Note for review — verification differs from the issue's text

Issue #1616 was written before the theme-system-overhaul landed, so its line numbers and two structural claims drifted. I worked from actual file content, not the issue's coordinates:

- **`citizen-v4-remove` count is 11, not the issue's "exactly 5".** The overhaul added 6 more **flip-scoped** (4.0-flip) markers after the issue was written — `App.vue` ×3, `defaultConfig.js`, `features.less:3`, `tokens/tokens.less:41`. All 11 survivors are genuinely 4.0-flip-scoped (legacy token pipeline / theme picker), owned by the flip runbook — not token-rename shims.
- **The entry file `tokens.new/tokens.less` has 1 dual-gate block, not 3.** The overhaul had already rewritten the Night/OS blocks to bare `.skin-theme-clientpref-*` selectors.
- Verify with `git grep` (tracked files), not plain `grep -rn` — the gitignored `docs/.vitepress/dist` has legitimate *historical* changelog references to `$wgCitizenUseNewToken`.

## Verification

- `git grep citizen-token-new` = 0, `git grep -i usenewtoken` = 0, `git grep citizen-v4-remove` (includes/resources/tests) = 11 (all flip-scoped)
- PHPUnit 165 pass · Vitest 1018 pass · style + i18n lints clean · Phan-clean on changed files

_Pre-existing and unrelated to this PR: local `composer preflight` is red on `includes/Components/CitizenComponentBodyContent.php` Phan `UnusedPluginSuppression` — a PHP-8.3-local vs 8.2-CI quirk that fails identically on `main`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview styling now uses the current token generation only.
* **Changes**
  * Removed the deprecated “Use New Token” configuration option and related translations.
  * Preview-channel selection now relies on the preview setting, URL parameter, and cookie.
  * Removed legacy compatibility styling and classes.
* **Bug Fixes**
  * Updated preview behavior and styling to consistently apply the current generation.
* **Tests**
  * Updated coverage for the simplified preview configuration and token behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->