### PR TITLE
refactor(media): reuse the shared float mixin for image floats

### DIFF
--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -284,9 +284,10 @@
 	}
 }
 
-// Standard float treatment for user-floated content. Shared between the
-// legacy float classes (common/hacks.less) and the overflow wrapper float
-// modifiers (components/OverflowElements.less) so the two cannot drift.
+// Standard float treatment for floated content. Shared by the legacy float
+// classes (common/hacks.less), the overflow wrapper float modifiers
+// (components/OverflowElements.less), and the media/thumbnail floats
+// (skinning/content.media-common.less) so they cannot drift.
 // Floats are physical by MediaWiki convention, so each declaration carries
 // its own /* @noflip */ so CSSJanus does not flip them for RTL wikis.
 // Callers own only the tablet media query. Only the literal keywords

--- a/resources/skins.citizen.styles/skinning/content.media-common.less
+++ b/resources/skins.citizen.styles/skinning/content.media-common.less
@@ -105,21 +105,11 @@ figure[ typeof~='mw:File/Frame' ] {
 
 		// When float is not explicitly set
 		.mw-content-ltr & {
-			/* @noflip */
-			float: right;
-			/* @noflip */
-			clear: right;
-			/* @noflip */
-			margin-left: var( --space-lg );
+			.mixin-citizen-float-declarations( right );
 		}
 
 		.mw-content-rtl & {
-			/* @noflip */
-			float: left;
-			/* @noflip */
-			clear: left;
-			/* @noflip */
-			margin-right: var( --space-lg );
+			.mixin-citizen-float-declarations( left );
 		}
 	}
 
@@ -128,23 +118,13 @@ figure[ typeof~='mw:File/Frame' ] {
 	figure[ typeof~='mw:File/Thumb' ],
 	figure[ typeof~='mw:File/Frame' ] {
 		&.mw-halign-right {
-			/* @noflip */
-			float: right;
-			/* @noflip */
-			clear: right;
+			.mixin-citizen-float-declarations( right );
 			/* @noflip */
 			margin-right: 0;
-			/* @noflip */
-			margin-left: var( --space-lg );
 		}
 
 		&.mw-halign-left {
-			/* @noflip */
-			float: left;
-			/* @noflip */
-			clear: left;
-			/* @noflip */
-			margin-right: var( --space-lg );
+			.mixin-citizen-float-declarations( left );
 			/* @noflip */
 			margin-left: 0;
 		}


### PR DESCRIPTION
Follow-up to #1671.

## What & why

That PR introduced `.mixin-citizen-float-declarations` to hold the float/clear/text-side-margin treatment in one place "so they cannot drift" — but it only covered two of the sites that use that exact trio (the legacy `.floatleft`/`.floatright` classes and the overflow wrapper modifiers). `skinning/content.media-common.less` had three more copies of it, for image/thumbnail floats, left untouched.

This consolidates those three onto the same mixin, so the trio now lives in exactly one place and the drift guarantee actually holds across the board.

## What changed

- `skinning/content.media-common.less`: the default thumbnail float (`.mw-content-ltr`/`.mw-content-rtl`) and the `.mw-halign-right`/`.mw-halign-left` rules now call `.mixin-citizen-float-declarations( right | left )`. The halign rules keep their extra opposite-side `margin: 0` line (which the mixin doesn't set).
- `mixins.less`: doc comment updated to list the media floats as the third consumer.

Net −19 lines. No behavior change intended.

## Verification

- **Behavior-preserving by compilation**, not eyeball: compiled the old inline rules and the new mixin-based rules with `lessc` and confirmed each rule emits an identical set of declarations (the only diff is a cosmetic order swap of two independent longhand margins in `.mw-halign-right`, which has no rendering effect).
- Every emitted declaration keeps its `/* @noflip */`, so CSSJanus behavior on RTL wikis is unchanged.
- `npm run lint:styles` clean; pre-commit hook (lint + full test suite) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2q2vXd2shywqtJ7Y29fVe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media and thumbnail alignment on tablet-sized screens and larger.
  * Standardized left- and right-aligned media behavior across both left-to-right and right-to-left layouts.
  * Reduced inconsistent spacing and clearing around floated media elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->