### PR TITLE
fix(sections): make collapsing sections keyboard accessible

### DIFF
--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -1,5 +1,8 @@
 const COLLAPSED_CLASS = 'citizen-section--collapsed';
 const HEADING_SELECTOR = '.mw-heading, .citizen-section-heading';
+const HEADING_TAGS = 'h1, h2, h3, h4, h5, h6';
+const TOGGLE_CLASS = 'citizen-section-toggle';
+const INTERACTIVE_CLASS = 'citizen-sections-interactive';
 const COLLAPSED_SECTION_SELECTOR =
 	`section[data-mw-section-id].${ COLLAPSED_CLASS }, section.citizen-section.${ COLLAPSED_CLASS }`;
 
@@ -10,6 +13,7 @@ const COLLAPSED_SECTION_SELECTOR =
  * @return {Object}
  */
 function createSections( { document, bodyContent } ) {
+	let labelCount = 0;
 	/**
 	 * The section wrapper a heading belongs to: a native Parsoid section or
 	 * a section produced by the legacy transform (both carry the heading as
@@ -31,6 +35,88 @@ function createSections( { document, bodyContent } ) {
 	}
 
 	/**
+	 * The element whose text names the section. Legacy heading markup keeps
+	 * it in `.mw-headline`; newer markup drops that wrapper and puts the text
+	 * — and the anchor id — straight on the heading tag.
+	 *
+	 * @param {HTMLElement} heading
+	 * @param {HTMLElement|null} headingTag
+	 * @return {HTMLElement}
+	 */
+	function getHeadingLabel( heading, headingTag ) {
+		return heading.querySelector( '.mw-headline' ) || headingTag || heading;
+	}
+
+	/**
+	 * An id no other element on the page already claims. Section titles
+	 * normally carry their own anchor, so this is only reached for markup
+	 * that has none — but the counter restarts with every instance, and
+	 * nothing reserves the prefix against page content.
+	 *
+	 * @return {string}
+	 */
+	function getUniqueLabelId() {
+		let id;
+		do {
+			labelCount++;
+			id = `citizen-section-label-${ labelCount }`;
+		} while ( document.getElementById( id ) );
+		return id;
+	}
+
+	/**
+	 * Give a heading a real control. Pointer users can already toggle through
+	 * the delegated click handler, but a bare heading is unreachable by
+	 * keyboard and announces neither that it is a control nor what state it
+	 * is in. A native button fixes both and needs no listener of its own:
+	 * Enter and Space fire a click that bubbles to the same handler.
+	 *
+	 * @param {HTMLElement} heading
+	 * @return {void}
+	 */
+	function addToggle( heading ) {
+		if ( heading.querySelector( `.${ TOGGLE_CLASS }` ) ) {
+			return;
+		}
+
+		const headingTag = heading.matches( HEADING_TAGS ) ?
+			heading :
+			heading.querySelector( HEADING_TAGS );
+		const label = getHeadingLabel( heading, headingTag );
+		if ( !label.id ) {
+			label.id = getUniqueLabelId();
+		}
+
+		const toggle = document.createElement( 'button' );
+		toggle.type = 'button';
+		toggle.className = TOGGLE_CLASS;
+		toggle.setAttribute( 'aria-expanded', 'true' );
+		// Naming the control after its section is the disclosure convention:
+		// "Foo, button, collapsed" beats a generic label, and it keeps the
+		// wording out of i18n.
+		toggle.setAttribute( 'aria-labelledby', label.id );
+
+		if ( headingTag && headingTag !== heading ) {
+			// Newer markup wraps the heading tag in a container, so the
+			// button sits beside it and the heading keeps a clean accessible
+			// name. Placing it *after* the heading tag means jumping between
+			// headings and reading on reaches the control; the styles order
+			// it first, so nothing moves.
+			headingTag.after( toggle );
+		} else {
+			// Legacy markup has no wrapper, so the button goes inside the
+			// heading tag — which heading navigation lands on, so first child
+			// reads in the right order. It would otherwise be folded into the
+			// heading's accessible name, so pin that to the title text. Both
+			// can go when the legacy heading DOM does.
+			heading.insertBefore( toggle, heading.firstChild );
+			if ( headingTag && label !== heading ) {
+				heading.setAttribute( 'aria-labelledby', label.id );
+			}
+		}
+	}
+
+	/**
 	 * Collapse or expand a section that contains its own heading. The
 	 * heading stays visible; every other direct child (including nested
 	 * subsections) is hidden with `until-found` so find-in-page can still
@@ -44,6 +130,10 @@ function createSections( { document, bodyContent } ) {
 		section.classList.toggle( COLLAPSED_CLASS, collapsed );
 		for ( const child of section.children ) {
 			if ( child.matches( HEADING_SELECTOR ) ) {
+				const toggle = child.querySelector( `.${ TOGGLE_CLASS }` );
+				if ( toggle ) {
+					toggle.setAttribute( 'aria-expanded', ( !collapsed ).toString() );
+				}
 				continue;
 			}
 			child.hidden = collapsed ? 'until-found' : false;
@@ -59,6 +149,16 @@ function createSections( { document, bodyContent } ) {
 		if ( !document.body.classList.contains( 'citizen-sections-enabled' ) ) {
 			return;
 		}
+
+		for ( const heading of bodyContent.querySelectorAll( HEADING_SELECTOR ) ) {
+			// Pre-convergence cached markup keeps the heading outside the
+			// section, where there is nothing to toggle.
+			if ( getSectionFromHeading( heading ) ) {
+				addToggle( heading );
+			}
+		}
+		// Every toggle is in place, so the styles can hand the chevron over.
+		document.body.classList.add( INTERACTIVE_CLASS );
 
 		const onEditSectionClick = ( e ) => {
 			e.stopPropagation();

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -15,14 +15,33 @@ section[ data-mw-section-id ] > .mw-heading,
 	}
 }
 
-// The collapse affordance is applied purely through CSS — no indicator
-// markup is injected server- or client-side, so first paint carries it
-// with no layout shift and noscript clients never see it. All markup
-// shapes share one recipe: the legacy transform's sections (heading
-// inside, carrying .citizen-section-heading) and native Parsoid
+// The chevron. Drawn on the heading's ::before so first paint carries the
+// affordance with no layout shift and noscript clients never see it, then
+// handed to the injected toggle button once sections.js has run. Both take
+// the same box in the same flex slot, so the handover moves nothing.
+// Trade-off: the pre-JS form claims the heading's single ::before slot, so
+// any extension or gadget styling these headings' ::before will conflict.
+.mixin-citizen-section-chevron() {
+	display: block;
+	width: var( --size-icon );
+	height: var( --size-icon );
+	content: '';
+	background-color: currentcolor;
+	-webkit-mask-image: url( assets/images/cdxIconCollapse.svg );
+	mask-image: url( assets/images/cdxIconCollapse.svg );
+	-webkit-mask-repeat: no-repeat;
+	mask-repeat: no-repeat;
+	-webkit-mask-position: center;
+	mask-position: center;
+	-webkit-mask-size: contain;
+	mask-size: contain;
+	transition: var( --transition-hover );
+	transition-property: transform;
+}
+
+// All markup shapes share one recipe: the legacy transform's sections
+// (heading inside, carrying .citizen-section-heading) and native Parsoid
 // sections (<section data-mw-section-id> with the heading inside).
-// Trade-off: this claims the heading's single ::before slot, so any
-// extension or gadget styling these headings' ::before will conflict.
 .client-js .citizen-sections-enabled {
 	section:is( [ data-mw-section-id ], .citizen-section ) > :is( .mw-heading, .citizen-section-heading ) {
 		cursor: pointer;
@@ -32,21 +51,8 @@ section[ data-mw-section-id ] > .mw-heading,
 		&::before {
 			flex-shrink: 0;
 			order: -2;
-			width: var( --size-icon );
-			height: var( --size-icon );
 			margin-inline-end: var( --space-sm );
-			content: '';
-			background-color: currentcolor;
-			-webkit-mask-image: url( assets/images/cdxIconCollapse.svg );
-			mask-image: url( assets/images/cdxIconCollapse.svg );
-			-webkit-mask-repeat: no-repeat;
-			mask-repeat: no-repeat;
-			-webkit-mask-position: center;
-			mask-position: center;
-			-webkit-mask-size: contain;
-			mask-size: contain;
-			transition: var( --transition-hover );
-			transition-property: transform;
+			.mixin-citizen-section-chevron();
 		}
 
 		:is( .mw-headline, h1, h2, h3, h4, h5, h6 ) {
@@ -65,8 +71,53 @@ section[ data-mw-section-id ] > .mw-heading,
 		}
 	}
 
-	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > :is( .mw-heading, .citizen-section-heading ) {
+	// sections.js injects the real control, so the heading's own chevron
+	// stands down. The class only lands once every toggle is in place, which
+	// keeps the affordance continuous across the handover.
+	&.citizen-sections-interactive {
+		section:is( [ data-mw-section-id ], .citizen-section ) > :is( .mw-heading, .citizen-section-heading )::before {
+			content: none;
+		}
+	}
+
+	.citizen-section-toggle {
+		display: flex;
+		flex-shrink: 0;
+		align-items: center;
+		justify-content: center;
+		order: -2;
+		padding: 0;
+		margin-inline-end: var( --space-sm );
+		color: inherit;
+		appearance: none;
+		cursor: pointer;
+		background: transparent;
+		border: 0;
+		border-radius: var( --border-radius-base );
+
 		&::before {
+			.mixin-citizen-section-chevron();
+		}
+
+		&:focus-visible {
+			outline: var( --border-width-thick ) solid var( --color-progressive );
+			outline-offset: var( --space-xxs );
+		}
+
+		@media ( hover: hover ) {
+			&:hover {
+				opacity: var( --opacity-icon-base--hover );
+			}
+
+			&:active {
+				opacity: var( --opacity-icon-base--selected );
+			}
+		}
+	}
+
+	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > :is( .mw-heading, .citizen-section-heading ) {
+		&::before,
+		> .citizen-section-toggle::before {
 			transform: rotate3d( 1, 0, 0, 180deg );
 		}
 

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -220,4 +220,226 @@ describe( 'createSections', () => {
 			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 		} );
 	} );
+
+	describe( 'toggle control', () => {
+		// Legacy heading markup: no wrapper, so the heading tag itself is
+		// both the heading and the row that holds the edit links.
+		const LEGACY = `
+			<div class="mw-parser-output">
+				<section id="citizen-section-1" class="citizen-section">
+					<h2 class="citizen-section-heading"><span class="mw-headline" id="Foo">Foo</span>
+						<span class="mw-editsection"><a href="#">edit</a></span>
+					</h2>
+					<p>Bar</p>
+				</section>
+			</div>
+		`;
+
+		// Newer markup wraps the heading tag, so the row is the wrapper.
+		const WRAPPED = `
+			<div class="mw-parser-output">
+				<section data-mw-section-id="1">
+					<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2>
+						<span class="mw-editsection"><a href="#">edit</a></span>
+					</div>
+					<p>Bar</p>
+				</section>
+			</div>
+		`;
+
+		const PARSOID_NESTED = `
+			<div class="mw-parser-output">
+				<section data-mw-section-id="1">
+					<div class="mw-heading mw-heading2"><h2 id="Outer">Outer</h2></div>
+					<p>Bar</p>
+					<section data-mw-section-id="2">
+						<div class="mw-heading mw-heading3"><h3 id="Inner">Inner</h3></div>
+						<p>Nested</p>
+					</section>
+				</section>
+			</div>
+		`;
+
+		it( 'should give every collapsible heading a button', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
+			expect( toggle.tagName ).toBe( 'BUTTON' );
+			expect( toggle.type ).toBe( 'button' );
+			expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+		} );
+
+		it( 'should name the button after its section', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
+			expect( toggle.getAttribute( 'aria-labelledby' ) ).toBe( 'Foo' );
+		} );
+
+		it( 'should place the button after the heading tag when markup wraps it', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const h2 = bodyContent.querySelector( 'h2' );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
+			// Outside the h2, so the heading keeps a clean accessible name
+			expect( toggle.closest( 'h2' ) ).toBeNull();
+			expect( h2.hasAttribute( 'aria-labelledby' ) ).toBe( false );
+			// After it, so jumping between headings and reading on reaches
+			// the control. The styles order it first visually.
+			expect( h2.nextElementSibling ).toBe( toggle );
+		} );
+
+		it( 'should pin the heading name when the button lands inside the heading tag', () => {
+			const bodyContent = createBodyContent( LEGACY );
+			const heading = bodyContent.querySelector( '.citizen-section-heading' );
+
+			const toggle = heading.querySelector( '.citizen-section-toggle' );
+
+			expect( toggle.closest( 'h2' ) ).toBe( heading );
+			expect( heading.getAttribute( 'aria-labelledby' ) ).toBe( 'Foo' );
+			// First child, so it precedes the title the heading announces
+			expect( heading.firstElementChild ).toBe( toggle );
+		} );
+
+		it( 'should give every heading on the page its own button', () => {
+			const bodyContent = createBodyContent( `
+				<div class="mw-parser-output">
+					<section data-mw-section-id="1">
+						<div class="mw-heading"><h2 id="One">One</h2></div>
+						<p>First</p>
+						<section data-mw-section-id="2">
+							<div class="mw-heading"><h3 id="Two">Two</h3></div>
+							<p>Nested</p>
+						</section>
+					</section>
+					<section data-mw-section-id="3">
+						<div class="mw-heading"><h2 id="Three">Three</h2></div>
+						<p>Third</p>
+					</section>
+				</div>
+			` );
+
+			const toggles = [ ...bodyContent.querySelectorAll( '.citizen-section-toggle' ) ];
+			const names = toggles.map( ( t ) => t.getAttribute( 'aria-labelledby' ) );
+
+			expect( toggles ).toHaveLength( 3 );
+			expect( new Set( names ).size ).toBe( 3 );
+			expect( names ).toEqual( [ 'One', 'Two', 'Three' ] );
+		} );
+
+		it( 'should leave other sections alone when one is toggled', () => {
+			const bodyContent = createBodyContent( PARSOID_NESTED );
+			const outer = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const nested = bodyContent.querySelector( 'section[data-mw-section-id="2"]' );
+			const nestedToggle = nested.querySelector( '.citizen-section-toggle' );
+
+			click( nestedToggle );
+
+			expect( nestedToggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+			expect( outer.querySelector( ':scope > .mw-heading > .citizen-section-toggle' )
+				.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+		} );
+
+		it( 'should not add a second button when run again over the same content', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+
+			// wikipage.content can fire more than once per page view
+			createSections( { document, bodyContent } ).init();
+
+			expect( bodyContent.querySelectorAll( '.citizen-section-toggle' ) ).toHaveLength( 1 );
+		} );
+
+		it( 'should not reuse an id the page already claims', () => {
+			const bodyContent = createBodyContent( `
+				<div class="mw-parser-output">
+					<p id="citizen-section-label-1">Content that took the id first</p>
+					<section data-mw-section-id="1">
+						<div class="mw-heading"><h2>No anchor</h2></div>
+						<p>Bar</p>
+					</section>
+				</div>
+			` );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+			const labelId = toggle.getAttribute( 'aria-labelledby' );
+
+			expect( labelId ).not.toBe( 'citizen-section-label-1' );
+			expect( document.querySelectorAll( `#${ labelId }` ) ).toHaveLength( 1 );
+		} );
+
+		it( 'should toggle the section when the button is activated', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const toggle = section.querySelector( '.citizen-section-toggle' );
+
+			// Enter and Space on a native button produce a click
+			click( toggle );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+			expect( section.querySelector( ':scope > p' ).hidden ).toBeTruthy();
+		} );
+
+		it( 'should track the collapsed state in aria-expanded', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const toggle = section.querySelector( '.citizen-section-toggle' );
+
+			click( toggle );
+
+			expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+
+			click( toggle );
+
+			expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+		} );
+
+		it( 'should restore aria-expanded when find-in-page expands the section', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const toggle = section.querySelector( '.citizen-section-toggle' );
+			click( toggle );
+
+			section.querySelector( ':scope > p' )
+				.dispatchEvent( new Event( 'beforematch', { bubbles: true } ) );
+
+			expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+		} );
+
+		it( 'should generate an id when the section title has no anchor', () => {
+			const bodyContent = createBodyContent( `
+				<div class="mw-parser-output">
+					<section data-mw-section-id="1">
+						<div class="mw-heading"><h2>Foo</h2></div>
+						<p>Bar</p>
+					</section>
+				</div>
+			` );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
+			expect( toggle.getAttribute( 'aria-labelledby' ) )
+				.toBe( bodyContent.querySelector( 'h2' ).id );
+			expect( toggle.getAttribute( 'aria-labelledby' ) ).toBeTruthy();
+		} );
+
+		it( 'should not add a button to a heading that owns no section', () => {
+			const bodyContent = createBodyContent( `
+				<div class="mw-parser-output">
+					<div class="mw-heading"><h2 id="Foo">Foo</h2></div>
+					<section class="citizen-section"><p>Bar</p></section>
+				</div>
+			` );
+
+			expect( bodyContent.querySelector( '.citizen-section-toggle' ) ).toBeNull();
+		} );
+
+		it( 'should mark the body once the toggles are in place', () => {
+			createBodyContent( WRAPPED );
+
+			expect( document.body.classList.contains( 'citizen-sections-interactive' ) ).toBe( true );
+		} );
+	} );
 } );


### PR DESCRIPTION
Follow-up to #1694, which flagged this gap.

## The problem

Collapsing was driven entirely by a click handler on the heading. The heading is a bare `<h2>`/`<div>` — not focusable, no `role`, no accessible name as a control, no `aria-expanded`. Measured on a real page before this change:

```
role: null  tabindex: null  aria-expanded: null  focusable: false
```

So sections could not be toggled by keyboard **at all**, and assistive technology got no signal that a heading was interactive or whether its section was open. That is two Level A failures: **WCAG 2.1.1 Keyboard** and **WCAG 4.1.2 Name, Role, Value**.

#1694 raised the stakes: content that used to stay visible when a section was "collapsed" is now genuinely hidden behind a control keyboard users could not operate, with find-in-page as the only escape hatch.

## Approach

`sections.js` gives each collapsible heading a real `<button>`.

It needs **no listener of its own** — Enter and Space fire a `click` that bubbles to the existing delegated handler, which resolves it via `closest(HEADING_SELECTOR)`. Verified in the browser before writing any of this. So clicking anywhere on the heading row still toggles, and there is no second code path to keep in sync or double-toggle to guard against.

The button is named after its section via the title's existing anchor id, which reads as "Foo, button, collapsed" — the standard disclosure convention, and it keeps the wording out of i18n entirely (no new message key).

### Why the button goes inside the heading

Which element `HEADING_SELECTOR` matches differs per markup shape, and that turns out to do the right thing on its own — all three confirmed in-browser:

| shape | matched element | button lands | heading name |
| --- | --- | --- | --- |
| legacy heading DOM | `<h2>` | inside the `<h2>` | pinned to the title text |
| modern `.mw-heading` | `<div>` | beside the `<h2>` | untouched |
| Parsoid native section | `<div>` | beside the `<h2>` | untouched |

On the modern shape the button lands exactly where a hand-built row container would put it, with no DOM restructuring and no accessible-name collision. Only legacy markup — where MediaWiki puts the headline *and* the edit links inside the `<h2>` — needs the name pinned, and that pin can be deleted when `$wgParserEnableLegacyHeadingDOM` goes away.

The alternative considered was normalising the row by wrapping the `<h2>` in a container. Rejected: it nests the heading one level deeper inside the `<section>`, breaking `h2 + p` and `:first-child` selectors in gadgets, TemplateStyles and other extensions — invisible breakage on a skin many wikis extend, to buy a structure that arrives on its own as core migrates.

### Chevron handover

The chevron is still drawn on the heading's `::before` for first paint, so noscript clients see no affordance and there is no layout shift. It moves to the button once every toggle is in place (`citizen-sections-interactive` on `body`). Both take the same box in the same flex slot — measured at **0px** shift in both the legacy and modern shapes:

```
pre-JS : headlineX 54, headingH 34
post-JS: headlineX 54, headingH 34
```

## Verification

Browser-tested against **all three markup shapes** on MediaWiki 1.45 (legacy heading DOM, `$wgParserEnableLegacyHeadingDOM = false`, and `?useparsoid=1`):

| | legacy | modern `.mw-heading` | Parsoid |
| --- | --- | --- | --- |
| button injected (3 sections) | yes | yes | yes |
| button placement | inside `<h2>` | beside `<h2>` | beside `<h2>` |
| heading name pinned | yes | no (not needed) | no (not needed) |
| Enter / Space toggles | yes | yes | yes |
| focus retained on activation | yes | yes | yes |
| `aria-expanded` tracks state | yes | yes | yes |
| thumb hidden (#1694) | `table 330` -> `block 0` | `table 330` -> `block 0` | `table 330` -> `block 0` |
| section height collapsed | 519 -> 40 | 521 -> 34 | 521 -> 34 |
| layout shift | 0px | 0px | 0px |

Accessibility tree on the modern and Parsoid shapes shows the control and the heading as separate, cleanly-named nodes:

```
button  "Section with a standalone thumb" expandable focusable focused
heading "Section with a standalone thumb" level="2"
```

On the legacy shape the button is exposed identically; the heading name is pinned so the control's name is not folded into it.

Worth noting from the Parsoid run: with the section collapsed, its thumbnail, table, gallery and nested subsection are **absent from the accessibility tree entirely** — #1694 working at the a11y layer, not just visually.

Also confirmed: `aria-expanded` is restored when find-in-page expands a section, the focus ring renders on `:focus-visible`, and the console is clean apart from a pre-existing `mediawiki.Uri` deprecation from another extension.

11 new Vitest tests (1075 total, all passing) cover button injection, naming, placement per markup shape, activation through the delegated handler, `aria-expanded` sync, id generation when a title has no anchor, and that headings owning no section get no button. stylelint clean, eslint at baseline, `less.php` compiles.

CSS + JS only against existing markup, so no parser-cache split is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive expand/collapse buttons to section headings.
  * Added keyboard-accessible controls with appropriate ARIA labels and expanded/collapsed states.
  * Added support for nested sections and find-in-page expansion behavior.
  * Added visual chevrons, focus indicators, and hover states for section toggles.

* **Bug Fixes**
  * Prevented duplicate toggles when section behavior is initialized more than once.
  * Ensured headings without associated sections do not display toggle controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->