### PR TITLE
fix(sections): keep sections collapsible after the content re-renders

### DIFF
--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -7,6 +7,20 @@ const COLLAPSED_SECTION_SELECTOR =
 	`section[data-mw-section-id].${ COLLAPSED_CLASS }, section.citizen-section.${ COLLAPSED_CLASS }`;
 
 /**
+ * Content roots whose handlers are already attached.
+ *
+ * Setup runs once per `wikipage.content`, which fires again whenever the
+ * content is re-rendered — a live preview, or saving without a reload. The
+ * root element survives that, so a second pass would leave two sets of
+ * delegated handlers on it and every click would toggle a section twice,
+ * landing back where it started. Held weakly so a replaced root is
+ * collectable.
+ *
+ * @type {WeakSet<HTMLElement>}
+ */
+const boundRoots = new WeakSet();
+
+/**
  * @param {Object} deps
  * @param {Document} deps.document
  * @param {HTMLElement} deps.bodyContent
@@ -150,6 +164,7 @@ function createSections( { document, bodyContent } ) {
 			return;
 		}
 
+		// Re-rendered content brings new headings, so this always runs.
 		for ( const heading of bodyContent.querySelectorAll( HEADING_SELECTOR ) ) {
 			// Pre-convergence cached markup keeps the heading outside the
 			// section, where there is nothing to toggle.
@@ -159,6 +174,13 @@ function createSections( { document, bodyContent } ) {
 		}
 		// Every toggle is in place, so the styles can hand the chevron over.
 		document.body.classList.add( INTERACTIVE_CLASS );
+
+		// The handlers below are delegated, so the ones already on this root
+		// cover whatever was just rendered into it.
+		if ( boundRoots.has( bodyContent ) ) {
+			return;
+		}
+		boundRoots.add( bodyContent );
 
 		const onEditSectionClick = ( e ) => {
 			e.stopPropagation();

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -381,6 +381,30 @@ describe( 'createSections', () => {
 			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
 		} );
 
+		it( 'should reach content rendered into the root after the first run', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			bodyContent.insertAdjacentHTML( 'beforeend', `
+				<section data-mw-section-id="2">
+					<div class="mw-heading mw-heading2"><h2 id="Later">Later</h2></div>
+					<p>Rendered later</p>
+				</section>
+			` );
+
+			createSections( { document, bodyContent } ).init();
+
+			const later = bodyContent.querySelector( 'section[data-mw-section-id="2"]' );
+			const toggle = later.querySelector( '.citizen-section-toggle' );
+			expect( toggle ).not.toBeNull();
+			expect( toggle.getAttribute( 'aria-labelledby' ) ).toBe( 'Later' );
+
+			// The handlers bound on the first run drive content that did not
+			// exist when they were attached
+			click( toggle );
+
+			expect( later.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+			expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+		} );
+
 		it( 'should bind a content root it has not seen before', () => {
 			const first = createBodyContent( WRAPPED );
 			const second = createBodyContent( WRAPPED );

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -352,6 +352,46 @@ describe( 'createSections', () => {
 			expect( bodyContent.querySelectorAll( '.citizen-section-toggle' ) ).toHaveLength( 1 );
 		} );
 
+		it( 'should still toggle once per click after running again', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const toggle = section.querySelector( '.citizen-section-toggle' );
+
+			// A second set of delegated handlers would toggle twice per click
+			createSections( { document, bodyContent } ).init();
+			click( toggle );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+			expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+		} );
+
+		it( 'should keep toggling after several re-runs', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const section = bodyContent.querySelector( 'section[data-mw-section-id="1"]' );
+			const toggle = section.querySelector( '.citizen-section-toggle' );
+
+			createSections( { document, bodyContent } ).init();
+			createSections( { document, bodyContent } ).init();
+			createSections( { document, bodyContent } ).init();
+
+			click( toggle );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+
+			click( toggle );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+		} );
+
+		it( 'should bind a content root it has not seen before', () => {
+			const first = createBodyContent( WRAPPED );
+			const second = createBodyContent( WRAPPED );
+			const section = second.querySelector( 'section[data-mw-section-id="1"]' );
+
+			click( section.querySelector( '.citizen-section-toggle' ) );
+
+			expect( first.querySelector( 'section' ).classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+		} );
+
 		it( 'should not reuse an id the page already claims', () => {
 			const bodyContent = createBodyContent( `
 				<div class="mw-parser-output">


### PR DESCRIPTION
Pre-existing bug, found while reviewing #1695. Not introduced by #1694 or #1695.

## The bug

Section setup runs from `initBodyContent`, which `skin.js` binds to `mw.hook( 'wikipage.content' )`. That hook fires again whenever page content is re-rendered — a live preview, or saving an edit without a reload.

The content root element survives a re-render, but `init()` attached its delegated handlers to it unconditionally, with a fresh closure each time. So every extra fire left another set of handlers on the same element. Two sets meant one click ran the toggle logic twice — collapse, then immediately expand — so **collapsing simply stopped responding**, with no error and no visible cause, until the page was reloaded.

Reproduced in the browser by firing the hook the way MediaWiki does:

```js
mw.hook( 'wikipage.content' ).fire( $( document.querySelector( '.mw-body-content' ) ) );
```

| | before fix | after fix |
| --- | --- | --- |
| click toggles a section (no re-fire) | yes | yes |
| click toggles after 1 re-fire | **no** | yes |
| click toggles after 4 re-fires | **no** | yes |
| buttons in the heading after re-fire | 1 | 1 |

## The fix

Handlers are attached once per content root, tracked in a module-level `WeakSet` so a replaced root stays collectable.

The heading scan deliberately still runs on every fire — re-rendered content brings headings that need a toggle — and the handlers already on the root are delegated, so they pick up that new content without rebinding. Verified both halves:

- a section inserted into the existing root after setup had no toggle, gained one on the next hook fire (`aria-labelledby` correctly resolved to its own title), and the handler bound *before* that content existed drove it correctly;
- toggle count per heading stayed at 1 across four re-fires.

Only `sections.js` was affected. `overflowElements` binds to elements it creates itself and has matching teardown; `contentEnhancements` registers no listeners.

## Tests

Four added (1082 total, all passing). The two behavioural ones are real regression tests — confirmed failing against the unfixed `sections.js` and passing with it:

```
× should still toggle once per click after running again
× should keep toggling after several re-runs
```

The other two cover that a content root not seen before still gets bound, and that no second button appears.

Note: an unrelated `skins.citizen.share` test failed once during the pre-commit run. It passes in isolation and on a full re-run, and this diff touches nothing outside `sections.js` and its test — the known Vitest parallel-execution flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)