### PR TITLE
docs: cut over links to mwcitizen.skin and fix archived version paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/XcKwqyD4sc
     about: Join our Discord server and ask in #citizen-skin-support.
   - name: Documentation
-    url: https://starcitizentools.github.io/mediawiki-skins-Citizen/
+    url: https://mwcitizen.skin/
     about: Check the documentation for setup guides and configuration options.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for considering contributing to *Citizen*!
 *Citizen* is a small open-source project, and we appreciate any help. Here are some ways you can contribute:
 
 - [Code patches](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/pulls)
-- [Documentation improvements](https://starcitizentools.github.io/mediawiki-skins-Citizen/)
+- [Documentation improvements](https://mwcitizen.skin/)
 - [Bug reports](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/issues/new?template=bug_report.yml)
 - [Feature requests and suggestions](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/issues/new?template=feature_request.yml)
 - [Translations](#translations)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 <p align="center">
   <a href="https://starcitizen.tools">🚀 Live demo</a> |
-  <a href="https://starcitizentools.github.io/mediawiki-skins-Citizen/community/showcase/">✨ Showcase</a> |
-  <a href="https://starcitizentools.github.io/mediawiki-skins-Citizen">📚 Documentation</a>
+  <a href="https://mwcitizen.skin/community/showcase/">✨ Showcase</a> |
+  <a href="https://mwcitizen.skin">📚 Documentation</a>
 </p>
 
 ## Notable features
@@ -46,7 +46,7 @@
 
 ## Configurations
 
-Check out the [configuration documentation](https://starcitizentools.github.io/mediawiki-skins-Citizen/config/) for more details.
+Check out the [configuration documentation](https://mwcitizen.skin/config/) for more details.
 
 ## Requirements
 
@@ -60,7 +60,7 @@ Version | MediaWiki version
 
 ## Extensions
 
-Check out the [extensions documentation](https://starcitizentools.github.io/mediawiki-skins-Citizen/config/extensions) for recommended extensions and supported extension styles.
+Check out the [extensions documentation](https://mwcitizen.skin/config/extensions) for recommended extensions and supported extension styles.
 
 ## Contributors
 

--- a/docs/src/contribute/index.md
+++ b/docs/src/contribute/index.md
@@ -5,6 +5,12 @@ description: How to contribute to the Citizen skin.
 
 <!--@include: ../../../CONTRIBUTING.md-->
 
+## Documentation previews
+
+Every pull request that changes the documentation gets its own live preview site — a bot comments on the PR with the link shortly after you push, and the preview updates on every subsequent push. No local setup needed to see your changes rendered.
+
+Previews are built for branches in the main repository. Pull requests from forks still run the documentation lint and build checks, but don't get a preview link.
+
 ## Contributors
 
 <a href="https://github.com/StarCitizenTools/mediawiki-skins-citizen/graphs/contributors">

--- a/docs/src/public/_redirects
+++ b/docs/src/public/_redirects
@@ -1,0 +1,5 @@
+# Cloudflare Pages redirects.
+# Archived version builds (/v3.13/–/v3.18/) were built for the old GitHub Pages
+# base path and still reference /mediawiki-skins-Citizen/... internally — this
+# also covers external links using the old path shape.
+/mediawiki-skins-Citizen/* /:splat 301


### PR DESCRIPTION
## Summary
- Fixes the broken styles/links on the archived version docs (`/v3.13/`–`/v3.18/`): those builds were made for the old GitHub Pages base path and still reference `/mediawiki-skins-Citizen/...` internally. A Cloudflare Pages `_redirects` rule (`/mediawiki-skins-Citizen/* → /:splat 301`) repairs all of them without touching the frozen artifacts, and also covers external links using the old path shape.
- Updates README, issue template, and CONTRIBUTING links from `starcitizentools.github.io/mediawiki-skins-Citizen` to `https://mwcitizen.skin`.
- Documents the new docs PR preview deployments on the contribute page.

## Test Plan
- [x] `_redirects` verified in `dist/` root after a local build; markdown + docs lint clean
- [x] This PR gets a preview comment with `pr-<N>.mediawiki-skins-citizen.pages.dev` (smoke test of the new preview flow)
- [x] Post-merge: `https://mwcitizen.skin/mediawiki-skins-Citizen/v3.17/assets/style.x62PotCr.css` → 301 → 200, and `https://mwcitizen.skin/v3.17/` renders styled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project links for the Showcase, documentation, configuration, and extensions pages.
  - Added guidance about documentation preview links for eligible contributions.
  - Added redirects so older documentation URLs continue to work.
- **Chores**
  - Updated the issue template’s documentation contact link to the new documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->