### PR TITLE
feat(sections): nest section markup with headings inside like Parsoid

### DIFF
--- a/includes/Components/CitizenComponentBodyContent.php
+++ b/includes/Components/CitizenComponentBodyContent.php
@@ -31,15 +31,15 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	public const SECTION_CLASS = 'citizen-section';
 
 	/**
+	 * Sentinel nesting level for the lead section: no heading level nests
+	 * beneath it, matching Parsoid's lead section semantics.
+	 */
+	private const LEAD_SECTION_LEVEL = 7;
+
+	/**
 	 * List of tags that could be considered as section headers.
 	 */
 	private array $topHeadingTags = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
-
-	/**
-	 * The tag name of the top-level heading elements used for section breaks.
-	 * This is determined on the fly when processing the content.
-	 */
-	private ?string $topHeadingName = null;
 
 	public function __construct(
 		private readonly string $html,
@@ -48,7 +48,13 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	}
 
 	/**
-	 * Splits the body of the document into sections in a single pass.
+	 * Wraps the body of the document into nested sections in a single pass.
+	 *
+	 * The output mirrors the shape Parsoid produces natively: each heading
+	 * starts a <section> that contains the heading and everything up to the
+	 * next heading of equal or higher rank; lower-ranked headings nest their
+	 * sections inside the current one. Content before the first heading goes
+	 * into a headingless lead section.
 	 */
 	private function makeSections( Document $doc ): Document {
 		$container = DOMCompat::querySelector( $doc, 'div.mw-parser-output' );
@@ -57,70 +63,61 @@ class CitizenComponentBodyContent implements CitizenComponent {
 			return $doc;
 		}
 
-		// Reset state for this run
-		$this->topHeadingName = null;
-
 		$sectionNumber = 0;
-		$sectionBody = $this->createSectionBodyElement( $doc, $sectionNumber );
+		$currentLevel = self::LEAD_SECTION_LEVEL;
+		$currentSection = $this->createSectionBodyElement( $doc, $sectionNumber );
+		$container->insertBefore( $currentSection, $container->firstChild );
 
-		$currentNode = $container->firstChild;
+		/** @var array<array{0: int, 1: Element}> Open ancestor sections */
+		$stack = [];
+
+		// The lead section is the container's first child now; walk what follows it
+		$currentNode = $currentSection->nextSibling;
 		while ( $currentNode ) {
 			$nextNode = $currentNode->nextSibling;
 
 			// @phan-suppress-next-line PhanTypeMismatchArgument DOMNode is a Parsoid DOM\Node alias
-			if ( !$this->isSectionBreak( $currentNode ) ) {
-				$sectionBody->appendChild( $currentNode );
+			$level = $this->getSectionHeadingLevel( $currentNode );
+			if ( $level === null ) {
+				$currentSection->appendChild( $currentNode );
 			} else {
-				$container->insertBefore( $sectionBody, $currentNode );
+				// Pop ancestors that cannot contain a section of this rank
+				while ( $stack && end( $stack )[0] >= $level ) {
+					array_pop( $stack );
+				}
+				if ( $currentLevel < $level ) {
+					$stack[] = [ $currentLevel, $currentSection ];
+				}
 
-				// isSectionBreak() guarantees $currentNode is an Element,
-				// but Phan cannot infer that from the control flow.
+				$sectionNumber++;
+				$newSection = $this->createSectionBodyElement( $doc, $sectionNumber );
+				$parent = $stack ? end( $stack )[1] : null;
+				if ( $parent ) {
+					$parent->appendChild( $newSection );
+				} else {
+					$container->insertBefore( $newSection, $currentNode );
+				}
+
+				$newSection->appendChild( $currentNode );
 				if ( $currentNode instanceof Element ) {
 					$this->prepareHeading( $currentNode );
 				}
 
-				$sectionNumber++;
-				$sectionBody = $this->createSectionBodyElement( $doc, $sectionNumber );
+				$currentLevel = $level;
+				$currentSection = $newSection;
 			}
 
 			$currentNode = $nextNode;
 		}
 
-		// Append the final section body, which contains all nodes after the last heading.
-		$container->appendChild( $sectionBody );
-
 		return $doc;
 	}
 
 	/**
-	 * Determines if a given node should be treated as a section break.
-	 * This method has the side effect of setting the `$topHeadingName`
-	 * property when the first valid section heading is found.
+	 * The heading rank (1-6) when the node starts a section, or null when it
+	 * is ordinary content.
 	 */
-	private function isSectionBreak( Node $node ): bool {
-		if ( !$node instanceof Element ) {
-			return false;
-		}
-
-		$currentHeadingName = $this->getHeadingName( $node );
-		if ( !$currentHeadingName ) {
-			return false;
-		}
-
-		if ( $this->topHeadingName === null ) {
-			// This is the first potential heading. If it's valid, make it the standard.
-			if ( $this->isValidSectionHeading( $node ) ) {
-				$this->topHeadingName = $currentHeadingName;
-				return true;
-			}
-			return false;
-		} else {
-			// This is a subsequent heading. Check if it matches the top-level one.
-			return $currentHeadingName === $this->topHeadingName;
-		}
-	}
-
-	private function getHeadingName( Node $node ): ?string {
+	private function getSectionHeadingLevel( Node $node ): ?int {
 		if ( !( $node instanceof Element ) ) {
 			return null;
 		}
@@ -128,19 +125,26 @@ class CitizenComponentBodyContent implements CitizenComponent {
 		// We accept both kinds of nodes: a `<h1>` to `<h6>` node, or a
 		// `<div class="mw-heading">` node wrapping it. In the future, the wrapper
 		// will be required (T13555).
+		$headingNode = $node;
 		if ( DOMCompat::getClassList( $node )->contains( 'mw-heading' ) ) {
 			$headingNode = DOMCompat::querySelector( $node, implode( ',', $this->topHeadingTags ) );
-			if ( $headingNode instanceof Element ) {
-				$tagName = $headingNode->tagName;
-				// Normalize the tag name to lowercase
-				// Since tagName seems to return uppercase in MW 1.44+ with PHP 8.4+
-				return in_array( strtolower( $tagName ), $this->topHeadingTags ) ? $tagName : null;
+			if ( !( $headingNode instanceof Element ) ) {
+				return null;
 			}
+		}
+
+		// Normalize the tag name to lowercase
+		// Since tagName seems to return uppercase in MW 1.44+ with PHP 8.4+
+		$tagName = strtolower( $headingNode->tagName );
+		if ( !in_array( $tagName, $this->topHeadingTags ) ) {
 			return null;
 		}
 
-		$tagName = $node->tagName;
-		return in_array( strtolower( $tagName ), $this->topHeadingTags ) ? $tagName : null;
+		if ( !$this->isValidSectionHeading( $node ) ) {
+			return null;
+		}
+
+		return (int)$tagName[1];
 	}
 
 	/**

--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -77,29 +77,17 @@ function createSections( { document, bodyContent } ) {
 				return;
 			}
 
-			// Sections that contain their own heading: native Parsoid markup
-			// and the legacy transform's converged output
 			const section = getSectionFromHeading( heading );
 			if ( section ) {
 				setSectionCollapsed(
 					section,
 					!section.classList.contains( COLLAPSED_CLASS )
 				);
-				return;
-			}
-
-			// Pre-convergence cached markup: the heading precedes a sibling
-			// section that wraps only the body
-			if ( heading.nextElementSibling && heading.nextElementSibling.classList.contains( 'citizen-section' ) ) {
-				const sibling = heading.nextElementSibling;
-				sibling.hidden = sibling.hidden ? false : 'until-found';
 			}
 		};
 
-		// Pre-convergence cached sections self-heal on find-in-page: the
-		// browser clears the wrapper's own `hidden`. Converged and Parsoid
-		// sections hide individual children, so expand the whole chain of
-		// collapsed ancestors on a match.
+		// Sections hide individual children, so expand the whole chain of
+		// collapsed ancestors on a find-in-page match.
 		const handleBeforeMatch = ( e ) => {
 			let section = e.target instanceof Element ?
 				e.target.closest( COLLAPSED_SECTION_SELECTOR ) :

--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -1,4 +1,7 @@
-const COLLAPSED_CLASS = 'citizen-parsoid-section--collapsed';
+const COLLAPSED_CLASS = 'citizen-section--collapsed';
+const HEADING_SELECTOR = '.mw-heading, .citizen-section-heading';
+const COLLAPSED_SECTION_SELECTOR =
+	`section[data-mw-section-id].${ COLLAPSED_CLASS }, section.citizen-section.${ COLLAPSED_CLASS }`;
 
 /**
  * @param {Object} deps
@@ -8,32 +11,38 @@ const COLLAPSED_CLASS = 'citizen-parsoid-section--collapsed';
  */
 function createSections( { document, bodyContent } ) {
 	/**
-	 * The native Parsoid section wrapper a heading belongs to, or null when
-	 * the heading is not the direct heading of such a section (legacy markup).
+	 * The section wrapper a heading belongs to: a native Parsoid section or
+	 * a section produced by the legacy transform (both carry the heading as
+	 * a direct child). Null for pre-convergence cached markup, where the
+	 * heading sits outside the section.
 	 *
 	 * @param {HTMLElement} heading
 	 * @return {HTMLElement|null}
 	 */
-	function getParsoidSection( heading ) {
+	function getSectionFromHeading( heading ) {
 		const section = heading.parentElement;
-		if ( section && section.hasAttribute( 'data-mw-section-id' ) ) {
+		if ( section && (
+			section.hasAttribute( 'data-mw-section-id' ) ||
+			section.classList.contains( 'citizen-section' )
+		) ) {
 			return section;
 		}
 		return null;
 	}
 
 	/**
-	 * Collapse or expand a native Parsoid section. The heading stays visible;
-	 * every other direct child (including nested subsections) is hidden with
-	 * `until-found` so find-in-page can still reach the content.
+	 * Collapse or expand a section that contains its own heading. The
+	 * heading stays visible; every other direct child (including nested
+	 * subsections) is hidden with `until-found` so find-in-page can still
+	 * reach the content.
 	 *
 	 * @param {HTMLElement} section
 	 * @param {boolean} collapsed
 	 */
-	function setParsoidSectionCollapsed( section, collapsed ) {
+	function setSectionCollapsed( section, collapsed ) {
 		section.classList.toggle( COLLAPSED_CLASS, collapsed );
 		for ( const child of section.children ) {
-			if ( child.classList.contains( 'mw-heading' ) ) {
+			if ( child.matches( HEADING_SELECTOR ) ) {
 				continue;
 			}
 			child.hidden = collapsed ? 'until-found' : false;
@@ -63,42 +72,42 @@ function createSections( { document, bodyContent } ) {
 				return;
 			}
 
-			// Native Parsoid sections: the heading is a direct child of its
-			// own <section data-mw-section-id> wrapper
-			const mwHeading = target.closest( '.mw-heading' );
-			if ( mwHeading ) {
-				const parsoidSection = getParsoidSection( mwHeading );
-				if ( parsoidSection ) {
-					setParsoidSectionCollapsed(
-						parsoidSection,
-						!parsoidSection.classList.contains( COLLAPSED_CLASS )
-					);
-					return;
-				}
+			const heading = target.closest( HEADING_SELECTOR );
+			if ( !heading ) {
+				return;
 			}
 
-			const heading = target.closest( '.citizen-section-heading' );
+			// Sections that contain their own heading: native Parsoid markup
+			// and the legacy transform's converged output
+			const section = getSectionFromHeading( heading );
+			if ( section ) {
+				setSectionCollapsed(
+					section,
+					!section.classList.contains( COLLAPSED_CLASS )
+				);
+				return;
+			}
 
-			if ( heading && heading.nextElementSibling && heading.nextElementSibling.classList.contains( 'citizen-section' ) ) {
-				const section = heading.nextElementSibling;
-
-				if ( section ) {
-					section.hidden = section.hidden ? false : 'until-found';
-				}
+			// Pre-convergence cached markup: the heading precedes a sibling
+			// section that wraps only the body
+			if ( heading.nextElementSibling && heading.nextElementSibling.classList.contains( 'citizen-section' ) ) {
+				const sibling = heading.nextElementSibling;
+				sibling.hidden = sibling.hidden ? false : 'until-found';
 			}
 		};
 
-		// Legacy sections self-heal on find-in-page: the browser clears the
-		// wrapper's own `hidden`. Parsoid sections hide individual children,
-		// so expand the whole chain of collapsed ancestors on a match.
+		// Pre-convergence cached sections self-heal on find-in-page: the
+		// browser clears the wrapper's own `hidden`. Converged and Parsoid
+		// sections hide individual children, so expand the whole chain of
+		// collapsed ancestors on a match.
 		const handleBeforeMatch = ( e ) => {
 			let section = e.target instanceof Element ?
-				e.target.closest( `section[data-mw-section-id].${ COLLAPSED_CLASS }` ) :
+				e.target.closest( COLLAPSED_SECTION_SELECTOR ) :
 				null;
 			while ( section ) {
-				setParsoidSectionCollapsed( section, false );
+				setSectionCollapsed( section, false );
 				section = section.parentElement ?
-					section.parentElement.closest( `section[data-mw-section-id].${ COLLAPSED_CLASS }` ) :
+					section.parentElement.closest( COLLAPSED_SECTION_SELECTOR ) :
 					null;
 			}
 		};

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -17,10 +17,11 @@ section[ data-mw-section-id ] > .mw-heading,
 
 // The collapse affordance is applied purely through CSS — no indicator
 // markup is injected server- or client-side, so first paint carries it
-// with no layout shift and noscript clients never see it. Both markup
-// shapes share one recipe: the legacy transform's sibling sections
-// (heading carries .citizen-section-heading) and native Parsoid sections
-// (<section data-mw-section-id> with the heading inside).
+// with no layout shift and noscript clients never see it. All markup
+// shapes share one recipe: the legacy transform's sections (heading
+// inside, carrying .citizen-section-heading), native Parsoid sections
+// (<section data-mw-section-id> with the heading inside), and cached
+// pre-convergence markup where the heading precedes a sibling section.
 // Trade-off: this claims the heading's single ::before slot, so any
 // extension or gadget styling these headings' ::before will conflict.
 .client-js .citizen-sections-enabled {
@@ -67,7 +68,7 @@ section[ data-mw-section-id ] > .mw-heading,
 	}
 
 	.citizen-section-heading:has( + .citizen-section[ hidden ] ),
-	section[ data-mw-section-id ].citizen-parsoid-section--collapsed > .mw-heading {
+	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > :is( .mw-heading, .citizen-section-heading ) {
 		&::before {
 			transform: rotate3d( 1, 0, 0, 180deg );
 		}

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -19,14 +19,12 @@ section[ data-mw-section-id ] > .mw-heading,
 // markup is injected server- or client-side, so first paint carries it
 // with no layout shift and noscript clients never see it. All markup
 // shapes share one recipe: the legacy transform's sections (heading
-// inside, carrying .citizen-section-heading), native Parsoid sections
-// (<section data-mw-section-id> with the heading inside), and cached
-// pre-convergence markup where the heading precedes a sibling section.
+// inside, carrying .citizen-section-heading) and native Parsoid
+// sections (<section data-mw-section-id> with the heading inside).
 // Trade-off: this claims the heading's single ::before slot, so any
 // extension or gadget styling these headings' ::before will conflict.
 .client-js .citizen-sections-enabled {
-	.citizen-section-heading,
-	section[ data-mw-section-id ] > .mw-heading {
+	section:is( [ data-mw-section-id ], .citizen-section ) > :is( .mw-heading, .citizen-section-heading ) {
 		cursor: pointer;
 		-webkit-user-select: none;
 		user-select: none;
@@ -67,7 +65,6 @@ section[ data-mw-section-id ] > .mw-heading,
 		}
 	}
 
-	.citizen-section-heading:has( + .citizen-section[ hidden ] ),
 	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > :is( .mw-heading, .citizen-section-heading ) {
 		&::before {
 			transform: rotate3d( 1, 0, 0, 180deg );

--- a/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
@@ -28,9 +28,8 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @dataProvider provideSectioningCases
 	 * @covers ::createSectionBodyElement
-	 * @covers ::getHeadingName
+	 * @covers ::getSectionHeadingLevel
 	 * @covers ::getTemplateData
-	 * @covers ::isSectionBreak
 	 * @covers ::isValidSectionHeading
 	 * @covers ::makeSections
 	 * @covers ::prepareHeading
@@ -49,10 +48,10 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output"><h2>Foo</h2><p>Bar</p><h2>Baz</h2><p>Quux</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
-			'<h2 class="citizen-section-heading">Foo</h2>' .
-			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
-			'<h2 class="citizen-section-heading">Baz</h2>' .
-			'<section id="citizen-section-2" class="citizen-section"><p>Quux</p></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Foo</h2><p>Bar</p></section>' .
+			'<section id="citizen-section-2" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Baz</h2><p>Quux</p></section>' .
 			'</div>'
 		];
 
@@ -61,8 +60,8 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output"><p>Lead content.</p><h2>Foo</h2><p>Bar</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"><p>Lead content.</p></section>' .
-			'<h2 class="citizen-section-heading">Foo</h2>' .
-			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Foo</h2><p>Bar</p></section>' .
 			'</div>'
 		];
 
@@ -79,8 +78,8 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output"><div class="mw-heading"><h2>Foo</h2></div><p>Bar</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
-			'<div class="mw-heading citizen-section-heading"><h2>Foo</h2></div>' .
-			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
+			'<div class="mw-heading citizen-section-heading"><h2>Foo</h2></div><p>Bar</p></section>' .
 			'</div>'
 		];
 
@@ -93,20 +92,35 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section">' .
 			'<div class="toctitle"><h2>Contents</h2></div></section>' .
-			'<h2 class="citizen-section-heading">Real Heading</h2>' .
-			'<section id="citizen-section-1" class="citizen-section"><p>Content</p></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Real Heading</h2><p>Content</p></section>' .
 			'</div>'
 		];
 
-		yield 'Uses highest ranking headings' => [
-			'Uses highest ranking headings',
-			'<div class="mw-parser-output"><h2>Foo</h2><h3>Should be ignored</h3><p>Bar</p><h2>Baz</h2></div>',
+		yield 'Subsections nest like Parsoid' => [
+			'An h3 inside an h2 section nests; the next h2 pops back to the top level',
+			'<div class="mw-parser-output"><h2>Foo</h2><h3>Sub</h3><p>Bar</p><h2>Baz</h2></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
 			'<h2 class="citizen-section-heading">Foo</h2>' .
-			'<section id="citizen-section-1" class="citizen-section"><h3>Should be ignored</h3><p>Bar</p></section>' .
-			'<h2 class="citizen-section-heading">Baz</h2>' .
-			'<section id="citizen-section-2" class="citizen-section"></section>' .
+			'<section id="citizen-section-2" class="citizen-section">' .
+			'<h3 class="citizen-section-heading">Sub</h3><p>Bar</p></section>' .
+			'</section>' .
+			'<section id="citizen-section-3" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Baz</h2></section>' .
+			'</div>'
+		];
+
+		yield 'Rank increases after a lower heading' => [
+			'An h2 after an h3 becomes a sibling, not a child',
+			'<div class="mw-parser-output"><h3>Deep first</h3><p>A</p><h2>Top</h2><p>B</p></div>',
+			'<div class="mw-parser-output">' .
+			'<section id="citizen-section-0" class="citizen-section"></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
+			'<h3 class="citizen-section-heading">Deep first</h3><p>A</p></section>' .
+			'<section id="citizen-section-2" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Top</h2><p>B</p></section>' .
 			'</div>'
 		];
 
@@ -126,8 +140,8 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<section id="citizen-section-0" class="citizen-section">' .
 			// The serializer normalizes &gt; to a bare > in text content
 			'<pre>&lt;section data-mw-section-id="1"></pre></section>' .
-			'<h2 class="citizen-section-heading">Foo</h2>' .
-			'<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Foo</h2><p>Bar</p></section>' .
 			'</div>'
 		];
 

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -60,6 +60,75 @@ describe( 'createSections', () => {
 		} );
 	} );
 
+	describe( 'converged legacy sections (heading inside section)', () => {
+		const CONVERGED = `
+			<div class="mw-parser-output">
+				<section id="citizen-section-0" class="citizen-section"><p>Lead</p></section>
+				<section id="citizen-section-1" class="citizen-section">
+					<div class="mw-heading citizen-section-heading"><h2 id="Foo">Foo</h2>
+						<span class="mw-editsection"><a href="#">edit</a></span>
+					</div>
+					<p>Bar</p>
+					<section id="citizen-section-2" class="citizen-section">
+						<h3 class="citizen-section-heading" id="Sub">Sub</h3>
+						<p>Nested</p>
+					</section>
+				</section>
+			</div>
+		`;
+
+		it( 'should toggle a converged section from its heading', () => {
+			const bodyContent = createBodyContent( CONVERGED );
+			const section = bodyContent.querySelector( '#citizen-section-1' );
+			const heading = section.querySelector( ':scope > .mw-heading' );
+
+			click( heading );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+			expect( section.querySelector( ':scope > p' ).hidden ).toBeTruthy();
+			expect( section.querySelector( '#citizen-section-2' ).hidden ).toBeTruthy();
+			expect( heading.hidden ).toBeFalsy();
+
+			click( heading );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+			expect( section.querySelector( ':scope > p' ).hidden ).toBeFalsy();
+		} );
+
+		it( 'should toggle a bare heading section without an mw-heading wrapper', () => {
+			const bodyContent = createBodyContent( CONVERGED );
+			const nested = bodyContent.querySelector( '#citizen-section-2' );
+			const bareHeading = nested.querySelector( ':scope > h3' );
+
+			click( bareHeading );
+
+			expect( nested.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+			expect( nested.querySelector( 'p' ).hidden ).toBeTruthy();
+			expect( bareHeading.hidden ).toBeFalsy();
+		} );
+
+		it( 'should not toggle when the edit link is clicked', () => {
+			const bodyContent = createBodyContent( CONVERGED );
+			const section = bodyContent.querySelector( '#citizen-section-1' );
+
+			click( section.querySelector( '.mw-editsection a' ) );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+		} );
+
+		it( 'should expand collapsed converged ancestors on find-in-page', () => {
+			const bodyContent = createBodyContent( CONVERGED );
+			const section = bodyContent.querySelector( '#citizen-section-1' );
+			click( section.querySelector( ':scope > .mw-heading' ) );
+
+			const hidden = section.querySelector( ':scope > p' );
+			hidden.dispatchEvent( new Event( 'beforematch', { bubbles: true } ) );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+			expect( hidden.hidden ).toBeFalsy();
+		} );
+	} );
+
 	describe( 'parsoid sections (native markup)', () => {
 		const PARSOID = `
 			<div class="mw-parser-output">
@@ -85,7 +154,7 @@ describe( 'createSections', () => {
 
 			click( heading );
 
-			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
 			expect( section.querySelector( 'p' ).hidden ).toBeTruthy();
 			expect( section.querySelector( 'table' ).hidden ).toBeTruthy();
 			expect( section.querySelector( 'section[data-mw-section-id="2"]' ).hidden ).toBeTruthy();
@@ -101,7 +170,7 @@ describe( 'createSections', () => {
 			click( heading );
 			click( heading );
 
-			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 			expect( section.querySelector( 'p' ).hidden ).toBeFalsy();
 			expect( section.querySelector( 'table' ).hidden ).toBeFalsy();
 		} );
@@ -114,10 +183,10 @@ describe( 'createSections', () => {
 
 			click( nestedHeading );
 
-			expect( nested.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+			expect( nested.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
 			expect( nested.querySelector( 'p' ).hidden ).toBeTruthy();
 			// The outer section is unaffected
-			expect( outer.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+			expect( outer.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 			expect( outer.querySelector( ':scope > p' ).hidden ).toBeFalsy();
 		} );
 
@@ -128,7 +197,7 @@ describe( 'createSections', () => {
 
 			click( editLink );
 
-			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 		} );
 
 		it( 'should preserve a nested collapsed state across parent toggles', () => {
@@ -143,7 +212,7 @@ describe( 'createSections', () => {
 			// The nested section is visible again, but its own collapsed
 			// state survived the parent's collapse/expand cycle
 			expect( nested.hidden ).toBeFalsy();
-			expect( nested.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+			expect( nested.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
 			expect( nested.querySelector( 'p' ).hidden ).toBeTruthy();
 		} );
 
@@ -153,12 +222,12 @@ describe( 'createSections', () => {
 			const heading = section.querySelector( '.mw-heading2' );
 
 			click( heading );
-			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( true );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
 
 			const hiddenParagraph = section.querySelector( ':scope > p' );
 			hiddenParagraph.dispatchEvent( new Event( 'beforematch', { bubbles: true } ) );
 
-			expect( section.classList.contains( 'citizen-parsoid-section--collapsed' ) ).toBe( false );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 			expect( hiddenParagraph.hidden ).toBeFalsy();
 		} );
 	} );

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -26,40 +26,6 @@ afterEach( () => {
 } );
 
 describe( 'createSections', () => {
-	describe( 'legacy sections (Citizen transform markup)', () => {
-		const LEGACY = `
-			<div class="mw-parser-output">
-				<section id="citizen-section-0" class="citizen-section"><p>Lead</p></section>
-				<div class="mw-heading citizen-section-heading"><h2 id="Foo">Foo</h2>
-					<span class="mw-editsection"><a href="#">edit</a></span>
-				</div>
-				<section id="citizen-section-1" class="citizen-section"><p>Bar</p></section>
-			</div>
-		`;
-
-		it( 'should toggle the sibling section on heading click', () => {
-			const bodyContent = createBodyContent( LEGACY );
-			const heading = bodyContent.querySelector( '.citizen-section-heading' );
-			const section = bodyContent.querySelector( '#citizen-section-1' );
-
-			click( heading );
-			expect( section.hidden ).toBeTruthy();
-
-			click( heading );
-			expect( section.hidden ).toBeFalsy();
-		} );
-
-		it( 'should not toggle when the edit link is clicked', () => {
-			const bodyContent = createBodyContent( LEGACY );
-			const editLink = bodyContent.querySelector( '.mw-editsection a' );
-			const section = bodyContent.querySelector( '#citizen-section-1' );
-
-			click( editLink );
-
-			expect( section.hidden ).toBeFalsy();
-		} );
-	} );
-
 	describe( 'converged legacy sections (heading inside section)', () => {
 		const CONVERGED = `
 			<div class="mw-parser-output">
@@ -229,6 +195,29 @@ describe( 'createSections', () => {
 
 			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 			expect( hiddenParagraph.hidden ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'stale pre-convergence markup (heading outside section)', () => {
+		// Cached pages from before the sections were converged: the heading
+		// precedes a sibling section that wraps only the body. Collapsing is
+		// unsupported — clicking the heading must be a harmless no-op.
+		const STALE = `
+			<div class="mw-parser-output">
+				<h2 class="citizen-section-heading" id="Old">Old</h2>
+				<section id="citizen-section-1" class="citizen-section"><p>Body</p></section>
+			</div>
+		`;
+
+		it( 'should leave cached pre-convergence sections inert', () => {
+			const bodyContent = createBodyContent( STALE );
+			const heading = bodyContent.querySelector( '.citizen-section-heading' );
+			const section = bodyContent.querySelector( '#citizen-section-1' );
+
+			click( heading );
+
+			expect( section.hidden ).toBeFalsy();
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

Converges the legacy-parser collapsible-section markup to the shape Parsoid produces natively, so the frontend has a single markup contract — and because heading-inside-section is the semantically correct HTML structure.

Two commits, designed for commit-by-commit deployment (this PR is rebase-merged):

1. **feat(sections): nest section markup with headings inside like Parsoid** — the server-side transform now mirrors Parsoid's `WrapSectionsState` algorithm: each heading starts a `<section class="citizen-section">` that contains the heading plus everything up to the next heading of equal or higher rank; lower-rank headings nest their sections inside; content before the first heading goes into a headingless lead section. Nested sections collapse with their parent and toggle independently — previously exclusive to Parsoid read views. The JS/CSS are generalized so one recipe handles both native Parsoid sections and converged legacy sections, and the collapsed-state class is renamed to `citizen-section--collapsed` (the old `citizen-parsoid-section--collapsed` never shipped in a release). Pages cached with the old flat markup keep working through a sibling-toggle fallback.
2. **refactor(sections): drop the fallback for the old section markup** — removes the fallback branch, its rotation selector, and its tests, and scopes the collapse affordance to headings inside sections so stale cached headings degrade to plain expanded headings (no dead pointer/indicator; clicking is a harmless no-op, pinned by a regression test).

⚠️ **Deploy note for commit 2:** deploy it only after full pages cached before commit 1 have expired or been purged. Until then, stale pages render sections expanded with no collapse control — content stays fully readable.

Notes:

- `data-mw-section-id` is never fabricated — that attribute stays Parsoid's contract with editing tools; legacy sections keep `id="citizen-section-N"` (sequential in document order) as their marker.
- Parsoid-rendered pages pass through the transform untouched (`<section data-mw-section-id=` cannot occur in sanitized user content, and a test guards against the escaped-markup-in-`<pre>` false positive).

## Test plan

- [x] PHPUnit: 168 tests pass in-container; provider cases pin nesting, rank pop/increase, lead section, TOC-title exclusion, Parsoid pass-through, and the escaped-markup guard
- [x] Vitest: full suite passes; sections tests cover converged legacy + Parsoid toggling, nested independence, edit-link guard (both shapes), `beforematch` ancestor expansion, and the stale-markup no-op
- [x] Commit 1 verified standalone in a detached worktree (old-shape fallback tests pass at that SHA)
- [x] eslint / stylelint clean
- [x] Live browser (legacy + `?useparsoid=1`): nested collapse/expand, independent nested toggles, find-in-page self-heal, collapse affordance (pointer + indicator), TOC scroll-spy unaffected, console clean
- [x] Live browser: injected old-shape markup after commit 2 shows no affordance (`cursor: auto`, no `::before` indicator) and clicking no-ops
- [x] Reviewed by code-review subagent; both Important findings addressed (regression test added; the two phan `UnusedPluginSuppression` warnings are the known pre-existing local-MW vs REL1_43 mismatch — the suppressions are required on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKjzET2kZLfQyC4xJgMvSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved section nesting to consistently include headings with their content.
  * Added unified section collapsing behavior across supported markup formats.
  * Find-in-page now automatically expands collapsed parent sections.

* **Bug Fixes**
  * Prevented edit-link clicks from unintentionally collapsing sections.
  * Improved handling of nested sections and legacy page markup.
  * Updated visual indicators for collapsed sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->