### PR TITLE
perf(tableOfContents): keep section activation from forcing page reflows

### DIFF
--- a/resources/skins.citizen.scripts/setupObservers.js
+++ b/resources/skins.citizen.scripts/setupObservers.js
@@ -130,15 +130,21 @@ const setupTableOfContents = (
 	} );
 	const elements = () => bodyContent.querySelectorAll( `${ HEADING_SELECTOR }, .mw-body-content` );
 
+	// Whether the scroll spy has activated any section yet. The initial
+	// activation is deferred to idle (see below); once the spy has fired,
+	// its live state is authoritative and the deferred pass must not run.
+	let sectionsActivated = false;
+
 	const sectionObserver = createSectionObserver( {
 		window,
 		mw,
 		IntersectionObserver,
 		elements: elements(),
 		topMargin: getDocumentScrollPaddingTop( window, document ),
-		onIntersection: getHeadingIntersectionHandler(
-			tableOfContents.changeActiveSections.bind( tableOfContents )
-		)
+		onIntersection: getHeadingIntersectionHandler( ( ids ) => {
+			sectionsActivated = true;
+			tableOfContents.changeActiveSections( ids );
+		} )
 	} );
 	const updateElements = () => {
 		sectionObserver.resume();
@@ -228,7 +234,20 @@ const setupTableOfContents = (
 		}
 	};
 
-	setInitialActiveSection();
+	// The boot idle tasks flip document-level classes (performance mode,
+	// animations-ready) and append to <body>; geometry reads issued before
+	// those writes are painted force a full-page reflow. Run the initial
+	// activation at idle plus one frame so its reads land on clean layout.
+	mw.requestIdleCallback( () => {
+		deferUntilFrame( () => {
+			// If the user scrolled or clicked in the meantime, the spy's
+			// live state wins — the boot-time hash heuristic (T325086)
+			// would activate a stale target.
+			if ( !sectionsActivated ) {
+				setInitialActiveSection();
+			}
+		}, 1 );
+	}, { timeout: 3000 } );
 
 	return tableOfContents;
 };

--- a/resources/skins.citizen.scripts/tableOfContents.js
+++ b/resources/skins.citizen.scripts/tableOfContents.js
@@ -245,12 +245,16 @@ class TableOfContents {
 		}
 
 		// Defer geometry reads to the next frame so class mutations above
-		// don't force a synchronous layout reflow.
+		// don't force a synchronous layout reflow, and batch both measure
+		// phases ahead of both apply phases so the writes (the unit-height
+		// custom property affects layout) never sit between reads.
 		this.window.requestAnimationFrame( () => {
-			this.updateIndicatorBar();
-			if ( ids.length > 0 ) {
-				this.scrollToActiveSection( ids[ 0 ] );
-			}
+			const indicatorMetrics = this.measureIndicator();
+			const scrollAdjustment = ids.length > 0 ?
+				this.measureScrollAdjustment( ids[ 0 ] ) :
+				null;
+			this.applyIndicator( indicatorMetrics );
+			this.applyScrollAdjustment( scrollAdjustment );
 		} );
 	}
 
@@ -279,65 +283,90 @@ class TableOfContents {
 	}
 
 	/**
-	 * Cache the unit height (one link row) for scaleY calculation.
+	 * Measure everything the indicator bar update needs. Geometry reads
+	 * only — callers can batch this ahead of any write phase.
 	 *
-	 * @param {HTMLElement} link A visible link element to measure.
+	 * @return {Object|null} Metrics for applyIndicator(), or null when
+	 * there is no indicator bar.
 	 */
-	cacheIndicatorUnitHeight( link ) {
-		if ( this.indicatorUnitHeight ) {
-			return;
-		}
-		this.indicatorUnitHeight = link.getBoundingClientRect().height;
-		if ( this.indicatorUnitHeight > 0 ) {
-			this.indicatorBar.style.setProperty(
-				'--indicator-unit-height', this.indicatorUnitHeight + 'px'
-			);
-		}
-	}
-
-	/**
-	 * Update the indicator bar position and height based on active sections.
-	 */
-	updateIndicatorBar() {
+	measureIndicator() {
 		if ( !this.indicatorBar ) {
-			return;
+			return null;
 		}
 		if ( this.activeIds.size === 0 ) {
-			this.indicatorBar.style.setProperty( '--indicator-scale', '0' );
-			return;
+			return { hide: true };
 		}
 
 		const { first: firstLink, last: lastLink } = this.getActiveLinks();
 		if ( !firstLink || !lastLink ) {
-			this.indicatorBar.style.setProperty( '--indicator-scale', '0' );
-			return;
+			return { hide: true };
 		}
 
-		this.cacheIndicatorUnitHeight( firstLink );
+		const unitHeight = this.indicatorUnitHeight ||
+			firstLink.getBoundingClientRect().height;
 
 		// Use the indicator's offset parent (its CSS positioning context) as reference
 		const positioningParent = this.indicatorBar.offsetParent || this.props.container;
 		const containerRect = positioningParent.getBoundingClientRect();
 		const firstRect = firstLink.getBoundingClientRect();
 		const lastRect = lastLink.getBoundingClientRect();
-		const top = firstRect.top - containerRect.top + positioningParent.scrollTop;
-		const height = lastRect.bottom - firstRect.top;
-		const scale = this.indicatorUnitHeight > 0 ?
-			height / this.indicatorUnitHeight : 0;
 
-		this.indicatorBar.style.setProperty( '--indicator-top', top + 'px' );
+		return {
+			hide: false,
+			unitHeight,
+			top: firstRect.top - containerRect.top + positioningParent.scrollTop,
+			height: lastRect.bottom - firstRect.top
+		};
+	}
+
+	/**
+	 * Apply previously measured indicator metrics. Style writes only.
+	 *
+	 * @param {Object|null} metrics Result of measureIndicator().
+	 */
+	applyIndicator( metrics ) {
+		if ( !metrics ) {
+			return;
+		}
+		if ( metrics.hide ) {
+			this.indicatorBar.style.setProperty( '--indicator-scale', '0' );
+			return;
+		}
+
+		// Cache the unit height (one link row) for scaleY calculation
+		if ( !this.indicatorUnitHeight && metrics.unitHeight > 0 ) {
+			this.indicatorUnitHeight = metrics.unitHeight;
+			this.indicatorBar.style.setProperty(
+				'--indicator-unit-height', metrics.unitHeight + 'px'
+			);
+		}
+
+		const scale = this.indicatorUnitHeight > 0 ?
+			metrics.height / this.indicatorUnitHeight : 0;
+
+		this.indicatorBar.style.setProperty( '--indicator-top', metrics.top + 'px' );
 		this.indicatorBar.style.setProperty( '--indicator-scale', String( scale ) );
 	}
 
 	/**
-	 * Scroll active section into view if necessary
+	 * Update the indicator bar position and height based on active sections.
+	 */
+	updateIndicatorBar() {
+		this.applyIndicator( this.measureIndicator() );
+	}
+
+	/**
+	 * Measure whether and how far the ToC container needs scrolling to keep
+	 * the active section visible. Geometry reads only.
 	 *
 	 * @param {string} id The id of the element to be scrolled to in the Table of Contents.
+	 * @return {Object|null} Adjustment for applyScrollAdjustment(), or null
+	 * when no scrolling is needed.
 	 */
-	scrollToActiveSection( id ) {
+	measureScrollAdjustment( id ) {
 		const section = this.document.getElementById( id );
 		if ( !section ) {
-			return;
+			return null;
 		}
 
 		// Get currently visible active link
@@ -355,37 +384,71 @@ class TableOfContents {
 
 		const isContainerScrollable = this.props.container.scrollHeight >
 			this.props.container.clientHeight;
-		if ( link && isContainerScrollable ) {
-			const containerRect = this.props.container.getBoundingClientRect();
-			const linkRect = link.getBoundingClientRect();
+		if ( !link || !isContainerScrollable ) {
+			return null;
+		}
 
-			// Pixels above or below the TOC where we start scrolling the active section into view
-			const hiddenThreshold = 100;
-			const midpoint = ( containerRect.bottom - containerRect.top ) / 2;
-			const linkHiddenTopValue = containerRect.top - linkRect.top;
+		const containerRect = this.props.container.getBoundingClientRect();
+		const linkRect = link.getBoundingClientRect();
+
+		return {
+			midpoint: ( containerRect.bottom - containerRect.top ) / 2,
+			linkHiddenTopValue: containerRect.top - linkRect.top,
 			// Because the bottom of the TOC can extend below the viewport,
 			// min() is used to find the value where the active section first becomes hidden
-			const linkHiddenBottomValue = linkRect.bottom -
-				Math.min( containerRect.bottom, this.window.innerHeight );
+			linkHiddenBottomValue: linkRect.bottom -
+				Math.min( containerRect.bottom, this.window.innerHeight ),
+			scrollTop: this.props.container.scrollTop
+		};
+	}
 
-			// Respect 'prefers-reduced-motion' user preference
-			const scrollBehavior = this.prefersReducedMotion() ? undefined : 'smooth';
-
-			// Manually increment and decrement TOC scroll rather than using scrollToView
-			// in order to account for threshold
-			if ( linkHiddenTopValue + hiddenThreshold > 0 ) {
-				this.props.container.scrollTo( {
-					top: this.props.container.scrollTop - linkHiddenTopValue - midpoint,
-					behavior: scrollBehavior
-				} );
-			}
-			if ( linkHiddenBottomValue + hiddenThreshold > 0 ) {
-				this.props.container.scrollTo( {
-					top: this.props.container.scrollTop + linkHiddenBottomValue + midpoint,
-					behavior: scrollBehavior
-				} );
-			}
+	/**
+	 * Apply a previously measured scroll adjustment. No geometry reads.
+	 *
+	 * @param {Object|null} adjustment Result of measureScrollAdjustment().
+	 */
+	applyScrollAdjustment( adjustment ) {
+		if ( !adjustment ) {
+			return;
 		}
+
+		const { linkHiddenTopValue, linkHiddenBottomValue, midpoint } = adjustment;
+		// Pixels above or below the TOC where we start scrolling the active section into view
+		const hiddenThreshold = 100;
+		// Respect 'prefers-reduced-motion' user preference
+		const scrollBehavior = this.prefersReducedMotion() ? undefined : 'smooth';
+		// Track the target instead of re-reading scrollTop between the two
+		// adjustments so this phase stays free of geometry reads. When both
+		// adjustments fire with instant scrolling, the chained value skips
+		// the browser's clamping of the first jump — a few pixels off, only
+		// reachable with a scrollable container shorter than the threshold.
+		let targetTop = adjustment.scrollTop;
+
+		// Manually increment and decrement TOC scroll rather than using scrollToView
+		// in order to account for threshold
+		if ( linkHiddenTopValue + hiddenThreshold > 0 ) {
+			targetTop = targetTop - linkHiddenTopValue - midpoint;
+			this.props.container.scrollTo( {
+				top: targetTop,
+				behavior: scrollBehavior
+			} );
+		}
+		if ( linkHiddenBottomValue + hiddenThreshold > 0 ) {
+			targetTop = targetTop + linkHiddenBottomValue + midpoint;
+			this.props.container.scrollTo( {
+				top: targetTop,
+				behavior: scrollBehavior
+			} );
+		}
+	}
+
+	/**
+	 * Scroll active section into view if necessary
+	 *
+	 * @param {string} id The id of the element to be scrolled to in the Table of Contents.
+	 */
+	scrollToActiveSection( id ) {
+		this.applyScrollAdjustment( this.measureScrollAdjustment( id ) );
 	}
 
 	/**

--- a/tests/vitest/skins.citizen.scripts/setupObservers.test.js
+++ b/tests/vitest/skins.citizen.scripts/setupObservers.test.js
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+/* global document */
+
+const setupObservers = require( '../../../resources/skins.citizen.scripts/setupObservers.js' );
+const mw = require( '../mocks/mw.js' );
+
+/**
+ * Minimal ToC + article fixture: one top-level section whose heading
+ * carries the id the location hash points at.
+ *
+ * @return {{ tocItem: HTMLElement }}
+ */
+function createFixture() {
+	document.body.innerHTML = `
+		<div id="citizen-toc">
+			<div class="citizen-toc-indicator"></div>
+			<ul id="mw-panel-toc-list">
+				<li id="toc-s1" class="citizen-toc-list-item citizen-toc-level-1">
+					<a class="citizen-toc-link" href="#s1">Section 1</a>
+					<button class="citizen-toc-toggle"></button>
+				</li>
+				<li id="toc-s2" class="citizen-toc-list-item citizen-toc-level-1">
+					<a class="citizen-toc-link" href="#s2">Section 2</a>
+					<button class="citizen-toc-toggle"></button>
+				</li>
+			</ul>
+		</div>
+		<div id="bodyContent">
+			<div class="mw-parser-output">
+				<div class="mw-heading"><h2 id="s1">Section 1</h2></div>
+				<div class="mw-heading"><h2 id="s2">Section 2</h2></div>
+			</div>
+		</div>
+		<div id="citizen-page-header-sticky-sentinel"></div>
+	`;
+	return {
+		tocItem: document.getElementById( 'toc-s1' ),
+		tocItem2: document.getElementById( 'toc-s2' ),
+		heading2: document.querySelectorAll( '.mw-heading' )[ 1 ]
+	};
+}
+
+describe( 'setupObservers', () => {
+	let rafQueue;
+	let idleCallbacks;
+	let win;
+
+	function flushFrame() {
+		rafQueue.splice( 0 ).forEach( ( cb ) => cb() );
+	}
+
+	function createMockWindow() {
+		return {
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			location: { hash: '#s1' },
+			innerHeight: 800,
+			scrollY: 0,
+			matchMedia: vi.fn( () => ( {
+				// Desktop breakpoint matches so the scroll spy is active
+				matches: true,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn()
+			} ) ),
+			getComputedStyle: vi.fn( () => ( {
+				getPropertyValue: vi.fn( () => '75' )
+			} ) ),
+			requestAnimationFrame: vi.fn( ( cb ) => cb() )
+		};
+	}
+
+	beforeEach( () => {
+		rafQueue = [];
+		// deferUntilFrame uses the global requestAnimationFrame
+		vi.stubGlobal( 'requestAnimationFrame', ( cb ) => {
+			rafQueue.push( cb );
+			return rafQueue.length;
+		} );
+
+		idleCallbacks = [];
+		mw.requestIdleCallback = vi.fn( ( cb ) => {
+			idleCallbacks.push( cb );
+		} );
+	} );
+
+	afterEach( () => {
+		[ 've.activationStart', 've.deactivationComplete', 'wikipage.tableOfContents' ]
+			.forEach( ( name ) => mw.hook( name )._reset() );
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'should defer initial section activation until idle plus one frame', () => {
+		const { tocItem } = createFixture();
+		win = createMockWindow();
+		mw.util.getTargetFromFragment = vi.fn( () => tocItem );
+		const MockIntersectionObserver = vi.fn( function () {
+			this.observe = vi.fn();
+			this.unobserve = vi.fn();
+			this.disconnect = vi.fn();
+		} );
+
+		setupObservers.init( {
+			document,
+			window: win,
+			mw,
+			IntersectionObserver: MockIntersectionObserver
+		} );
+
+		// Boot idle tasks dirty document-level state; reading TOC geometry
+		// before they are painted forces a full-page reflow. Nothing may
+		// activate synchronously.
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--expanded' ) ).toBe( false );
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( false );
+		expect( idleCallbacks.length ).toBeGreaterThan( 0 );
+
+		idleCallbacks.forEach( ( cb ) => cb() );
+
+		// Still waiting for the post-idle frame
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( false );
+
+		flushFrame();
+
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--expanded' ) ).toBe( true );
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( true );
+	} );
+
+	it( 'should defer the hash-less initial intersection calculation to idle plus one frame', () => {
+		createFixture();
+		win = createMockWindow();
+		win.location.hash = '';
+		const ioInstances = [];
+		const MockIntersectionObserver = vi.fn( function ( cb ) {
+			this.cb = cb;
+			this.observe = vi.fn();
+			this.unobserve = vi.fn();
+			this.disconnect = vi.fn();
+			ioInstances.push( this );
+		} );
+
+		setupObservers.init( {
+			document,
+			window: win,
+			mw,
+			IntersectionObserver: MockIntersectionObserver
+		} );
+
+		// The section observer (first constructed) only observes elements when
+		// calcIntersection runs — which must wait for idle plus one frame
+		const sectionSpyIo = ioInstances[ 0 ];
+		expect( sectionSpyIo.observe ).not.toHaveBeenCalled();
+
+		idleCallbacks.forEach( ( cb ) => cb() );
+		expect( sectionSpyIo.observe ).not.toHaveBeenCalled();
+
+		flushFrame();
+
+		expect( sectionSpyIo.observe ).toHaveBeenCalled();
+	} );
+
+	it( 'should skip the deferred initial activation when the scroll spy has already fired', () => {
+		const { tocItem, tocItem2, heading2 } = createFixture();
+		win = createMockWindow();
+		// Page loaded with a hash pointing at section 1
+		win.location.hash = '#s1';
+		mw.util.getTargetFromFragment = vi.fn( () => tocItem );
+		const ioInstances = [];
+		const MockIntersectionObserver = vi.fn( function ( cb ) {
+			this.cb = cb;
+			this.observe = vi.fn();
+			this.unobserve = vi.fn();
+			this.disconnect = vi.fn();
+			ioInstances.push( this );
+		} );
+
+		setupObservers.init( {
+			document,
+			window: win,
+			mw,
+			IntersectionObserver: MockIntersectionObserver
+		} );
+
+		// Before idle fires, the user scrolls and the spy activates section 2
+		ioInstances[ 0 ].cb( [
+			{ target: heading2, boundingClientRect: { top: 10 } }
+		] );
+		expect( tocItem2.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( true );
+
+		idleCallbacks.forEach( ( cb ) => cb() );
+		flushFrame();
+
+		// The stale boot-time hash target must not clobber the live spy state
+		expect( tocItem2.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( true );
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( false );
+	} );
+
+	it( 'should not activate at idle on narrow viewports where the spy is paused', () => {
+		const { tocItem } = createFixture();
+		win = createMockWindow();
+		// Below the desktop breakpoint the ToC popover is collapsed
+		win.matchMedia = vi.fn( () => ( {
+			matches: false,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn()
+		} ) );
+		mw.util.getTargetFromFragment = vi.fn( () => tocItem );
+		const MockIntersectionObserver = vi.fn( function () {
+			this.observe = vi.fn();
+			this.unobserve = vi.fn();
+			this.disconnect = vi.fn();
+		} );
+
+		setupObservers.init( {
+			document,
+			window: win,
+			mw,
+			IntersectionObserver: MockIntersectionObserver
+		} );
+		idleCallbacks.forEach( ( cb ) => cb() );
+		flushFrame();
+
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( false );
+	} );
+} );

--- a/tests/vitest/skins.citizen.scripts/tableOfContents.test.js
+++ b/tests/vitest/skins.citizen.scripts/tableOfContents.test.js
@@ -500,6 +500,105 @@ describe( 'TableOfContents', () => {
 		} );
 	} );
 
+	describe( 'activation read/write batching', () => {
+		/**
+		 * Instrument an element property with a logging getter.
+		 *
+		 * @param {HTMLElement} el
+		 * @param {string} prop
+		 * @param {*} value
+		 * @param {string[]} log
+		 */
+		function logGetter( el, prop, value, log ) {
+			Object.defineProperty( el, prop, {
+				configurable: true,
+				get() {
+					log.push( 'read' );
+					return value;
+				}
+			} );
+		}
+
+		/**
+		 * @param {HTMLElement} el
+		 * @param {Object} rect
+		 * @param {string[]} log
+		 */
+		function logRect( el, rect, log ) {
+			el.getBoundingClientRect = () => {
+				log.push( 'read' );
+				return rect;
+			};
+		}
+
+		it( 'should perform every geometry read before any style write on activation', () => {
+			const { container } = renderTocDom();
+			const toc = createToc( container );
+			const log = [];
+
+			// Scrollable container so the scroll-into-view path also engages
+			logGetter( container, 'scrollHeight', 1000, log );
+			logGetter( container, 'clientHeight', 200, log );
+			Object.defineProperty( container, 'scrollTop', { value: 0, configurable: true } );
+			container.scrollTo = () => {
+				log.push( 'write' );
+			};
+			logRect( container, { top: 100, bottom: 300, left: 0, right: 200 }, log );
+
+			Object.defineProperty( toc.indicatorBar, 'offsetParent', {
+				configurable: true,
+				get() {
+					log.push( 'read' );
+					return container;
+				}
+			} );
+			vi.spyOn( toc.indicatorBar.style, 'setProperty' ).mockImplementation( () => {
+				log.push( 'write' );
+			} );
+
+			const link1 = document.querySelector( '#toc-section1 > .citizen-toc-link' );
+			const link2 = document.querySelector( '#toc-section2 > .citizen-toc-link' );
+			logGetter( link1, 'offsetParent', container, log );
+			logGetter( link2, 'offsetParent', container, log );
+			logRect( link1, { top: 110, bottom: 130, height: 20, left: 0, right: 200 }, log );
+			logRect( link2, { top: 140, bottom: 160, height: 20, left: 0, right: 200 }, log );
+
+			toc.changeActiveSections( [ 'toc-section1', 'toc-section2' ] );
+
+			expect( log.filter( ( e ) => e === 'read' ).length ).toBeGreaterThan( 0 );
+			expect( log.filter( ( e ) => e === 'write' ).length ).toBeGreaterThan( 0 );
+			// Interleaved reads after writes force extra reflows per activation
+			expect( log.indexOf( 'write' ) ).toBeGreaterThan( log.lastIndexOf( 'read' ) );
+		} );
+
+		it( 'should write the indicator unit height only on first activation', () => {
+			const { container } = renderTocDom();
+			const toc = createToc( container );
+
+			Object.defineProperty( toc.indicatorBar, 'offsetParent', { value: container } );
+			container.getBoundingClientRect = vi.fn( () => ( {
+				top: 100, bottom: 500, left: 0, right: 200
+			} ) );
+			Object.defineProperty( container, 'scrollTop', { value: 0, configurable: true } );
+			[ 'toc-section1', 'toc-section2' ].forEach( ( id ) => {
+				const link = document.querySelector( `#${ id } > .citizen-toc-link` );
+				Object.defineProperty( link, 'offsetParent', { value: container } );
+				link.getBoundingClientRect = vi.fn( () => ( {
+					top: 110, bottom: 130, height: 20, left: 0, right: 200
+				} ) );
+			} );
+
+			toc.changeActiveSections( [ 'toc-section1' ] );
+			const spy = vi.spyOn( toc.indicatorBar.style, 'setProperty' );
+			toc.changeActiveSections( [ 'toc-section2' ] );
+
+			const unitHeightWrites = spy.mock.calls.filter(
+				( call ) => call[ 0 ] === '--indicator-unit-height'
+			);
+			expect( unitHeightWrites ).toHaveLength( 0 );
+		} );
+	} );
+
 	describe( 'handleHashChange', () => {
 		it( 'should expand and activate section matching the hash', () => {
 			const { container } = renderTocDom();


### PR DESCRIPTION
## What

Follow-up to #1660: with the boot-path reflows gone, the last skin-attributed forced reflow was the table of contents activation path — 90–110 ms at 4× CPU throttle on a long desktop article, attributed to `getActiveLinks`. Two changes:

- **Measure/apply split.** The indicator update interleaved geometry reads with the layout-affecting `--indicator-unit-height` write (it drives the indicator's `height`; `--indicator-top`/`--indicator-scale` are transform-only), and the scroll-into-view pass read `scrollHeight`/rects again after the indicator writes. Both paths are now strict read-phase/write-phase pairs (`measureIndicator`/`applyIndicator`, `measureScrollAdjustment`/`applyScrollAdjustment`), and the activation frame batches every read ahead of every write. `updateIndicatorBar()`/`scrollToActiveSection()` remain as wrappers, so toggle clicks, resize, deactivation, and the VE reload path keep their contracts.
- **Initial activation waits for idle + one frame.** Honest empirical note: the batching alone did *not* move the measured number — the dominant cost was the activation's first geometry read paying for a document-wide layout dirtied by the boot idle tasks (performance-mode class flip, `animations-ready`, speculation-rules append, core's notification-area insertion). `setInitialActiveSection` now runs via `mw.requestIdleCallback` + one frame, after that churn is painted. The scroll spy still reacts immediately if the user scrolls sooner, and a `sectionsActivated` guard skips the deferred pass entirely once the spy has fired — the boot-time hash heuristic (T325086) is only safe to evaluate before user interaction, so live spy state always wins.

## Result

Throttled traces on a long article now show **zero forced reflow attributed to skin code** (previously `getActiveLinks` at 90–110 ms; only MediaWiki core's `mediawiki.notification` at ~36 ms remains). Together with #1659/#1660, every forced-reflow item from the frontend audit's JS boot path is cleared.

## Verification

- TDD: instrumented read/write ordering test (asserts every geometry read precedes the first style write during activation), unit-height single-write pin, no-hash idle-deferral timing test, narrow-viewport guard test, and a stale-hash clobber regression test (spy fires before idle → deferred pass must not override it). Full suite: 1036 passing.
- Live on the served production bundle: scroll-spy highlighting, indicator tracking (position + scale + one-time unit-height cache), TOC link clicks, `#hash` navigation (expand + activate + scroll), spy takeover after scrolling — all verified, console clean.
- Known micro-caveat, commented in code: with reduced motion (instant scrolling) and a scrollable ToC container shorter than the 100 px threshold, chained double scroll adjustments can differ from the old behavior by a few pixels (the write phase no longer re-reads `scrollTop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKjzET2kZLfQyC4xJgMvSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table of contents activation to prevent stale sections from overriding the user’s current position.
  * Deferred initial section activation for more reliable page loading and hash navigation.
  * Improved scrolling behavior, including reduced-motion support.
  * Optimized indicator updates for smoother table of contents interactions.

* **Tests**
  * Added coverage for deferred activation, scroll-spy behavior, narrow viewports, and activation rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->