### PR TITLE
docs(overflow): add a dedicated overflow handling page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -96,6 +96,10 @@ export default defineConfig({
 						link: "/features/command-palette",
 					},
 					{
+						text: "Overflow handling",
+						link: "/features/overflow",
+					},
+					{
 						text: "Performance mode",
 						link: "/features/performance-mode",
 					},

--- a/docs/src/customization/utility-classes.md
+++ b/docs/src/customization/utility-classes.md
@@ -16,40 +16,8 @@ Control the positioning and flow of your content.
 | <CopyCode code=".floatright" /> | Floats content to the right. Stacks vertically on small screens. |
 | <CopyCode code=".floatleft" /> | Floats content to the left. Stacks vertically on small screens. |
 | <CopyCode code=".floatnone" /> | Clears floating alignment. |
-| <CopyCode code=".citizen-overflow" /> | Wraps content in a horizontally scrollable container with indicators. |
-| <CopyCode code=".citizen-overflow-sticky-header" /> | Makes an element sticky within a `.citizen-overflow` container. |
-
-### Element sticky header
-
-You can make headers sticky within a scrollable area (like a wide table) by adding the `citizen-overflow-sticky-header` class. This works for both `div` elements and wikitables.
-
-For `div` elements:
-
-```html
-<div class="citizen-overflow">
-  <div class="citizen-overflow-sticky-header">I am sticky 👍</div>
-  <div>I am not sticky 👎</div>
-</div>
-```
-
-For wikitables:
-
-```wikitext
-{| class="wikitable"
-|- class="citizen-overflow-sticky-header"
-! Header text !! Header text !! Header text
-|-
-| Example || Example || Example
-|-
-| Example || Example || Example
-|-
-| Example || Example || Example
-|}
-```
-
-### Floated overflow content
-
-When an element that Citizen wraps for overflow is floated — through an inline `float` style or a class defined in your wiki's CSS — Citizen keeps the float working by re-applying it to the wrapper it adds. This covers any `.citizen-overflow` element as well as wikitables, which are wrapped automatically: floated content sits beside the text on tablet screens and up, and stacks on mobile. To opt out of wrapping (for example, an automatically wrapped wikitable), use `.citizen-table-nowrap` or any class listed in `$wgCitizenOverflowNowrapClasses`.
+| <CopyCode code=".citizen-overflow" /> | Wraps content in a horizontal scroll container. See [Overflow handling](/features/overflow). |
+| <CopyCode code=".citizen-overflow-sticky-header" /> | Keeps an element sticky within a `.citizen-overflow` container. See [Overflow handling](/features/overflow#sticky-headers). |
 
 ## Tables
 
@@ -57,11 +25,11 @@ Enhance the look and feel of your tables.
 
 | Class | Description |
 | :--- | :--- |
-| <CopyCode code=".wikitable" /> | Applies standard Citizen styling. Automatically wrapped in `.citizen-overflow`. |
+| <CopyCode code=".wikitable" /> | Applies standard Citizen styling. Automatically [wrapped for overflow](/features/overflow). |
 | <CopyCode code=".wikitable--border" /> | Adds vertical borders. |
 | <CopyCode code=".wikitable--stripe" /> | Adds zebra striping for better readability. |
 | <CopyCode code=".wikitable--fluid" /> | Expands the table to fill 100% of the available width. |
-| <CopyCode code=".citizen-table-nowrap" /> | Prevents the table from being wrapped in a scrollable container. |
+| <CopyCode code=".citizen-table-nowrap" /> | Prevents the table from being [wrapped for overflow](/features/overflow#opting-out). |
 
 ## Interaction
 

--- a/docs/src/features/overflow.md
+++ b/docs/src/features/overflow.md
@@ -1,0 +1,88 @@
+---
+title: Overflow handling
+description: Stop wide tables and code blocks from pushing the whole page sideways — Citizen scrolls them in place, with navigation buttons and sticky headers.
+---
+
+# Overflow handling
+
+When a table, code block, or other element is wider than the page, the whole page scrolls sideways to fit it — and everything else slides off-screen along with it. Citizen confines that sideways scrolling to the wide element alone, so the page stays put and only the element itself scrolls.
+
+## How it works
+
+Citizen makes that sideways scrolling easy to spot and use:
+
+- **Navigation buttons** — on devices with a mouse or trackpad, buttons appear at each edge to scroll the content left and right.
+- **Scroll indicators** — a soft fade appears at any edge where the content continues, so it's clear there's more to see.
+
+Tables with the `wikitable` class are wrapped automatically.
+
+### Opting in
+
+Give any element the same treatment by adding the `citizen-overflow` class:
+
+```html
+<div class="citizen-overflow">
+  Wide content that should scroll on its own instead of pushing the page sideways.
+</div>
+```
+
+### Opting out
+
+To leave an element as-is — for example a table you lay out yourself — add the `citizen-table-nowrap` class:
+
+```wikitext
+{| class="wikitable citizen-table-nowrap"
+! Header !! Header
+|-
+| Example || Example
+|}
+```
+
+The list of opt-out classes is configurable — see [`$wgCitizenOverflowNowrapClasses`](#wgcitizenoverflownowrapclasses).
+
+### Sticky headers
+
+Keep a header visible while the rest of a wide element scrolls by adding the `citizen-overflow-sticky-header` class. It works for both `div` elements and wikitables.
+
+For `div` elements:
+
+```html
+<div class="citizen-overflow">
+  <div class="citizen-overflow-sticky-header">I am sticky 👍</div>
+  <div>I am not sticky 👎</div>
+</div>
+```
+
+For wikitables:
+
+```wikitext
+{| class="wikitable"
+|- class="citizen-overflow-sticky-header"
+! Header text !! Header text !! Header text
+|-
+| Example || Example || Example
+|-
+| Example || Example || Example
+|-
+| Example || Example || Example
+|}
+```
+
+## Configuration
+
+### `$wgCitizenOverflowNowrapClasses`
+
+Classes that make Citizen skip an element entirely. Set this in `LocalSettings.php`. Default:
+
+```php [LocalSettings.php]
+$wgCitizenOverflowNowrapClasses = [
+    'noresize',
+    'citizen-table-nowrap',
+    'cargoDynamicTable',
+    'dataTable',
+    'smw-datatable',
+    'srf-datatable',
+];
+```
+
+The defaults cover `citizen-table-nowrap` and the table classes used by common extensions (Cargo, DataTables, Semantic MediaWiki) that manage their own layout. Add your own classes to skip them too.


### PR DESCRIPTION
Documentation follow-up: overflow handling was hard to find because it was scattered across the **Layout** and **Tables** sections of the utility classes page, framed as a set of static classes. It's really a runtime behavior — scroll indicators, navigation buttons, sticky headers — so this gives it a dedicated page in the **Features** group and leaves the class tables as a scannable index that links into it.

## What changed

- **New page `docs/src/features/overflow.md`** (Features sidebar, between Command palette and Performance mode): what the feature does and why, how it works (navigation buttons, scroll indicators), opting in with `citizen-overflow`, opting out with `citizen-table-nowrap`, sticky headers, and the `$wgCitizenOverflowNowrapClasses` configuration.
- **`utility-classes.md` trimmed**: the `.citizen-overflow`, `.citizen-overflow-sticky-header`, `.citizen-table-nowrap`, and `.wikitable` rows stay as a quick reference, each now cross-linking into the new page; the sticky-header and float prose blocks are removed (moved / dropped).
- **`config.ts`**: sidebar entry for the new page.

The copy is deliberately reader-focused — no implementation jargon, and it leads with the reader's problem (a wide element dragging the whole page sideways) rather than the mechanism.

## Verification

- `npm run lint:md`, `npm run lint:js` (oxlint), and `npm run format:check` all clean.
- `npm run docs:build` passes with VitePress dead-link checking active (the top-level config does not disable it), so every cross-link and in-page anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2q2vXd2shywqtJ7Y29fVe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Overflow handling” guide covering horizontal scrolling for wide content such as tables and code blocks.
  * Documented navigation buttons, scroll indicators, opt-in and opt-out classes, and sticky headers.
  * Added the new guide to the Features navigation.
  * Simplified and linked overflow-related utility class and table guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->