### PR TITLE
fix(overflowElements): disconnect stale observers when content is replaced

### DIFF
--- a/resources/skins.citizen.scripts/overflowElements/index.js
+++ b/resources/skins.citizen.scripts/overflowElements/index.js
@@ -157,7 +157,20 @@ class OverflowElement {
 }
 
 /**
+ * The observer pair serving the current content generation. Held so a
+ * re-init can disconnect it — the observers otherwise keep the replaced
+ * generation's elements (and through them the detached DOM) alive.
+ *
+ * @type {{intersectionObserver: IntersectionObserver, resizeObserver: ResizeObserver}|null}
+ */
+let activeObservers = null;
+
+/**
  * Initialize overflow element enhancements for all matching elements.
+ *
+ * Runs once per wikipage.content fire — content is replaced (e.g. after a
+ * VisualEditor save), so the previous generation's observers are
+ * disconnected before the new content is processed.
  *
  * All elements share a single IntersectionObserver and a single
  * ResizeObserver. Entries arrive batched, so the resize callback can group
@@ -177,6 +190,12 @@ function init( {
 	document, window, mw, IntersectionObserver, ResizeObserver,
 	bodyContent, config
 } ) {
+	if ( activeObservers ) {
+		activeObservers.intersectionObserver.disconnect();
+		activeObservers.resizeObserver.disconnect();
+		activeObservers = null;
+	}
+
 	const nowrapClasses = config.wgCitizenOverflowNowrapClasses;
 	if ( !nowrapClasses || !Array.isArray( nowrapClasses ) ) {
 		mw.log.error(
@@ -254,6 +273,8 @@ function init( {
 		instances.set( instance.element, instance );
 		intersectionObserver.observe( instance.element );
 	} );
+
+	activeObservers = { intersectionObserver, resizeObserver };
 }
 
 module.exports = {

--- a/tests/vitest/skins.citizen.scripts/overflowElements.test.js
+++ b/tests/vitest/skins.citizen.scripts/overflowElements.test.js
@@ -55,19 +55,25 @@ function createConfig( overrides = {} ) {
 function createMockObservers() {
 	let intersectionCallback;
 	const intersectionObserve = vi.fn();
+	const intersectionInstances = [];
 	// Must use function (not arrow) so it can be called with new
 	const MockIntersectionObserver = vi.fn( function ( cb ) {
 		intersectionCallback = cb;
 		this.observe = intersectionObserve;
+		this.disconnect = vi.fn();
+		intersectionInstances.push( this );
 	} );
 
 	let resizeCallback;
 	const resizeObserve = vi.fn();
 	const resizeUnobserve = vi.fn();
+	const resizeInstances = [];
 	const MockResizeObserver = vi.fn( function ( cb ) {
 		resizeCallback = cb;
 		this.observe = resizeObserve;
 		this.unobserve = resizeUnobserve;
+		this.disconnect = vi.fn();
+		resizeInstances.push( this );
 	} );
 
 	return {
@@ -76,8 +82,10 @@ function createMockObservers() {
 		getIntersectionCallback: () => intersectionCallback,
 		getResizeCallback: () => resizeCallback,
 		intersectionObserve,
+		intersectionInstances,
 		resizeObserve,
-		resizeUnobserve
+		resizeUnobserve,
+		resizeInstances
 	};
 }
 
@@ -600,6 +608,65 @@ describe( 'overflowElements', () => {
 			expect( handlers[ 0 ] ).toBe( handlers[ 1 ] );
 			expect( observers.resizeObserve ).toHaveBeenCalledTimes( 2 );
 			expect( observers.resizeObserve ).toHaveBeenNthCalledWith( 2, table );
+		} );
+
+		// Note: overflowElements keeps its current observer pair in module
+		// state that persists across tests (matching the production
+		// ResourceLoader singleton). The first init() in a test may therefore
+		// disconnect a pair left behind by an earlier test — assertions here
+		// only use this test's own mock instances, so that bleed is inert.
+		it( 'should disconnect the previous generation of observers on re-init', () => {
+			const observers = createMockObservers();
+			const deps = {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				config: createConfig()
+			};
+			const firstContent = createBodyContent( '<table class="wikitable"></table>' );
+
+			init( { ...deps, bodyContent: firstContent } );
+
+			// Simulate a wikipage.content re-fire with replaced content
+			firstContent.remove();
+			const secondContent = createBodyContent( '<table class="wikitable"></table>' );
+
+			init( { ...deps, bodyContent: secondContent } );
+
+			expect( observers.intersectionInstances ).toHaveLength( 2 );
+			expect( observers.intersectionInstances[ 0 ].disconnect ).toHaveBeenCalled();
+			expect( observers.resizeInstances[ 0 ].disconnect ).toHaveBeenCalled();
+			// The live generation stays connected
+			expect( observers.intersectionInstances[ 1 ].disconnect ).not.toHaveBeenCalled();
+			expect( observers.resizeInstances[ 1 ].disconnect ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should disconnect previous observers even when new content has no overflow elements', () => {
+			const observers = createMockObservers();
+			const deps = {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				config: createConfig()
+			};
+			const firstContent = createBodyContent( '<table class="wikitable"></table>' );
+
+			init( { ...deps, bodyContent: firstContent } );
+
+			firstContent.remove();
+			const emptyContent = createBodyContent( '<p>No tables here</p>' );
+
+			init( { ...deps, bodyContent: emptyContent } );
+
+			// No new generation is constructed, but the old one is torn down
+			expect( observers.intersectionInstances ).toHaveLength( 1 );
+			expect( observers.resizeInstances ).toHaveLength( 1 );
+			expect( observers.intersectionInstances[ 0 ].disconnect ).toHaveBeenCalled();
+			expect( observers.resizeInstances[ 0 ].disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should handle only navButton clicks and distinguish left from right', () => {


### PR DESCRIPTION
## What

Follow-up flagged in #1659's review. `overflowElements.init()` runs on every `wikipage.content` fire — initial load, and again whenever content is replaced (VisualEditor saves, live preview). Each re-fire created a fresh shared IntersectionObserver + ResizeObserver pair without tearing down the previous one, and the old IntersectionObserver retains strong references to the replaced generation's tables — pinning each detached content DOM generation until page unload. The leak predates the shared observers (the old per-element design leaked 2×N observers per generation); sharing just made it cheap to fix.

`init()` now keeps a module-level handle to the current pair and disconnects it at the very top — before config validation and the element query, so teardown also happens when the replacement content has no overflow elements at all. The new pair is registered only after wiring completes, so no early-return path can leave a constructed-but-untracked pair, and a disconnect can never hit the live generation.

## Verification

- TDD: two new tests (watched failing first) — previous generation disconnected on re-init while the live generation stays connected, and teardown still happens when the new content has no overflow elements. Mock observers extended with per-construction instance tracking. Full suite: 1030 passing.
- Browser-verified with the real re-init sequence (fetch `action=parse` HTML, swap into `#mw-content-text`, re-fire `wikipage.content` — the same sequence MediaWiki runs after a VE save): fresh content wraps exactly once with no nested wrappers, the new generation activates on intersection, syncs sticky columns, and responds to viewport resize. Console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKjzET2kZLfQyC4xJgMvSS