### PR TITLE
feat(VisualEditor): ✨ minor categoryEdit styling improvements

### DIFF
--- a/resources/skins.citizen.styles/skinning/interface.category.less
+++ b/resources/skins.citizen.styles/skinning/interface.category.less
@@ -8,7 +8,7 @@
 	clear: both;
 	display: flex;
 	flex-wrap: wrap;
-	gap: var( --space-lg );
+	gap: var( --space-xs );
 
 	ul {
 		display: flex;

--- a/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
+++ b/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
@@ -66,8 +66,8 @@
 	align-items: center;
 	align-self: flex-start;
 	order: 1;
-	width: 40px;
-	height: 40px;
+	width: 32px;
+	height: 32px;
 	padding: var( --space-xs );
 	margin-top: auto;
 	color: var( --color-base );
@@ -81,7 +81,6 @@
 	a {
 		display: flex;
 		align-items: center;
-		margin: auto;
 		font-size: 0; // Hide "edit" text
 		color: inherit;
 		text-decoration: none;


### PR DESCRIPTION
this pr resizes the button and changes the gap size between the catlinks

before/after:
<img width="147" height="79" alt="image" src="https://github.com/user-attachments/assets/63b4830e-abdc-44c4-8efe-80f45f9bf32b" />
<img width="98" height="56" alt="image" src="https://github.com/user-attachments/assets/43c0253e-928a-4fba-81df-fc6d872b7859" />

---

additionally, i wanted to say thanks for adding my wiki to the showcase and finishing the share panel pr for me, i appreciate it!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced spacing between wrapped category links for a more compact layout.
  * Improved the appearance and alignment of the VisualEditor category edit control by reducing its size and refining its internal positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->