### PR TITLE
fix(sections): support collapsible sections on Parsoid pages

### DIFF
--- a/includes/Components/CitizenComponentBodyContent.php
+++ b/includes/Components/CitizenComponentBodyContent.php
@@ -18,6 +18,11 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	/**
 	 * The code below is largely based on the extension MobileFrontend
 	 * All credits go to the author and contributors of the project
+	 *
+	 * Core also has ParserOptions::setCollapsibleSections() (1.42+), which
+	 * wraps legacy-parser section contents in plain divs at parse time.
+	 * Nothing sets it by default and its wrappers carry no class to target,
+	 * so this transform stays; revisit if core ever enables it.
 	 */
 
 	/**
@@ -191,12 +196,25 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	}
 
 	/**
+	 * Whether the HTML was rendered by Parsoid, which wraps sections natively
+	 * in `<section data-mw-section-id>` elements. The tag-open form cannot
+	 * occur in user content: the sanitizer strips data-mw-* attributes from
+	 * wikitext, and escaped markup in code samples never contains a raw `<`.
+	 */
+	private function isParsoidContent( string $html ): bool {
+		return str_contains( $html, '<section data-mw-section-id=' );
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public function getTemplateData(): array {
 		$html = $this->html;
 
-		if ( $this->shouldMakeSections ) {
+		// Parsoid content already ships section wrappers; the heading walk
+		// below expects headings as direct children of the parser output and
+		// would fold the whole page into a single section.
+		if ( $this->shouldMakeSections && !$this->isParsoidContent( $html ) ) {
 			$doc = DOMUtils::parseHTML( $html );
 			$this->makeSections( $doc );
 			$html = DOMCompat::getInnerHTML( DOMCompat::getBody( $doc ) );

--- a/includes/Components/CitizenComponentBodyContent.php
+++ b/includes/Components/CitizenComponentBodyContent.php
@@ -76,7 +76,7 @@ class CitizenComponentBodyContent implements CitizenComponent {
 				// isSectionBreak() guarantees $currentNode is an Element,
 				// but Phan cannot infer that from the control flow.
 				if ( $currentNode instanceof Element ) {
-					$this->prepareHeading( $doc, $currentNode );
+					$this->prepareHeading( $currentNode );
 				}
 
 				$sectionNumber++;
@@ -172,15 +172,12 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	}
 
 	/**
-	 * Prepare section headings, add required classes
+	 * Prepare section headings, add required classes.
+	 * The collapse indicator renders purely through CSS on the heading's
+	 * ::before, the same way native Parsoid sections are styled.
 	 */
-	private function prepareHeading( Document $doc, Element $heading ): void {
+	private function prepareHeading( Element $heading ): void {
 		DOMCompat::getClassList( $heading )->add( 'citizen-section-heading' );
-
-		// prepend indicator - this avoids a reflow by creating a placeholder for a toggling indicator
-		$indicator = $doc->createElement( 'span' );
-		$indicator->setAttribute( 'class', 'citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse' );
-		$heading->insertBefore( $indicator, $heading->firstChild );
 	}
 
 	/**

--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -1,3 +1,5 @@
+const COLLAPSED_CLASS = 'citizen-parsoid-section--collapsed';
+
 /**
  * @param {Object} deps
  * @param {Document} deps.document
@@ -5,6 +7,39 @@
  * @return {Object}
  */
 function createSections( { document, bodyContent } ) {
+	/**
+	 * The native Parsoid section wrapper a heading belongs to, or null when
+	 * the heading is not the direct heading of such a section (legacy markup).
+	 *
+	 * @param {HTMLElement} heading
+	 * @return {HTMLElement|null}
+	 */
+	function getParsoidSection( heading ) {
+		const section = heading.parentElement;
+		if ( section && section.hasAttribute( 'data-mw-section-id' ) ) {
+			return section;
+		}
+		return null;
+	}
+
+	/**
+	 * Collapse or expand a native Parsoid section. The heading stays visible;
+	 * every other direct child (including nested subsections) is hidden with
+	 * `until-found` so find-in-page can still reach the content.
+	 *
+	 * @param {HTMLElement} section
+	 * @param {boolean} collapsed
+	 */
+	function setParsoidSectionCollapsed( section, collapsed ) {
+		section.classList.toggle( COLLAPSED_CLASS, collapsed );
+		for ( const child of section.children ) {
+			if ( child.classList.contains( 'mw-heading' ) ) {
+				continue;
+			}
+			child.hidden = collapsed ? 'until-found' : false;
+		}
+	}
+
 	/**
 	 * Set up functionality of collapsable sections
 	 *
@@ -28,6 +63,20 @@ function createSections( { document, bodyContent } ) {
 				return;
 			}
 
+			// Native Parsoid sections: the heading is a direct child of its
+			// own <section data-mw-section-id> wrapper
+			const mwHeading = target.closest( '.mw-heading' );
+			if ( mwHeading ) {
+				const parsoidSection = getParsoidSection( mwHeading );
+				if ( parsoidSection ) {
+					setParsoidSectionCollapsed(
+						parsoidSection,
+						!parsoidSection.classList.contains( COLLAPSED_CLASS )
+					);
+					return;
+				}
+			}
+
 			const heading = target.closest( '.citizen-section-heading' );
 
 			if ( heading && heading.nextElementSibling && heading.nextElementSibling.classList.contains( 'citizen-section' ) ) {
@@ -39,7 +88,23 @@ function createSections( { document, bodyContent } ) {
 			}
 		};
 
+		// Legacy sections self-heal on find-in-page: the browser clears the
+		// wrapper's own `hidden`. Parsoid sections hide individual children,
+		// so expand the whole chain of collapsed ancestors on a match.
+		const handleBeforeMatch = ( e ) => {
+			let section = e.target instanceof Element ?
+				e.target.closest( `section[data-mw-section-id].${ COLLAPSED_CLASS }` ) :
+				null;
+			while ( section ) {
+				setParsoidSectionCollapsed( section, false );
+				section = section.parentElement ?
+					section.parentElement.closest( `section[data-mw-section-id].${ COLLAPSED_CLASS }` ) :
+					null;
+			}
+		};
+
 		bodyContent.addEventListener( 'click', handleClick, false );
+		bodyContent.addEventListener( 'beforematch', handleBeforeMatch, false );
 	}
 
 	return { init };

--- a/resources/skins.citizen.styles/assets/images/cdxIconCollapse.svg
+++ b/resources/skins.citizen.styles/assets/images/cdxIconCollapse.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+	<title>
+		collapse
+	</title>
+	<path d="m2.5 15.25 7.5-7.5 7.5 7.5 1.5-1.5-9-9-9 9z"/>
+</svg>

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -1,11 +1,15 @@
-// Hide indicator when client is noscript
-// FIXME: On rare occasion, indicator can appear without the .citizen-sections-enabled class, not sure why
-.citizen-section-indicator,
-.client-nojs.citizen-sections-enabled .citizen-section-indicator {
-	display: none;
+// Cached HTML compat: pages rendered before the indicator moved to CSS
+// carry a server-injected indicator span; keep it inert until caches
+// expire. !important because the span also matches .citizen-ui-icon
+// rules of equal specificity elsewhere and must not depend on import
+// order to lose. The next commit removes this rule for wikis that
+// deploy commit by commit.
+.citizen-section-indicator {
+	display: none !important;
 }
 
 .citizen-section-heading,
+section[ data-mw-section-id ] > .mw-heading,
 .mw-editsection {
 	--size-icon: 1.125rem;
 }
@@ -18,66 +22,19 @@
 		.mw-headline {
 			flex-grow: 1;
 		}
-
-		:is( .mw-headline, h1, h2, h3, h4, h5, h6 ) {
-			transition: var( --transition-hover );
-			transition-property: opacity;
-
-			@media ( hover: pointer ) {
-				&:hover {
-					opacity: var( --opacity-icon-base--hover );
-				}
-
-				&:active {
-					opacity: var( --opacity-icon-base--selected );
-				}
-			}
-		}
-
-		&:has( + .citizen-section[ hidden ] ) {
-			.citizen-section-indicator {
-				transform: rotate3d( 1, 0, 0, 180deg );
-			}
-
-			:is( .mw-headline, h1, h2, h3, h4, h5, h6 ) {
-				color: var( --color-subtle );
-			}
-		}
 	}
 }
 
-.citizen-sections-enabled {
-	.citizen-section {
-		&-heading {
-			cursor: pointer;
-			-webkit-user-select: none;
-			user-select: none;
-		}
-
-		&-indicator {
-			display: block;
-			order: -2;
-			width: var( --size-icon );
-			height: var( --size-icon );
-			margin-inline-end: var( --space-sm );
-			cursor: pointer;
-			transition: var( --transition-hover );
-			transition-property: transform;
-		}
-	}
-}
-
-// Native Parsoid sections (<section data-mw-section-id>) ship their own
-// wrappers, so the collapse affordance is applied purely through CSS —
-// no indicator markup is injected server- or client-side. Scoped to
-// client-js because the sections cannot toggle without JS.
+// The collapse affordance is applied purely through CSS — no indicator
+// markup is injected server- or client-side, so first paint carries it
+// with no layout shift and noscript clients never see it. Both markup
+// shapes share one recipe: the legacy transform's sibling sections
+// (heading carries .citizen-section-heading) and native Parsoid sections
+// (<section data-mw-section-id> with the heading inside).
 // Trade-off: this claims the heading's single ::before slot, so any
-// extension or gadget styling .mw-heading::before will conflict here.
-section[ data-mw-section-id ] > .mw-heading {
-	--size-icon: 1.125rem;
-}
-
+// extension or gadget styling these headings' ::before will conflict.
 .client-js .citizen-sections-enabled {
+	.citizen-section-heading,
 	section[ data-mw-section-id ] > .mw-heading {
 		cursor: pointer;
 		-webkit-user-select: none;
@@ -103,7 +60,7 @@ section[ data-mw-section-id ] > .mw-heading {
 			transition-property: transform;
 		}
 
-		:is( h1, h2, h3, h4, h5, h6 ) {
+		:is( .mw-headline, h1, h2, h3, h4, h5, h6 ) {
 			transition: var( --transition-hover );
 			transition-property: opacity;
 
@@ -119,12 +76,13 @@ section[ data-mw-section-id ] > .mw-heading {
 		}
 	}
 
+	.citizen-section-heading:has( + .citizen-section[ hidden ] ),
 	section[ data-mw-section-id ].citizen-parsoid-section--collapsed > .mw-heading {
 		&::before {
 			transform: rotate3d( 1, 0, 0, 180deg );
 		}
 
-		:is( h1, h2, h3, h4, h5, h6 ) {
+		:is( .mw-headline, h1, h2, h3, h4, h5, h6 ) {
 			color: var( --color-subtle );
 		}
 	}

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -59,10 +59,73 @@
 			order: -2;
 			width: var( --size-icon );
 			height: var( --size-icon );
-			margin-right: var( --space-sm );
+			margin-inline-end: var( --space-sm );
 			cursor: pointer;
 			transition: var( --transition-hover );
 			transition-property: transform;
+		}
+	}
+}
+
+// Native Parsoid sections (<section data-mw-section-id>) ship their own
+// wrappers, so the collapse affordance is applied purely through CSS —
+// no indicator markup is injected server- or client-side. Scoped to
+// client-js because the sections cannot toggle without JS.
+// Trade-off: this claims the heading's single ::before slot, so any
+// extension or gadget styling .mw-heading::before will conflict here.
+section[ data-mw-section-id ] > .mw-heading {
+	--size-icon: 1.125rem;
+}
+
+.client-js .citizen-sections-enabled {
+	section[ data-mw-section-id ] > .mw-heading {
+		cursor: pointer;
+		-webkit-user-select: none;
+		user-select: none;
+
+		&::before {
+			flex-shrink: 0;
+			order: -2;
+			width: var( --size-icon );
+			height: var( --size-icon );
+			margin-inline-end: var( --space-sm );
+			content: '';
+			background-color: currentcolor;
+			-webkit-mask-image: url( assets/images/cdxIconCollapse.svg );
+			mask-image: url( assets/images/cdxIconCollapse.svg );
+			-webkit-mask-repeat: no-repeat;
+			mask-repeat: no-repeat;
+			-webkit-mask-position: center;
+			mask-position: center;
+			-webkit-mask-size: contain;
+			mask-size: contain;
+			transition: var( --transition-hover );
+			transition-property: transform;
+		}
+
+		:is( h1, h2, h3, h4, h5, h6 ) {
+			transition: var( --transition-hover );
+			transition-property: opacity;
+
+			@media ( hover: hover ) {
+				&:hover {
+					opacity: var( --opacity-icon-base--hover );
+				}
+
+				&:active {
+					opacity: var( --opacity-icon-base--selected );
+				}
+			}
+		}
+	}
+
+	section[ data-mw-section-id ].citizen-parsoid-section--collapsed > .mw-heading {
+		&::before {
+			transform: rotate3d( 1, 0, 0, 180deg );
+		}
+
+		:is( h1, h2, h3, h4, h5, h6 ) {
+			color: var( --color-subtle );
 		}
 	}
 }

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -1,13 +1,3 @@
-// Cached HTML compat: pages rendered before the indicator moved to CSS
-// carry a server-injected indicator span; keep it inert until caches
-// expire. !important because the span also matches .citizen-ui-icon
-// rules of equal specificity elsewhere and must not depend on import
-// order to lose. The next commit removes this rule for wikis that
-// deploy commit by commit.
-.citizen-section-indicator {
-	display: none !important;
-}
-
 .citizen-section-heading,
 section[ data-mw-section-id ] > .mw-heading,
 .mw-editsection {

--- a/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
@@ -124,5 +124,37 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'',
 			''
 		];
+
+		yield 'Escaped Parsoid markup in code samples does not disable sectioning' => [
+			'Documentation showing Parsoid markup as escaped text is still legacy content',
+			'<div class="mw-parser-output">' .
+			'<pre>&lt;section data-mw-section-id="1"&gt;</pre>' .
+			'<h2>Foo</h2><p>Bar</p>' .
+			'</div>',
+			'<div class="mw-parser-output">' .
+			'<section id="citizen-section-0" class="citizen-section">' .
+			// The serializer normalizes &gt; to a bare > in text content
+			'<pre>&lt;section data-mw-section-id="1"></pre></section>' .
+			'<h2 class="citizen-section-heading">' .
+			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>Foo</h2>' .
+			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
+			'</div>'
+		];
+
+		yield 'Parsoid content is left untouched' => [
+			'Parsoid wraps sections natively; the transform must not run',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="0" id="mwAQ"><p>Lead</p></section>' .
+			'<section data-mw-section-id="1" id="mwAg">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div><p>Bar</p>' .
+			'</section>' .
+			'</div>',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="0" id="mwAQ"><p>Lead</p></section>' .
+			'<section data-mw-section-id="1" id="mwAg">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div><p>Bar</p>' .
+			'</section>' .
+			'</div>'
+		];
 	}
 }

--- a/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
@@ -49,11 +49,9 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output"><h2>Foo</h2><p>Bar</p><h2>Baz</h2><p>Quux</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
-			'<h2 class="citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>Foo</h2>' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
 			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
-			'<h2 class="citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>Baz</h2>' .
+			'<h2 class="citizen-section-heading">Baz</h2>' .
 			'<section id="citizen-section-2" class="citizen-section"><p>Quux</p></section>' .
 			'</div>'
 		];
@@ -63,8 +61,7 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output"><p>Lead content.</p><h2>Foo</h2><p>Bar</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"><p>Lead content.</p></section>' .
-			'<h2 class="citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>Foo</h2>' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
 			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
 			'</div>'
 		];
@@ -82,9 +79,7 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output"><div class="mw-heading"><h2>Foo</h2></div><p>Bar</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
-			'<div class="mw-heading citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>' .
-			'<h2>Foo</h2></div>' .
+			'<div class="mw-heading citizen-section-heading"><h2>Foo</h2></div>' .
 			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
 			'</div>'
 		];
@@ -98,9 +93,7 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section">' .
 			'<div class="toctitle"><h2>Contents</h2></div></section>' .
-			'<h2 class="citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>' .
-			'Real Heading</h2>' .
+			'<h2 class="citizen-section-heading">Real Heading</h2>' .
 			'<section id="citizen-section-1" class="citizen-section"><p>Content</p></section>' .
 			'</div>'
 		];
@@ -110,11 +103,9 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output"><h2>Foo</h2><h3>Should be ignored</h3><p>Bar</p><h2>Baz</h2></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
-			'<h2 class="citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>Foo</h2>' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
 			'<section id="citizen-section-1" class="citizen-section"><h3>Should be ignored</h3><p>Bar</p></section>' .
-			'<h2 class="citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>Baz</h2>' .
+			'<h2 class="citizen-section-heading">Baz</h2>' .
 			'<section id="citizen-section-2" class="citizen-section"></section>' .
 			'</div>'
 		];
@@ -135,8 +126,7 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<section id="citizen-section-0" class="citizen-section">' .
 			// The serializer normalizes &gt; to a bare > in text content
 			'<pre>&lt;section data-mw-section-id="1"></pre></section>' .
-			'<h2 class="citizen-section-heading">' .
-			'<span class="citizen-section-indicator citizen-ui-icon mw-ui-icon-wikimedia-collapse"></span>Foo</h2>' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
 			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
 			'</div>'
 		];

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+/* global document */
+
+const { createSections } = require( '../../../resources/skins.citizen.scripts/sections.js' );
+
+/**
+ * @param {string} innerHTML
+ * @return {HTMLElement}
+ */
+function createBodyContent( innerHTML ) {
+	document.body.classList.add( 'citizen-sections-enabled' );
+	const bodyContent = document.createElement( 'div' );
+	bodyContent.innerHTML = innerHTML;
+	document.body.appendChild( bodyContent );
+	createSections( { document, bodyContent } ).init();
+	return bodyContent;
+}
+
+function click( el ) {
+	el.dispatchEvent( new Event( 'click', { bubbles: true } ) );
+}
+
+afterEach( () => {
+	document.body.className = '';
+	document.body.innerHTML = '';
+} );
+
+describe( 'createSections', () => {
+	describe( 'legacy sections (Citizen transform markup)', () => {
+		const LEGACY = `
+			<div class="mw-parser-output">
+				<section id="citizen-section-0" class="citizen-section"><p>Lead</p></section>
+				<div class="mw-heading citizen-section-heading"><h2 id="Foo">Foo</h2>
+					<span class="mw-editsection"><a href="#">edit</a></span>
+				</div>
+				<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>
+			</div>
+		`;
+
+		it( 'should toggle the sibling section on heading click', () => {
+			const bodyContent = createBodyContent( LEGACY );
+			const heading = bodyContent.querySelector( '.citizen-section-heading' );
+			const section = bodyContent.querySelector( '#citizen-section-1' );
+
+			click( heading );
+			expect( section.hidden ).toBeTruthy();
+
+			click( heading );
+			expect( section.hidden ).toBeFalsy();
+		} );
+
+		it( 'should not toggle when the edit link is clicked', () => {
+			const bodyContent = createBodyContent( LEGACY );
+			const editLink = bodyContent.querySelector( '.mw-editsection a' );
+			const section = bodyContent.querySelector( '#citizen-section-1' );
+
+			click( editLink );
+
+			expect( section.hidden ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'parsoid sections (native markup)', () => {
+		const PARSOID = `
+			<div class="mw-parser-output">
+				<section data-mw-section-id="0"><p>Lead</p></section>
+				<section data-mw-section-id="1">
+					<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2>
+						<span class="mw-editsection"><a href="#">edit</a></span>
+					</div>
+					<p>Bar</p>
+					<table><tbody><tr><td>Baz</td></tr></tbody></table>
+					<section data-mw-section-id="2">
+						<div class="mw-heading mw-heading3"><h3 id="Sub">Sub</h3></div>
+						<p>Nested content</p>
+					</section>
+				</section>
+			</div>
+		`;
+
+		it( 'should collapse all non-heading children on heading click', () => {
+			const bodyContent = createBodyContent( PARSOID );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const heading = section.querySelector( '.mw-heading2' );
+
+			click( heading );
+
+			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+			expect( section.querySelector( 'p' ).hidden ).toBeTruthy();
+			expect( section.querySelector( 'table' ).hidden ).toBeTruthy();
+			expect( section.querySelector( 'section[data-mw-section-id="2"]' ).hidden ).toBeTruthy();
+			// The heading itself stays visible
+			expect( heading.hidden ).toBeFalsy();
+		} );
+
+		it( 'should expand back on second click', () => {
+			const bodyContent = createBodyContent( PARSOID );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const heading = section.querySelector( '.mw-heading2' );
+
+			click( heading );
+			click( heading );
+
+			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+			expect( section.querySelector( 'p' ).hidden ).toBeFalsy();
+			expect( section.querySelector( 'table' ).hidden ).toBeFalsy();
+		} );
+
+		it( 'should toggle nested subsections independently', () => {
+			const bodyContent = createBodyContent( PARSOID );
+			const outer = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const nested = bodyContent.querySelector( 'section[data-mw-section-id="2"]' );
+			const nestedHeading = nested.querySelector( '.mw-heading3' );
+
+			click( nestedHeading );
+
+			expect( nested.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+			expect( nested.querySelector( 'p' ).hidden ).toBeTruthy();
+			// The outer section is unaffected
+			expect( outer.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+			expect( outer.querySelector( ':scope > p' ).hidden ).toBeFalsy();
+		} );
+
+		it( 'should not toggle when the edit link is clicked', () => {
+			const bodyContent = createBodyContent( PARSOID );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const editLink = section.querySelector( '.mw-editsection a' );
+
+			click( editLink );
+
+			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+		} );
+
+		it( 'should preserve a nested collapsed state across parent toggles', () => {
+			const bodyContent = createBodyContent( PARSOID );
+			const outer = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const nested = bodyContent.querySelector( 'section[data-mw-section-id="2"]' );
+
+			click( nested.querySelector( '.mw-heading3' ) );
+			click( outer.querySelector( '.mw-heading2' ) );
+			click( outer.querySelector( '.mw-heading2' ) );
+
+			// The nested section is visible again, but its own collapsed
+			// state survived the parent's collapse/expand cycle
+			expect( nested.hidden ).toBeFalsy();
+			expect( nested.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+			expect( nested.querySelector( 'p' ).hidden ).toBeTruthy();
+		} );
+
+		it( 'should expand collapsed ancestors when find-in-page matches inside', () => {
+			const bodyContent = createBodyContent( PARSOID );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const heading = section.querySelector( '.mw-heading2' );
+
+			click( heading );
+			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+
+			const hiddenParagraph = section.querySelector( ':scope > p' );
+			hiddenParagraph.dispatchEvent( new Event( 'beforematch', { bubbles: true } ) );
+
+			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+			expect( hiddenParagraph.hidden ).toBeFalsy();
+		} );
+	} );
+} );


### PR DESCRIPTION
## What

Under Parsoid read views (reachable today on any MW 1.43 wiki via the bundled ParserMigration extension, `?useparsoid=1`, and the migration target for all wikis), Citizen's collapsible sections were broken: Parsoid nests headings inside its native `<section data-mw-section-id>` wrappers, so the server-side transform — which expects headings as direct children of the parser output — folded the entire article into a single `citizen-section-0` wrapper with zero collapsible headings, while still paying the full DOM parse+serialize cost (~0.3–0.4 ms per KB, on HTML ~1.2× larger than the legacy parser's) on every view.

Three layers, no mode flags — the markup itself decides:

- **PHP**: the transform skips Parsoid content, detected by the literal tag-open `<section data-mw-section-id=`. The tag-open form cannot occur in user content: the sanitizer strips `data-mw-*` attributes from wikitext, and escaped example markup in code samples never contains a raw `<` (regression-tested — a bare substring check would have silently disabled sectioning on legacy pages documenting Parsoid markup).
- **JS**: `sections.js` dispatches on structure — a clicked `.mw-heading` whose parent carries `data-mw-section-id` toggles that section by setting `hidden="until-found"` on its non-heading children (nested subsections hide wholesale and keep their own state; toggle independently). A delegated `beforematch` handler expands the whole collapsed-ancestor chain so find-in-page reaches nested content. The legacy click path is unchanged.
- **CSS**: the collapse indicator renders purely via `::before` on the heading (vendored `cdxIconCollapse.svg`, byte-identical glyph to the icon pack's, mask + `currentcolor`), scoped under `.client-js`. No markup is injected server- or client-side, so first paint carries the affordance with zero layout shift. Trade-off documented in-code: this claims the heading's single `::before` slot.

Net effect: on Parsoid pages the per-view section transform cost drops to a `str_contains` check, sections are wrapped at parse time inside the parser cache, and collapsing gains feature parity with legacy — with the same interaction and visuals.

## Second commit: unified indicator rendering

The legacy transform no longer injects the indicator span either — legacy headings share the exact `::before` recipe Parsoid headings use, styled by one rule set. This deletes the long-standing noscript FIXME (without JS the indicator simply never exists) and trims one element per heading from every rendered page. Cached pages that still carry the injected span render identically under the new stylesheet via an inert-span compat rule — verified live by re-injecting the old span shape. The third commit removes that compat rule; intended for a rebase merge so wikis deploying commit by commit can hold until their full-page caches expire (a stale page under the final commit shows a cosmetic duplicate indicator until purged). Wikis styling `.citizen-section-indicator` in local CSS should target `.citizen-section-heading::before` instead.

## Verification

- TDD throughout: PHP regression cases (Parsoid HTML untouched; escaped-markup-in-`<pre>` still sectioned) and a new `sections.test.js` (8 cases: legacy pins, collapse/expand, nested independence, nested-state preservation across parent toggles, edit-link guard, ancestor-chain `beforematch`). Suites: 167 PHPUnit, 1044 Vitest, stylelint/eslint clean.
- Live on both render modes with the production bundle: 20 native sections and zero broken wrappers on the Parsoid page; indicator renders and rotates; real double-nested h3-in-h2 collapse and chain-expansion verified in-browser; legacy page regression-checked; console clean.
- Honest caveat: the browser's native find bar cannot be automated via CDP, so the find-in-page trigger rests on the platform's `beforematch` contract plus real-DOM verification of the handler; one manual Ctrl+F pass on a collapsed nested section is a worthwhile reviewer step.
- Future-proofing note in the component docblock: core's dormant `ParserOptions::setCollapsibleSections()` (1.42+) is the API to revisit if core ever enables parse-time wrappers for the legacy parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKjzET2kZLfQyC4xJgMvSS



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapse and expand support for native Parsoid-rendered sections.
  * Sections automatically expand when matching hidden content is located through find-in-page.
  * Added visual collapse indicators using CSS.

* **Bug Fixes**
  * Improved handling of Parsoid section markup to prevent entire pages from collapsing into one section.
  * Preserved independent nested-section behavior when parent sections are toggled.

* **Tests**
  * Added coverage for legacy and Parsoid section interactions, nested sections, edit links, and find-in-page expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->