### PR TITLE
perf(overflowElements): ⚡️ defer table measurement until scrolled into view

### DIFF
--- a/resources/skins.citizen.scripts/overflowElements/index.js
+++ b/resources/skins.citizen.scripts/overflowElements/index.js
@@ -4,22 +4,23 @@ const { createOverflowStickyHeader } = require( './stickyHeader.js' );
 
 /**
  * Manages the lifecycle of a single overflow element, composing wrapper,
- * state, and optional sticky header sub-modules. Handles observers,
- * scroll events, and resume/pause behavior.
+ * state, and optional sticky header sub-modules. Observation is shared:
+ * init() only builds DOM, and all measurement is driven by the shared
+ * observers so off-screen elements are never measured.
  */
 class OverflowElement {
 	constructor( {
-		document, window, mw, IntersectionObserver, ResizeObserver,
+		document, window, mw,
 		element, isPointerDevice, config
 	} ) {
 		this.document = document;
 		this.window = window;
 		this.mw = mw;
-		this.IntersectionObserver = IntersectionObserver;
-		this.ResizeObserver = ResizeObserver;
 		this.element = element;
 		this.isPointerDevice = isPointerDevice;
 		this.config = config;
+		// Assigned by the module init() after a successful element init
+		this.resizeObserver = null;
 		this.onScroll = mw.util.throttle( this.onScroll.bind( this ), 250 );
 		this.onClick = this.onClick.bind( this );
 	}
@@ -66,10 +67,33 @@ class OverflowElement {
 	}
 
 	/**
-	 * Resumes functionality: update state, add listeners, observe resize.
+	 * Measures sticky header column widths. Geometry reads only.
+	 *
+	 * @return {number[]|null}
+	 */
+	measureColumns() {
+		return this.sticky && this.sticky.measureColumns ?
+			this.sticky.measureColumns() :
+			null;
+	}
+
+	/**
+	 * Applies previously measured sticky header column widths. Writes only.
+	 *
+	 * @param {number[]|null} widths
+	 */
+	applyColumns( widths ) {
+		if ( widths && this.sticky && this.sticky.applyColumns ) {
+			this.sticky.applyColumns( widths );
+		}
+	}
+
+	/**
+	 * Resumes functionality: add listeners, observe resize.
+	 * Measurement is deliberately left to the shared ResizeObserver —
+	 * observe() always delivers an initial notification.
 	 */
 	resume() {
-		this.state.updateState();
 		this.content.addEventListener( 'scroll', this.onScroll );
 		this.resizeObserver.observe( this.element );
 		if ( this.isPointerDevice && this.nav ) {
@@ -89,7 +113,10 @@ class OverflowElement {
 	}
 
 	/**
-	 * Initialize the overflow element: wrap, set up observers, resume.
+	 * Initialize the overflow element DOM: wrapper, sticky header, state.
+	 * DOM writes only — no geometry is read here.
+	 *
+	 * @return {boolean} Whether initialization succeeded
 	 */
 	init() {
 		const refs = createOverflowWrapper( {
@@ -100,7 +127,7 @@ class OverflowElement {
 			inheritedClasses: this.config.wgCitizenOverflowInheritedClasses
 		} );
 		if ( !refs ) {
-			return;
+			return false;
 		}
 
 		this.wrapper = refs.wrapper;
@@ -108,7 +135,7 @@ class OverflowElement {
 		this.nav = refs.nav;
 
 		const headerRow = this.element.querySelector( '.citizen-overflow-sticky-header' );
-		const sticky = headerRow ?
+		this.sticky = headerRow ?
 			createOverflowStickyHeader( {
 				document: this.document,
 				element: this.element,
@@ -122,33 +149,20 @@ class OverflowElement {
 			element: this.element,
 			content: this.content,
 			wrapper: this.wrapper,
-			stickyHeader: sticky ? sticky.stickyHeader : null
+			stickyHeader: this.sticky ? this.sticky.stickyHeader : null
 		} );
 
-		this.resizeObserver = new this.ResizeObserver( () => {
-			this.state.updateState();
-			if ( sticky && sticky.syncColumns ) {
-				sticky.syncColumns();
-			}
-		} );
-
-		this.intersectionObserver = new this.IntersectionObserver( ( entries ) => {
-			entries.forEach( ( entry ) => {
-				if ( entry.isIntersecting ) {
-					this.resume();
-				} else {
-					this.pause();
-				}
-			} );
-		} );
-		this.intersectionObserver.observe( this.element );
-
-		this.resume();
+		return true;
 	}
 }
 
 /**
  * Initialize overflow element enhancements for all matching elements.
+ *
+ * All elements share a single IntersectionObserver and a single
+ * ResizeObserver. Entries arrive batched, so the resize callback can group
+ * every geometry read ahead of every style write instead of forcing one
+ * reflow per element.
  *
  * @param {Object} params
  * @param {Document} params.document
@@ -180,15 +194,65 @@ function init( {
 
 	const isPointerDevice = window.matchMedia( '(hover: hover) and (pointer: fine)' ).matches;
 
+	const initialized = [];
 	overflowElements.forEach( ( el ) => {
 		if ( nowrapClasses.some( ( cls ) => el.classList.contains( cls ) ) ) {
 			return;
 		}
 
-		new OverflowElement( {
-			document, window, mw, IntersectionObserver, ResizeObserver,
+		const instance = new OverflowElement( {
+			document, window, mw,
 			element: el, isPointerDevice, config
-		} ).init();
+		} );
+		if ( instance.init() ) {
+			initialized.push( instance );
+		}
+	} );
+
+	if ( !initialized.length ) {
+		return;
+	}
+
+	const instances = new WeakMap();
+
+	const resizeObserver = new ResizeObserver( ( entries ) => {
+		const affected = [];
+		entries.forEach( ( entry ) => {
+			const instance = instances.get( entry.target );
+			if ( instance ) {
+				affected.push( instance );
+			}
+		} );
+		// All geometry reads first (overflow state class writes are
+		// rAF-deferred inside updateState) ...
+		affected.forEach( ( instance ) => {
+			instance.state.updateState();
+		} );
+		const measurements = affected.map( ( instance ) => instance.measureColumns() );
+		// ... then all style writes
+		affected.forEach( ( instance, index ) => {
+			instance.applyColumns( measurements[ index ] );
+		} );
+	} );
+
+	const intersectionObserver = new IntersectionObserver( ( entries ) => {
+		entries.forEach( ( entry ) => {
+			const instance = instances.get( entry.target );
+			if ( !instance ) {
+				return;
+			}
+			if ( entry.isIntersecting ) {
+				instance.resume();
+			} else {
+				instance.pause();
+			}
+		} );
+	} );
+
+	initialized.forEach( ( instance ) => {
+		instance.resizeObserver = resizeObserver;
+		instances.set( instance.element, instance );
+		intersectionObserver.observe( instance.element );
 	} );
 }
 

--- a/resources/skins.citizen.scripts/overflowElements/stickyHeader.js
+++ b/resources/skins.citizen.scripts/overflowElements/stickyHeader.js
@@ -3,12 +3,16 @@
  * Detects whether the element is a table and creates the appropriate
  * clone structure (table with colgroup or div).
  *
+ * Column widths are synced in two phases so callers can batch the geometry
+ * reads of many tables ahead of any style writes: measureColumns() only
+ * reads, applyColumns() only writes.
+ *
  * @param {Object} params
  * @param {Document} params.document
  * @param {HTMLElement} params.element
  * @param {HTMLElement} params.content
  * @param {HTMLElement} params.headerRow
- * @return {{stickyHeader: HTMLElement, syncColumns: Function|null}}
+ * @return {{stickyHeader: HTMLElement, measureColumns: Function|null, applyColumns: Function|null}}
  */
 function createOverflowStickyHeader( { document, element, content, headerRow } ) {
 	const isTable = element instanceof HTMLTableElement;
@@ -47,22 +51,34 @@ function createOverflowStickyHeader( { document, element, content, headerRow } )
 	stickyHeader.setAttribute( 'aria-hidden', 'true' );
 	content.insertBefore( stickyHeader, element );
 
-	function syncColumns() {
+	function measureColumns() {
 		if ( !colgroup || !originalTh ) {
+			return null;
+		}
+		const widths = [];
+		originalTh.forEach( ( col ) => {
+			widths.push( col.getBoundingClientRect().width );
+		} );
+		return widths;
+	}
+
+	function applyColumns( widths ) {
+		if ( !widths || !colgroup ) {
 			return;
 		}
 		const stickyCols = colgroup.querySelectorAll( 'col' );
-		originalTh.forEach( ( col, index ) => {
-			stickyCols[ index ].style.minWidth = col.getBoundingClientRect().width + 'px';
+		widths.forEach( ( width, index ) => {
+			if ( stickyCols[ index ] ) {
+				stickyCols[ index ].style.setProperty( 'min-width', width + 'px' );
+			}
 		} );
 	}
 
-	// Initial sync
-	if ( isTable ) {
-		syncColumns();
-	}
-
-	return { stickyHeader, syncColumns: isTable ? syncColumns : null };
+	return {
+		stickyHeader,
+		measureColumns: isTable ? measureColumns : null,
+		applyColumns: isTable ? applyColumns : null
+	};
 }
 
 module.exports = { createOverflowStickyHeader };

--- a/tests/vitest/skins.citizen.scripts/overflowElements.test.js
+++ b/tests/vitest/skins.citizen.scripts/overflowElements.test.js
@@ -525,6 +525,83 @@ describe( 'overflowElements', () => {
 			expect( log.indexOf( 'write' ) ).toBeGreaterThan( log.lastIndexOf( 'read' ) );
 		} );
 
+		it( 'should keep measurements aligned when a batch mixes sticky and non-sticky elements', () => {
+			const stickyTable = `
+				<table class="wikitable">
+					<thead>
+						<tr class="citizen-overflow-sticky-header">
+							<th>A</th>
+							<th>B</th>
+						</tr>
+					</thead>
+				</table>
+			`;
+			const plainTable = '<table class="wikitable"><tbody><tr><td>plain</td></tr></tbody></table>';
+			const bodyContent = createBodyContent( stickyTable + plainTable );
+			const tables = bodyContent.querySelectorAll( 'table.wikitable' );
+			tables[ 0 ].querySelectorAll( 'th' ).forEach( ( th ) => {
+				th.getBoundingClientRect = () => ( { width: 150 } );
+			} );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			observers.getIntersectionCallback()( [
+				{ isIntersecting: true, target: tables[ 0 ] },
+				{ isIntersecting: true, target: tables[ 1 ] }
+			] );
+			// Deliver with the non-sticky element first to stress index alignment
+			observers.getResizeCallback()( [
+				{ target: tables[ 1 ] },
+				{ target: tables[ 0 ] }
+			] );
+
+			const cols = document.querySelectorAll( '.citizen-overflow-content-sticky-header col' );
+			expect( cols ).toHaveLength( 2 );
+			expect( cols[ 0 ].style.minWidth ).toBe( '150px' );
+			expect( cols[ 1 ].style.minWidth ).toBe( '150px' );
+		} );
+
+		it( 'should stay idempotent on repeated intersection without an intervening pause', () => {
+			const bodyContent = createBodyContent( '<table class="wikitable"></table>' );
+			const table = bodyContent.querySelector( 'table' );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow( {
+					matchMedia: vi.fn( () => ( { matches: true } ) )
+				} ),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			const contentEl = document.querySelector( '.citizen-overflow-content' );
+			const contentAddSpy = vi.spyOn( contentEl, 'addEventListener' );
+			const intersectionCb = observers.getIntersectionCallback();
+
+			intersectionCb( [ { isIntersecting: true, target: table } ] );
+			intersectionCb( [ { isIntersecting: true, target: table } ] );
+
+			// Same handler reference every time: rebinding stays a no-op for the DOM
+			expect( contentAddSpy ).toHaveBeenCalledTimes( 2 );
+			const handlers = contentAddSpy.mock.calls.map( ( call ) => call[ 1 ] );
+			expect( handlers[ 0 ] ).toBe( handlers[ 1 ] );
+			expect( observers.resizeObserve ).toHaveBeenCalledTimes( 2 );
+			expect( observers.resizeObserve ).toHaveBeenNthCalledWith( 2, table );
+		} );
+
 		it( 'should handle only navButton clicks and distinguish left from right', () => {
 			const bodyContent = createBodyContent( '<table class="wikitable"></table>' );
 			const rAF = vi.fn( ( cb ) => cb() );

--- a/tests/vitest/skins.citizen.scripts/overflowElements.test.js
+++ b/tests/vitest/skins.citizen.scripts/overflowElements.test.js
@@ -230,8 +230,11 @@ describe( 'overflowElements', () => {
 			} );
 
 			const table = bodyContent.querySelector( 'table' );
+			const intersectionCb = observers.getIntersectionCallback();
 
-			// resume() is called during init — resize observer should observe the element
+			// resume() happens once the element intersects
+			intersectionCb( [ { isIntersecting: true, target: table } ] );
+
 			expect( observers.resizeObserve ).toHaveBeenCalledWith( table );
 
 			// The content element should have a scroll listener
@@ -245,15 +248,14 @@ describe( 'overflowElements', () => {
 			const navRemoveSpy = vi.spyOn( navEl, 'removeEventListener' );
 
 			// Trigger intersection observer to pause then resume
-			const intersectionCb = observers.getIntersectionCallback();
-			intersectionCb( [ { isIntersecting: false } ] );
+			intersectionCb( [ { isIntersecting: false, target: table } ] );
 
 			expect( contentRemoveSpy ).toHaveBeenCalledWith( 'scroll', expect.any( Function ) );
 			expect( observers.resizeUnobserve ).toHaveBeenCalledWith( table );
 			expect( navRemoveSpy ).toHaveBeenCalledWith( 'click', expect.any( Function ) );
 
 			// Resume again
-			intersectionCb( [ { isIntersecting: true } ] );
+			intersectionCb( [ { isIntersecting: true, target: table } ] );
 
 			expect( contentAddSpy ).toHaveBeenCalledWith( 'scroll', expect.any( Function ) );
 			expect( navAddSpy ).toHaveBeenCalledWith( 'click', expect.any( Function ) );
@@ -278,6 +280,11 @@ describe( 'overflowElements', () => {
 				bodyContent,
 				config
 			} );
+
+			// Nav click listeners bind on intersection
+			observers.getIntersectionCallback()( [
+				{ isIntersecting: true, target: bodyContent.querySelector( 'table' ) }
+			] );
 
 			const contentEl = document.querySelector( '.citizen-overflow-content' );
 			const wrapperEl = document.querySelector( '.citizen-overflow-wrapper' );
@@ -319,6 +326,205 @@ describe( 'overflowElements', () => {
 			expect( contentEl.scrollLeft ).toBe( 0 );
 		} );
 
+		it( 'should not measure or observe resize until the element intersects', () => {
+			const bodyContent = createBodyContent( '<table class="wikitable"></table>' );
+			const table = bodyContent.querySelector( 'table' );
+			let scrollWidthReads = 0;
+			Object.defineProperty( table, 'scrollWidth', {
+				configurable: true,
+				get() {
+					scrollWidthReads++;
+					return 1000;
+				}
+			} );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			// Nothing is measured or resize-observed at boot
+			expect( observers.resizeObserve ).not.toHaveBeenCalled();
+			expect( scrollWidthReads ).toBe( 0 );
+
+			// Scrolling into view starts resize observation
+			observers.getIntersectionCallback()( [ { isIntersecting: true, target: table } ] );
+
+			expect( observers.resizeObserve ).toHaveBeenCalledWith( table );
+			expect( scrollWidthReads ).toBe( 0 );
+
+			// Measurement happens on resize observer delivery
+			observers.getResizeCallback()( [ { target: table } ] );
+
+			expect( scrollWidthReads ).toBeGreaterThan( 0 );
+			const wrapper = document.querySelector( '.citizen-overflow-wrapper' );
+			expect( wrapper.classList.contains( 'citizen-overflow--right' ) ).toBe( true );
+		} );
+
+		it( 'should not measure an element that never intersects', () => {
+			const bodyContent = createBodyContent( '<table class="wikitable"></table>' );
+			const table = bodyContent.querySelector( 'table' );
+			let scrollWidthReads = 0;
+			Object.defineProperty( table, 'scrollWidth', {
+				configurable: true,
+				get() {
+					scrollWidthReads++;
+					return 1000;
+				}
+			} );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			// Off-screen at boot: pause before any resume must be safe
+			observers.getIntersectionCallback()( [ { isIntersecting: false, target: table } ] );
+
+			expect( scrollWidthReads ).toBe( 0 );
+			expect( observers.resizeObserve ).not.toHaveBeenCalled();
+			expect( observers.resizeUnobserve ).toHaveBeenCalledWith( table );
+		} );
+
+		it( 'should share one IntersectionObserver and one ResizeObserver across all elements', () => {
+			const bodyContent = createBodyContent(
+				'<table class="wikitable"></table><table class="wikitable"></table>'
+			);
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			expect( observers.IntersectionObserver ).toHaveBeenCalledTimes( 1 );
+			expect( observers.ResizeObserver ).toHaveBeenCalledTimes( 1 );
+			const tables = bodyContent.querySelectorAll( 'table.wikitable' );
+			expect( observers.intersectionObserve ).toHaveBeenCalledWith( tables[ 0 ] );
+			expect( observers.intersectionObserve ).toHaveBeenCalledWith( tables[ 1 ] );
+		} );
+
+		it( 'should not sync sticky header columns until the resize observer fires', () => {
+			const bodyContent = createBodyContent( `
+				<table class="wikitable">
+					<thead>
+						<tr class="citizen-overflow-sticky-header">
+							<th>Column 1</th>
+							<th>Column 2</th>
+						</tr>
+					</thead>
+				</table>
+			` );
+			const table = bodyContent.querySelector( 'table' );
+			const ths = table.querySelectorAll( 'th' );
+			const boundingRectSpies = [];
+			ths.forEach( ( th ) => {
+				const spy = vi.fn( () => ( { width: 120 } ) );
+				th.getBoundingClientRect = spy;
+				boundingRectSpies.push( spy );
+			} );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			// No column measurement at boot
+			boundingRectSpies.forEach( ( spy ) => {
+				expect( spy ).not.toHaveBeenCalled();
+			} );
+
+			observers.getIntersectionCallback()( [ { isIntersecting: true, target: table } ] );
+			observers.getResizeCallback()( [ { target: table } ] );
+
+			boundingRectSpies.forEach( ( spy ) => {
+				expect( spy ).toHaveBeenCalled();
+			} );
+			const cols = document.querySelectorAll( '.citizen-overflow-content-sticky-header col' );
+			expect( cols ).toHaveLength( 2 );
+			expect( cols[ 0 ].style.minWidth ).toBe( '120px' );
+			expect( cols[ 1 ].style.minWidth ).toBe( '120px' );
+		} );
+
+		it( 'should batch all column reads before any column writes across tables', () => {
+			const stickyTable = `
+				<table class="wikitable">
+					<thead>
+						<tr class="citizen-overflow-sticky-header">
+							<th>A</th>
+							<th>B</th>
+						</tr>
+					</thead>
+				</table>
+			`;
+			const bodyContent = createBodyContent( stickyTable + stickyTable );
+			const tables = bodyContent.querySelectorAll( 'table.wikitable' );
+			const log = [];
+			tables.forEach( ( table ) => {
+				table.querySelectorAll( 'th' ).forEach( ( th ) => {
+					th.getBoundingClientRect = () => {
+						log.push( 'read' );
+						return { width: 100 };
+					};
+				} );
+			} );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			const cols = document.querySelectorAll( '.citizen-overflow-content-sticky-header col' );
+			cols.forEach( ( col ) => {
+				vi.spyOn( col.style, 'setProperty' ).mockImplementation( () => {
+					log.push( 'write' );
+				} );
+			} );
+
+			observers.getIntersectionCallback()( [
+				{ isIntersecting: true, target: tables[ 0 ] },
+				{ isIntersecting: true, target: tables[ 1 ] }
+			] );
+			observers.getResizeCallback()( [
+				{ target: tables[ 0 ] },
+				{ target: tables[ 1 ] }
+			] );
+
+			expect( log.filter( ( e ) => e === 'read' ) ).toHaveLength( 4 );
+			expect( log.filter( ( e ) => e === 'write' ) ).toHaveLength( 4 );
+			// Every geometry read happens before the first style write
+			expect( log.indexOf( 'write' ) ).toBeGreaterThan( log.lastIndexOf( 'read' ) );
+		} );
+
 		it( 'should handle only navButton clicks and distinguish left from right', () => {
 			const bodyContent = createBodyContent( '<table class="wikitable"></table>' );
 			const rAF = vi.fn( ( cb ) => cb() );
@@ -339,6 +545,11 @@ describe( 'overflowElements', () => {
 				config
 			} );
 
+			// Nav click listeners bind on intersection
+			observers.getIntersectionCallback()( [
+				{ isIntersecting: true, target: bodyContent.querySelector( 'table' ) }
+			] );
+
 			const contentEl = document.querySelector( '.citizen-overflow-content' );
 			const wrapperEl = document.querySelector( '.citizen-overflow-wrapper' );
 			const navEl = document.querySelector( '.citizen-overflow-nav' );
@@ -353,8 +564,6 @@ describe( 'overflowElements', () => {
 
 			navEl.dispatchEvent( new Event( 'click', { bubbles: false } ) );
 
-			// rAF is also called by createOverflowState.updateState during resume,
-			// so check that no scroll happened
 			expect( contentEl.scrollLeft ).toBe( 100 );
 
 			// Click on the right navButton — should scroll right


### PR DESCRIPTION
## What

Overflow-element wrapping used to eagerly measure every table at page load: per table, DOM writes (wrapper insertion) interleaved with geometry reads (`getBoundingClientRect` per `<th>` for sticky headers, `scrollWidth`/`offsetWidth` for scroll state), forcing roughly one synchronous reflow per table before the page became interactive — 50 ms attributed to `hasStateChanged` in a 4× CPU-throttled trace. Off-screen tables paid the full cost for nothing, and each table created its own IntersectionObserver + ResizeObserver pair.

Now:

- `init()` performs DOM writes only — zero geometry reads at boot.
- One shared IntersectionObserver + one shared ResizeObserver serve all overflow elements (WeakMap dispatch). Off-screen tables are never measured; they activate via the IntersectionObserver when scrolled into view, and the ResizeObserver's guaranteed initial delivery performs the first measurement.
- The resize callback batches all geometry reads (scroll state + column measurement) ahead of all style writes, so a delivery for N tables costs one layout pass instead of N. `syncColumns` is split into `measureColumns()` (reads) / `applyColumns()` (writes) accordingly.
- Incidental cleanup: the old eager `resume()` in `init()` ran a second time from the observer's initial callback; that duplication is gone.

## Verification

- TDD: 7 new Vitest cases (deferral, never-intersecting elements, shared observers, deferred column sync, read/write batching, mixed sticky/non-sticky batch alignment, repeated-intersection idempotence); 3 existing tests updated because IntersectionObserver entries now carry `target`. Full suite: 1025 passing.
- Browser-verified on a 2-table test page (wide sticky-header tables above and below the fold), debug and production bundles: below-fold table stays completely unmeasured until scrolled into view; columns re-sync on real table resize (72→807 px); nav buttons and edge-gradient classes behave as before; console clean.
- Re-traced under 4× CPU + Fast 4G throttle: overflow code no longer appears in the forced-reflow attribution.

## Follow-up (pre-existing, not introduced here)

Observer generations are never disconnected across `wikipage.content` re-fires (VE saves). This predates the change — the old design leaked 2×N observers per generation, now it is at most 2 — and is now trivial to fix by disconnecting the previous pair at the top of `init()`. Flagged during review; worth a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKjzET2kZLfQyC4xJgMvSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overflow handling for sticky table headers, including more consistent column sizing during window resizing.
  * Reduced unnecessary measurements and updates for overflow elements that are not currently visible.
  * Improved listener and resize observation behavior when elements enter or leave the viewport.

* **Performance**
  * Optimized processing when multiple overflow elements are present by coordinating resize and layout updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->