### PR TITLE
fix(main-page): render the main page header after the content

### DIFF
--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -295,6 +295,11 @@ class SkinCitizen extends SkinMustache {
 		// above). Drives the notifications dropdown in Header.mustache.
 		$parentData['data-notifications'] = $this->notificationData;
 
+		// Scope matches the .page-Main_Page.action-view main-page styles.
+		// skin.mustache renders the page header after the content on the main
+		// page so its bottom placement holds from the first streamed paint.
+		$parentData['is-mainpage'] = $title->isMainPage() && $this->getActionName() === 'view';
+
 		$parentData['toc-enabled'] = !empty( $parentData['data-toc'][ 'array-sections' ] );
 		if ( $parentData['toc-enabled'] ) {
 			// This body class depends on template data so it can't move to

--- a/resources/skins.citizen.styles/common/content.less
+++ b/resources/skins.citizen.styles/common/content.less
@@ -29,14 +29,10 @@
 		display: none;
 	}
 
-	// Move header to the bottom of the page
-	#content {
-		display: flex;
-		flex-direction: column;
-	}
-
+	// The header renders after the content in skin.mustache, which puts it
+	// at the bottom of the page without a layout-shift-prone CSS reorder
 	.citizen-page-header {
-		order: 9999;
+		margin-top: calc( var( --space-xl ) * 2 );
 
 		&-inner {
 			justify-content: center;

--- a/templates/skin.mustache
+++ b/templates/skin.mustache
@@ -7,6 +7,7 @@
 	string html-body-content--formatted
 	string html-categories
 	string html-after-content
+	bool is-mainpage whether this is a view of the wiki's main page
 	object data-footer for footer template partial. see Footer.mustache for documentation.
 }}
 
@@ -14,7 +15,10 @@
 <div class="citizen-page-container">
 	<div class="citizen-sitenotice-container">{{{html-site-notice}}}</div>
 	<main class="mw-body" id="content">
-		{{>PageHeader}}
+		{{! On the main page the header renders below the content, so it is
+			emitted after it — matching DOM order to visual order keeps
+			mid-stream paints from shifting the header. }}
+		{{^is-mainpage}}{{>PageHeader}}{{/is-mainpage}}
 		<div class="citizen-body-container">
 			<div id="bodyContent" class="citizen-body" aria-labelledby="firstHeading">
 				<div id="contentSub"{{{html-user-language-attributes}}}>{{{html-subtitle}}}</div>
@@ -25,6 +29,7 @@
 			{{#toc-enabled}}{{>PageSidebar}}{{/toc-enabled}}
 			{{>PageFooter}}
 		</div>
+		{{#is-mainpage}}{{>PageHeader}}{{/is-mainpage}}
 	</main>
 	{{{html-after-content}}}
 	{{#data-footer}}{{>Footer}}{{/data-footer}}


### PR DESCRIPTION
## What

Closes out the frontend audit's CLS investigation. The main page places its page header (heading hidden; actions bar) at the bottom of the content area via a CSS-only reorder — `#content { display: flex }` + `.citizen-page-header { order: 9999 }` — while the header stays first in the DOM. That breaks streaming's append-only property: any paint that happens while the article HTML is still arriving renders the header at the top of the near-empty flex column, and it jumps below the content once parsing finishes. Measured as a 0.0946 layout shift on cold loads (reproduced at mobile width; structurally verified at desktop by simulating the mid-stream DOM: header lands 424 px above its settled position). It was the last meaningful CLS source in the skin — everything else measures ≤0.01, all font-swap related.

Two commits, intended for a **rebase merge** so they land separately — wikis deploying commit by commit can hold between them:

1. **Template reorder.** `skin.mustache` emits `{{>PageHeader}}` after the content container on main page views, driven by a new `is-mainpage` template flag (`Title::isMainPage()` + action `view`, mirroring the `.page-Main_Page.action-view` CSS scope exactly — since MW 1.43 core stamps `page-Main_Page` for any configured main page title, so the two stay in lockstep even on renamed main pages). The `order: 9999` rule is kept so cached pre-reorder HTML keeps its bottom placement.
2. **CSS reorder removal.** Drops the flex container and `order` rule; the header margin doubles to compensate for block-level margin collapsing, keeping the gap pixel-identical (verified at 500 px and 1440 px — header 522/496 px, doc height unchanged).

DOM order now matches visual order, which also removes a WCAG 1.3.2/2.4.3 source-vs-visual-order mismatch for keyboard and screen-reader users.

## Deploy note

Only wikis serving full pages from a CDN/edge cache can pair pre-reorder cached HTML with the commit-2 stylesheet (header renders at top until purge/expiry — purging the main page fixes it immediately). Without a full-page cache layer the reorder applies on the next request.

## Verification

- Main page DOM verified `[content, header, sentinel]` on view; header stays first on all other pages and on `?action=history` (flag correctly gated).
- Geometry pixel-identical to the flex layout at mobile and desktop widths after both commits.
- 4 cold-load probes with a pre-script `PerformanceObserver`: the 0.09 header shift is gone; only pre-existing font-swap micro-shifts (0.0003–0.011) remain, tracked separately.
- Sticky-header sentinel travels with the partial; it is `display: none` on the main page and the observer setup checks computed display — no behavior change.
- phpcs clean, 165 PHPUnit tests green, stylelint clean. (Phan reports two pre-existing `UnusedPluginSuppression` findings in an untouched file, reproducible without this change — local MW vs CI REL1_43 phan mismatch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKjzET2kZLfQyC4xJgMvSS