### PR TITLE
test: replace deprecated assertArraySubmapSame with assertArrayContains

### DIFF
--- a/tests/phpunit/integration/Hooks/ResourceLoaderHooksTest.php
+++ b/tests/phpunit/integration/Hooks/ResourceLoaderHooksTest.php
@@ -30,7 +30,7 @@ class ResourceLoaderHooksTest extends MediaWikiIntegrationTestCase {
 			$this->getServiceContainer()->getMainConfig()
 		);
 
-		$this->assertArraySubmapSame( [
+		$this->assertArrayContains( [
 			'wgCitizenEnablePreferences' => false,
 			'wgCitizenOverflowInheritedClasses' => false,
 			'wgCitizenOverflowNowrapClasses' => false,
@@ -53,7 +53,7 @@ class ResourceLoaderHooksTest extends MediaWikiIntegrationTestCase {
 			$this->getServiceContainer()->getMainConfig()
 		);
 
-		$this->assertArraySubmapSame( [
+		$this->assertArrayContains( [
 			'wgCitizenThemeDefault' => 'dark',
 		], $config );
 	}


### PR DESCRIPTION
## What

`ResourceLoaderHooksTest` used `MediaWikiIntegrationTestCase::assertArraySubmapSame()`, which was **deprecated in MediaWiki 1.47**:

```
Use of MediaWikiIntegrationTestCase::assertArraySubmapSame was deprecated in MediaWiki 1.47.
```

Both call sites now use `assertArrayContains()` instead.

## Why this is the right replacement

`assertArraySubmapSame()` is a thin wrapper whose entire body is `$this->assertArrayContains( $expected, $actual, $message )` — identical signature and identical strict-equality submap semantics. `assertArrayContains()` lives in `MediaWikiTestCaseTrait` (`@since 1.41`), so it predates the skin's MW 1.43+ floor. The swap is behaviour-preserving.

## Verification

- `php -l` clean on the changed file
- No remaining `assertArraySubmapSame` usages in `tests/`
- Not run against MW 1.47 locally (local core is 1.43.6, where the method isn't deprecated yet) — relying on CI to confirm across supported MW versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated configuration checks to verify that expected settings are present, while allowing additional configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->