### PR TITLE
fix(sections): hide standalone images and tables when collapsed

### DIFF
--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -34,7 +34,8 @@ function createSections( { document, bodyContent } ) {
 	 * Collapse or expand a section that contains its own heading. The
 	 * heading stays visible; every other direct child (including nested
 	 * subsections) is hidden with `until-found` so find-in-page can still
-	 * reach the content.
+	 * reach the content. The attribute does not hide on its own — see the
+	 * `.citizen-section--collapsed > [hidden]` rules in Sections.less.
 	 *
 	 * @param {HTMLElement} section
 	 * @param {boolean} collapsed

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -74,4 +74,31 @@ section[ data-mw-section-id ] > .mw-heading,
 			color: var( --color-subtle );
 		}
 	}
+
+	// Collapsing hides each child with `hidden="until-found"`, but the
+	// attribute alone cannot be trusted to hide anything: its UA rendering
+	// loses to any author `display` declaration, and its `content-visibility`
+	// form is a no-op on elements whose inner display type is table. Thumbnail
+	// figures and bare wikitables hit both cases and stayed fully painted
+	// while the rest of the section collapsed.
+	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > [ hidden ] {
+		display: none;
+	}
+
+	// The attribute only reads back as `until-found` on engines that accept
+	// the value, and those are exactly the engines that render it as
+	// `content-visibility: hidden`; elsewhere it reflects as a bare `hidden`
+	// and keeps the plain hide above. Giving it a block box makes size
+	// containment apply, so that content-visibility takes hold and
+	// find-in-page still reaches the collapsed content.
+	// The UA matches this keyword case-insensitively and we cannot: less.php
+	// rejects the `i` flag in a selector. Collapsing writes the attribute
+	// through the `hidden` IDL setter on every child, so it is always
+	// canonically cased by the time these rules can match.
+	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > [ hidden='until-found' ] {
+		display: block;
+		// A size-contained box is zero-height but keeps its margins, which
+		// would stack the whole section's dead space under the heading.
+		margin-block: 0;
+	}
 }


### PR DESCRIPTION
Fixes #1693

## The bug

Collapsing a section hid text and galleries but left a standalone `[[File:x.jpg|thumb]]` fully painted — often floating over the *next* section. Reported on both Firefox and Chromium.

**Bare wikitables had the identical bug**, which nobody had reported.

## Root cause

Not an image-specific exemption — a CSS containment carve-out.

`sections.js` hides each child with `hidden="until-found"`, whose UA rendering is `content-visibility: hidden`. That relies on **size containment, which per css-contain has no effect when an element's inner display type is `table`**. `content.media-common.less` gives thumb/frame figures `display: table`, so containment never applied and they stayed fully rendered.

The attribute's other UA rendering, `[hidden] { display: none }`, is UA-origin and loses to *any* author `display` declaration — so it could not hide them either. That is why it reproduced across engines rather than looking like a browser bug.

## The fix

CSS only, in `Sections.less`:

- Hidden children of a collapsed section take an author-origin `display: none`, which beats the figure's `display: table`.
- On engines that accept `hidden="until-found"`, they instead get a block box, so containment applies, the UA's `content-visibility` takes hold, and find-in-page still reaches the content. The attribute value is itself the feature detector: it only reads back as `until-found` on engines that render it that way, so no `@supports` guard is needed.
- Their block margins are zeroed. A size-contained box is zero-height but keeps its margins, so a "collapsed" text section was already stacking ~84px of dead space under the heading.

## Verification

Measured on a real page (MW 1.45, Chrome 145), toggling via a real heading click:

| | collapsed section height | thumb figure |
| --- | --- | --- |
| before | 102px | `table 300x330` — visible |
| after | 40px | `block 0x0` |

Also confirmed:

- `display` reverts byte-identically on expand (`table` -> `table`, `flex` -> `flex`); no residue.
- The legacy branch (engines whose `HTMLElement.hidden` is boolean-only) hides via `display: none`, including the thumbs that were previously visible there too.
- `<style>` and `<link>` children stay invisible in every state.
- Fragment navigation into the now-skipped table fires `beforematch` on it and the UA strips the attribute — thumbs and tables now participate in the find-in-page reveal path they never could before.
- Focus sitting inside content when it collapses moves to `body`; nothing is trapped on an invisible element.
- 1065 Vitest tests, stylelint and eslint all clean.

No two-commit cache split is needed: this is CSS-only against markup that already exists, so it works against cached HTML in either direction.

## Notes

- No unit test added. The JS is unchanged (comment only) and jsdom does no layout, so any assertion would be a tautology.
- `less.php` cannot parse the `i` flag in an attribute selector (`Expected ']' got 'i'`), and **stylelint does not catch this** — it would take out the whole `skins.citizen.styles` module. The selector is left case-sensitive and the boundary documented; collapsing writes `hidden` through the IDL setter on every child, so casing is always canonical by the time the rules can match.
- Out of scope, worth its own issue: the collapse control is a bare `<h2>` with no `role`, `tabindex`, `aria-expanded` or focusability, so sections cannot be toggled by keyboard at all. This fix raises the stakes, since content that used to stay visible when collapsed is now genuinely hidden behind that control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsed sections so their content is reliably hidden.
  * Preserved find-in-page access for content using `hidden="until-found"` while preventing unwanted empty space beneath section headings.
* **Documentation**
  * Clarified how collapsed-section hiding behavior works.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->