### PR TITLE
feat(overflow): keep floated content floating when wrapped

### DIFF
--- a/docs/src/customization/utility-classes.md
+++ b/docs/src/customization/utility-classes.md
@@ -47,6 +47,10 @@ For wikitables:
 |}
 ```
 
+### Floated overflow content
+
+When an element that Citizen wraps for overflow is floated — through an inline `float` style or a class defined in your wiki's CSS — Citizen keeps the float working by re-applying it to the wrapper it adds. This covers any `.citizen-overflow` element as well as wikitables, which are wrapped automatically: floated content sits beside the text on tablet screens and up, and stacks on mobile. To opt out of wrapping (for example, an automatically wrapped wikitable), use `.citizen-table-nowrap` or any class listed in `$wgCitizenOverflowNowrapClasses`.
+
 ## Tables
 
 Enhance the look and feel of your tables.

--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -283,3 +283,28 @@
 		mask-image: linear-gradient( @direction, @color1, @color2, @color3, @color4 );
 	}
 }
+
+// Standard float treatment for user-floated content. Shared between the
+// legacy float classes (common/hacks.less) and the overflow wrapper float
+// modifiers (components/OverflowElements.less) so the two cannot drift.
+// Floats are physical by MediaWiki convention, so each declaration carries
+// its own /* @noflip */ so CSSJanus does not flip them for RTL wikis.
+// Callers own only the tablet media query. Only the literal keywords
+// `left`/`right` are accepted; any other value emits nothing.
+.mixin-citizen-float-declarations( @direction ) when ( @direction = right ) {
+	/* @noflip */
+	float: right;
+	/* @noflip */
+	clear: right;
+	/* @noflip */
+	margin-left: var( --space-lg );
+}
+
+.mixin-citizen-float-declarations( @direction ) when ( @direction = left ) {
+	/* @noflip */
+	float: left;
+	/* @noflip */
+	clear: left;
+	/* @noflip */
+	margin-right: var( --space-lg );
+}

--- a/resources/skins.citizen.scripts/overflowElements/float.js
+++ b/resources/skins.citizen.scripts/overflowElements/float.js
@@ -1,0 +1,28 @@
+/**
+ * Resolves the effective float direction of an element before it is wrapped.
+ *
+ * Covers floats the inherited-class migration does not know about: inline
+ * `style="float: right"` and wiki-defined classes (Common.css,
+ * TemplateStyles). Logical values are resolved against the element's
+ * computed direction so RTL wikis map correctly.
+ *
+ * @param {HTMLElement} element
+ * @param {Window} window
+ * @return {string|null} 'left', 'right', or null when not floated
+ */
+function detectFloatDirection( element, window ) {
+	const style = window.getComputedStyle( element );
+	const value = style.float;
+	if ( value === 'left' || value === 'right' ) {
+		return value;
+	}
+	if ( value === 'inline-start' ) {
+		return style.direction === 'rtl' ? 'right' : 'left';
+	}
+	if ( value === 'inline-end' ) {
+		return style.direction === 'rtl' ? 'left' : 'right';
+	}
+	return null;
+}
+
+module.exports = { detectFloatDirection };

--- a/resources/skins.citizen.scripts/overflowElements/index.js
+++ b/resources/skins.citizen.scripts/overflowElements/index.js
@@ -1,4 +1,5 @@
 const { createOverflowWrapper } = require( './wrapper.js' );
+const { detectFloatDirection } = require( './float.js' );
 const { createOverflowState } = require( './state.js' );
 const { createOverflowStickyHeader } = require( './stickyHeader.js' );
 
@@ -11,13 +12,14 @@ const { createOverflowStickyHeader } = require( './stickyHeader.js' );
 class OverflowElement {
 	constructor( {
 		document, window, mw,
-		element, isPointerDevice, config
+		element, isPointerDevice, floatDirection, config
 	} ) {
 		this.document = document;
 		this.window = window;
 		this.mw = mw;
 		this.element = element;
 		this.isPointerDevice = isPointerDevice;
+		this.floatDirection = floatDirection;
 		this.config = config;
 		// Assigned by the module init() after a successful element init
 		this.resizeObserver = null;
@@ -124,7 +126,8 @@ class OverflowElement {
 			mw: this.mw,
 			element: this.element,
 			isPointerDevice: this.isPointerDevice,
-			inheritedClasses: this.config.wgCitizenOverflowInheritedClasses
+			inheritedClasses: this.config.wgCitizenOverflowInheritedClasses,
+			floatDirection: this.floatDirection
 		} );
 		if ( !refs ) {
 			return false;
@@ -213,15 +216,41 @@ function init( {
 
 	const isPointerDevice = window.matchMedia( '(hover: hover) and (pointer: fine)' ).matches;
 
-	const initialized = [];
+	const inheritedClasses = config.wgCitizenOverflowInheritedClasses || [];
+
+	// Batched read pass before any wrapping: computed-style reads must not
+	// interleave with the DOM writes done by init(). Elements whose float
+	// comes from an inherited class are skipped — the class itself migrates
+	// to the wrapper and stays viewport-correct, unlike a computed snapshot.
+	const candidates = [];
 	overflowElements.forEach( ( el ) => {
 		if ( nowrapClasses.some( ( cls ) => el.classList.contains( cls ) ) ) {
 			return;
 		}
+		const hasInheritedClass = inheritedClasses.some(
+			( cls ) => el.classList.contains( cls )
+		);
+		// Fault-isolate the detection: a throw (e.g. a monkey-patched
+		// getComputedStyle) degrades this one element to no modifier
+		// instead of aborting the wrapping of every element on the page
+		let floatDirection = null;
+		if ( !hasInheritedClass ) {
+			try {
+				floatDirection = detectFloatDirection( el, window );
+			} catch ( error ) {
+				mw.log.error(
+					`[Citizen] Error occurred while detecting float direction: ${ error.message }`
+				);
+			}
+		}
+		candidates.push( { element: el, floatDirection } );
+	} );
 
+	const initialized = [];
+	candidates.forEach( ( { element, floatDirection } ) => {
 		const instance = new OverflowElement( {
 			document, window, mw,
-			element: el, isPointerDevice, config
+			element, isPointerDevice, floatDirection, config
 		} );
 		if ( instance.init() ) {
 			initialized.push( instance );

--- a/resources/skins.citizen.scripts/overflowElements/wrapper.js
+++ b/resources/skins.citizen.scripts/overflowElements/wrapper.js
@@ -1,7 +1,8 @@
 /**
  * Creates the DOM wrapper structure for an overflow element.
- * Handles inherited class migration (floatleft, floatright, etc.)
- * and optional navigation buttons for pointer devices.
+ * Handles inherited class migration (floatleft, floatright, etc.),
+ * detected-float modifiers, and optional navigation buttons for
+ * pointer devices.
  *
  * @param {Object} params
  * @param {Document} params.document
@@ -9,9 +10,12 @@
  * @param {HTMLElement} params.element
  * @param {boolean} params.isPointerDevice
  * @param {string[]} params.inheritedClasses
+ * @param {string|null} params.floatDirection
  * @return {{wrapper: HTMLElement, content: HTMLElement, nav: HTMLElement|null}|null}
  */
-function createOverflowWrapper( { document, mw, element, isPointerDevice, inheritedClasses } ) {
+function createOverflowWrapper( {
+	document, mw, element, isPointerDevice, inheritedClasses, floatDirection
+} ) {
 	if ( !element || !element.parentNode ) {
 		mw.log.error(
 			'[Citizen] Element or element.parentNode is null or undefined.'
@@ -34,6 +38,12 @@ function createOverflowWrapper( { document, mw, element, isPointerDevice, inheri
 					element.classList.remove( cls );
 				}
 			} );
+		}
+
+		// Re-express a detected float (inline style or unknown wiki class)
+		// as the skin-standard float treatment on the wrapper
+		if ( floatDirection ) {
+			wrapper.classList.add( `citizen-overflow-wrapper--float${ floatDirection }` );
 		}
 
 		let nav = null;

--- a/resources/skins.citizen.styles/common/hacks.less
+++ b/resources/skins.citizen.styles/common/hacks.less
@@ -28,19 +28,13 @@ div.tright {
 }
 
 @media ( min-width: @min-width-breakpoint-tablet ) {
-	/* @noflip */
 	div.tright,
 	.floatright {
-		float: right;
-		clear: right;
-		margin-left: var( --space-lg );
+		.mixin-citizen-float-declarations( right );
 	}
 
-	/* @noflip */
 	div.tleft,
 	.floatleft {
-		float: left;
-		clear: left;
-		margin-right: var( --space-lg );
+		.mixin-citizen-float-declarations( left );
 	}
 }

--- a/resources/skins.citizen.styles/components/OverflowElements.less
+++ b/resources/skins.citizen.styles/components/OverflowElements.less
@@ -26,11 +26,59 @@
 		&:has( .citizen-overflow-content > .wikitable--fluid ) {
 			max-width: none;
 		}
+
+		&--floatleft,
+		&--floatright {
+			margin: 0;
+
+			// The float and its margins are re-expressed on the wrapper —
+			// zero them on the inner element so author float-spacing does
+			// not double up inside the wrapper
+			.citizen-overflow-content > * {
+				margin: 0 !important;
+			}
+		}
+
+		// Keep this block last: two separate same-specificity ties resolve
+		// by source order and both need this media block to come after the
+		// rules above.
+		//   1. The mixin's margin-left/right ( on `&--float*` ) must beat the
+		//      `margin: 0` base above ( both 0,1,0 ) — the non-table float case.
+		//   2. The nested `:has()` override below must beat the card rule's
+		//      margin-inline ( both 0,3,0 ) — the floated-wikitable case.
+		@media ( min-width: @min-width-breakpoint-tablet ) {
+			&--floatright {
+				.mixin-citizen-float-declarations( right );
+
+				// The card rule's margin-inline (border-clipping fix) has
+				// equal specificity — restore the text-facing gap
+				&:has( .citizen-overflow-content > .wikitable ) {
+					/* @noflip */
+					margin-left: var( --space-lg );
+				}
+			}
+
+			&--floatleft {
+				.mixin-citizen-float-declarations( left );
+
+				&:has( .citizen-overflow-content > .wikitable ) {
+					/* @noflip */
+					margin-right: var( --space-lg );
+				}
+			}
+		}
 	}
 
 	&-content {
 		width: 100%;
 		overflow: auto hidden;
+
+		// A float directly inside the scroll container is never meaningful;
+		// detected floats are re-expressed on the wrapper as --float*
+		// modifiers. !important so inline styles cannot win
+		> * {
+			float: none !important;
+		}
 
 		> .wikitable {
 			display: table;

--- a/skin.json
+++ b/skin.json
@@ -200,6 +200,7 @@
 				"resources/skins.citizen.scripts/lastModified.js",
 				"resources/skins.citizen.scripts/overflowElements/index.js",
 				"resources/skins.citizen.scripts/overflowElements/wrapper.js",
+				"resources/skins.citizen.scripts/overflowElements/float.js",
 				"resources/skins.citizen.scripts/overflowElements/state.js",
 				"resources/skins.citizen.scripts/overflowElements/stickyHeader.js",
 				"resources/skins.citizen.scripts/performance.js",

--- a/tests/vitest/skins.citizen.scripts/overflowElements.test.js
+++ b/tests/vitest/skins.citizen.scripts/overflowElements.test.js
@@ -2,6 +2,7 @@
 /* global document */
 
 const { init } = require( '../../../resources/skins.citizen.scripts/overflowElements/index.js' );
+const { detectFloatDirection } = require( '../../../resources/skins.citizen.scripts/overflowElements/float.js' );
 const mw = require( '../mocks/mw.js' );
 
 /**
@@ -14,6 +15,10 @@ function createMockWindow( overrides = {} ) {
 	return {
 		matchMedia: vi.fn( () => ( { matches: false } ) ),
 		requestAnimationFrame: vi.fn( ( cb ) => cb() ),
+		getComputedStyle: vi.fn( ( el ) => ( {
+			float: el.style.getPropertyValue( 'float' ) || 'none',
+			direction: 'ltr'
+		} ) ),
 		...overrides
 	};
 }
@@ -156,6 +161,205 @@ describe( 'overflowElements', () => {
 			// No wrapper should be created for elements with nowrap class
 			expect( document.querySelector( '.citizen-overflow-wrapper' ) ).toBe( null );
 			expect( observers.IntersectionObserver ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'detectFloatDirection', () => {
+		const makeWindow = ( style ) => ( {
+			getComputedStyle: vi.fn( () => style )
+		} );
+
+		it.each( [
+			[ { float: 'right', direction: 'ltr' }, 'right' ],
+			[ { float: 'left', direction: 'ltr' }, 'left' ],
+			[ { float: 'none', direction: 'ltr' }, null ],
+			[ { float: 'inline-start', direction: 'ltr' }, 'left' ],
+			[ { float: 'inline-start', direction: 'rtl' }, 'right' ],
+			[ { float: 'inline-end', direction: 'ltr' }, 'right' ],
+			[ { float: 'inline-end', direction: 'rtl' }, 'left' ]
+		] )( 'should resolve computed %o to %s', ( style, expected ) => {
+			expect( detectFloatDirection( {}, makeWindow( style ) ) ).toBe( expected );
+		} );
+	} );
+
+	describe( 'float preservation', () => {
+		it( 'should mirror an inline float onto the wrapper as a modifier class', () => {
+			const bodyContent = createBodyContent(
+				'<table class="wikitable" style="float: right;"><tbody><tr><td>a</td></tr></tbody></table>'
+			);
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			const wrapper = document.querySelector( '.citizen-overflow-wrapper' );
+			expect( wrapper.classList.contains( 'citizen-overflow-wrapper--floatright' ) ).toBe( true );
+			expect( wrapper.querySelector( 'table' ) ).not.toBe( null );
+		} );
+
+		it( 'should mirror an inline float:left as the floatleft modifier', () => {
+			const bodyContent = createBodyContent(
+				'<table class="wikitable" style="float: left;"><tbody><tr><td>a</td></tr></tbody></table>'
+			);
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			const wrapper = document.querySelector( '.citizen-overflow-wrapper' );
+			expect( wrapper.classList.contains( 'citizen-overflow-wrapper--floatleft' ) ).toBe( true );
+		} );
+
+		it( 'should mirror an inline float on a .citizen-overflow div', () => {
+			const bodyContent = createBodyContent(
+				'<div class="citizen-overflow" style="float: right;">content</div>'
+			);
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			const wrapper = document.querySelector( '.citizen-overflow-wrapper' );
+			expect( wrapper.classList.contains( 'citizen-overflow-wrapper--floatright' ) ).toBe( true );
+			expect( wrapper.querySelector( 'div.citizen-overflow' ) ).not.toBe( null );
+		} );
+
+		it( 'should not add a float modifier to non-floated elements', () => {
+			const bodyContent = createBodyContent( '<table class="wikitable"></table>' );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: createMockWindow(),
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			const wrapper = document.querySelector( '.citizen-overflow-wrapper' );
+			expect( wrapper.classList.contains( 'citizen-overflow-wrapper--floatleft' ) ).toBe( false );
+			expect( wrapper.classList.contains( 'citizen-overflow-wrapper--floatright' ) ).toBe( false );
+		} );
+
+		it( 'should migrate inherited classes without adding a float modifier', () => {
+			const bodyContent = createBodyContent(
+				'<table class="wikitable floatright"></table>'
+			);
+			const win = createMockWindow();
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: win,
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig( {
+					wgCitizenOverflowInheritedClasses: [ 'floatright' ]
+				} )
+			} );
+
+			const wrapper = document.querySelector( '.citizen-overflow-wrapper' );
+			// The class migrates wholesale (viewport-correct via hacks.less)
+			expect( wrapper.classList.contains( 'floatright' ) ).toBe( true );
+			expect( wrapper.classList.contains( 'citizen-overflow-wrapper--floatright' ) ).toBe( false );
+			expect( bodyContent.querySelector( 'table' ).classList.contains( 'floatright' ) ).toBe( false );
+			// Detection is skipped entirely for inherited-class elements
+			expect( win.getComputedStyle ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should finish all computed-style reads before any wrapping', () => {
+			const bodyContent = createBodyContent(
+				'<table class="wikitable" style="float: right;"></table>' +
+				'<table class="wikitable" style="float: left;"></table>'
+			);
+			const wrappersAtRead = [];
+			const win = createMockWindow( {
+				getComputedStyle: vi.fn( ( el ) => {
+					wrappersAtRead.push(
+						document.querySelectorAll( '.citizen-overflow-wrapper' ).length
+					);
+					return { float: el.style.getPropertyValue( 'float' ) || 'none', direction: 'ltr' };
+				} )
+			} );
+			const observers = createMockObservers();
+
+			init( {
+				document,
+				window: win,
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} );
+
+			// Every read saw zero wrappers: reads were fully batched ahead of writes
+			expect( wrappersAtRead ).toEqual( [ 0, 0 ] );
+			expect( document.querySelectorAll( '.citizen-overflow-wrapper' ) ).toHaveLength( 2 );
+		} );
+
+		it( 'should isolate a computed-style failure to its own element', () => {
+			const bodyContent = createBodyContent(
+				'<table class="wikitable"></table>' +
+				'<table class="wikitable" style="float: left;"></table>'
+			);
+			const tables = bodyContent.querySelectorAll( 'table' );
+			const win = createMockWindow( {
+				getComputedStyle: vi.fn( ( el ) => {
+					if ( el === tables[ 0 ] ) {
+						throw new Error( 'monkey-patched' );
+					}
+					return { float: el.style.getPropertyValue( 'float' ) || 'none', direction: 'ltr' };
+				} )
+			} );
+			const observers = createMockObservers();
+
+			expect( () => init( {
+				document,
+				window: win,
+				mw,
+				IntersectionObserver: observers.IntersectionObserver,
+				ResizeObserver: observers.ResizeObserver,
+				bodyContent,
+				config: createConfig()
+			} ) ).not.toThrow();
+
+			// Both elements are still wrapped despite the failed detection
+			const wrappers = document.querySelectorAll( '.citizen-overflow-wrapper' );
+			expect( wrappers ).toHaveLength( 2 );
+			// The throwing element degrades to no modifier ...
+			expect( wrappers[ 0 ].classList.contains( 'citizen-overflow-wrapper--floatleft' ) ).toBe( false );
+			expect( wrappers[ 0 ].classList.contains( 'citizen-overflow-wrapper--floatright' ) ).toBe( false );
+			// ... while the healthy element still gets its modifier
+			expect( wrappers[ 1 ].classList.contains( 'citizen-overflow-wrapper--floatleft' ) ).toBe( true );
+			expect( mw.log.error ).toHaveBeenCalledWith(
+				expect.stringContaining( '[Citizen] Error occurred while detecting float direction' )
+			);
 		} );
 	} );
 


### PR DESCRIPTION
## What & why

The overflow enhancement wraps wide content (wikitables, `.citizen-overflow` elements) in a scroll container at runtime. When a wiki author had floated that element — via an inline `style="float: right"` or a class defined in the wiki's CSS — wrapping stranded the float on the inner element, where it sits inside the wrapper's formatting context and does nothing. The author's layout silently broke.

Wiki content is user-generated, and most editors aren't thinking about how their float interacts with the skin's responsive wrapping. This makes the skin do the sensible thing for them.

## Approach

Detect the float and **re-express it on the wrapper using the skin's standard responsive float treatment** — the same rules MW core float classes already get: floated beside the text at tablet width and up, stacked in normal flow on mobile. We take the author's float *direction* as intent and render it the skin's way, rather than copying their exact styling (which would faithfully reproduce broken mobile layouts) or skipping the wrap (which would lose the overflow handling entirely).

Authors who want full control keep the existing escape hatch: `citizen-table-nowrap` / `$wgCitizenOverflowNowrapClasses` opts an element out of wrapping entirely.

## What changed

- **JS detection** (`overflowElements/float.js`, `index.js`, `wrapper.js`): a batched computed-style read pass runs *before* any wrapping and, for elements without a known inherited float class, resolves the computed `float` (including logical `inline-start`/`inline-end` against `direction` for RTL). The wrapper is then stamped with a `citizen-overflow-wrapper--floatleft`/`--floatright` modifier. Reads stay fully batched ahead of DOM writes, and detection is fault-isolated so one throwing element can't abort the whole pass.
- **LESS** (`mixins.less`, `common/hacks.less`, `components/OverflowElements.less`): a shared `.mixin-citizen-float-declarations` holds the float/clear/margin treatment so the new modifiers and the legacy `.floatleft`/`.floatright` classes can't drift. Each declaration carries its own `/* @noflip */` so CSSJanus keeps the floats physical on RTL wikis. The inner element's float and margins are neutralized so author spacing doesn't double up inside the wrapper.
- **Known float classes** (`$wgCitizenOverflowInheritedClasses`, default `floatleft`/`floatright`) keep their existing wholesale-class-migration path and are skipped by detection — that path is viewport-correct where a computed snapshot isn't.
- **Docs**: a "Floated tables" note in `docs/src/customization/utility-classes.md`.

No PHP, config, or i18n changes. Not preview-gated (works in both worlds). No two-commit cache split needed — the wrapper is client-rendered and the CSS/JS ship together.

## Testing

- **Unit** (Vitest): detection helper across all float values incl. logical + RTL; wrapper modifier stamping for tables and `.citizen-overflow` divs; inherited-class path skips detection; nowrap skip; read-before-write batching probe; fault-isolation regression. Full suite green.
- **Browser** (live wiki, Citizen skin): inline-float table, `floatleft`-class table, and a bare floated `.citizen-overflow` div, verified at desktop (float preserved, correct text-facing gap, inner float/margins neutralized, no doubled gap), mobile (stacks below the tablet breakpoint), and **RTL** (`uselang=ar` — floats stay physically correct, not flipped).
- **RTL noflip** independently verified through the real `wikimedia/less.php` + `wikimedia/cssjanus` round-trip.
- **Performance**: no forced reflow — `float`/`direction` are style-resolved keywords (not layout-dependent), reads are batched ahead of writes, and the read benched at ~0.8µs.

## Notes

Draft — opened for review. The one documented fragility is that the wrapper's float-margin cascade relies on source order within `OverflowElements.less` (both same-specificity ties are commented in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2q2vXd2shywqtJ7Y29fVe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved left- and right-floated content when tables or other elements are wrapped for horizontal scrolling.
  - Improved handling of floated content in both left-to-right and right-to-left layouts.
  - Prevented duplicate spacing and unintended float behavior inside overflow wrappers.

- **Documentation**
  - Added guidance on floated overflow content and how to disable automatic wrapping with the supported opt-out classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->