### PR TITLE
feat: add a skip link to jump straight to page content

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -40,6 +40,7 @@
 	"citizen-footer-tagline": "Edit this text on [[MediaWiki:Citizen-footer-tagline]]",
 	"citizen-action-addsection": "Add topic",
 	"citizen-jumptotop": "Back to top",
+	"citizen-jumptocontent": "Jump to content",
 	"citizen-toc-toggle-button-label": "Toggle $1 subsection",
 
 	"citizen-search-empty-desc": "Type to start searching",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -47,6 +47,7 @@
 	"citizen-footer-tagline": "Default text for the site footer tagline.",
 	"citizen-action-addsection": "Used in the Citizen skin. See for example {{canonicalurl:Talk:Main_Page|useskin=vector}}\n{{Identical|Add topic}}. Same as vector-action-addsection in Vector skin.",
 	"citizen-jumptotop": "Label for link to jump to top of page",
+	"citizen-jumptocontent": "Label for the link at the very top of the page that skips the site header and jumps straight to the page content. Visually hidden until it receives keyboard focus.",
 	"citizen-toc-toggle-button-label": "Accessible label for the toggle button that expands/collapses a table of contents subsection. $1 is the section heading text.",
 	"citizen-search-empty-desc": "Helper text in the search suggestion when there are no search query",
 	"citizen-search-noresults-title": "Title in the search suggestion when there are no search results",

--- a/resources/skins.citizen.styles/common/print.less
+++ b/resources/skins.citizen.styles/common/print.less
@@ -10,6 +10,7 @@
 
 // Hide unnessecary elements for printing
 .noprint,
+.mw-jump-link,
 .citizen-header,
 .citizen-sitenotice-container,
 .citizen-page-actions,

--- a/resources/skins.citizen.styles/components/JumpLink.less
+++ b/resources/skins.citizen.styles/components/JumpLink.less
@@ -1,0 +1,48 @@
+/*
+ * Skip link — the first focusable control on the page.
+ *
+ * Visually hidden until focused, then drawn above the fixed header and any
+ * open dropdown card (WCAG 2.2 SC 2.4.11). Core's notification toasts sit
+ * higher still, so a toast raised at the moment the link is focused can
+ * partly cover it — 2.4.11 permits partial obscuring, and chasing core's
+ * z-index would only move the problem.
+ *
+ * No `tabindex` on the target: browsers move the sequential focus navigation
+ * starting point on fragment navigation, so the next Tab lands inside
+ * `#bodyContent` on its own. Making a container focusable costs more than it
+ * gives here — assistive technology announces it as an empty group, and it
+ * has been reported to break scroll restoration on iOS back-navigation.
+ *
+ * Styling hangs off `.citizen-jump-link` rather than `.mw-jump-link` so a
+ * third-party jump link injected elsewhere in the page is not flung to the
+ * viewport corner.
+ */
+.citizen-jump-link {
+	&:not( :focus ) {
+		.mixin-citizen-screen-reader-only;
+		// Keep the hidden label out of select-all and page copy.
+		.user-select( none );
+	}
+
+	&:focus {
+		position: fixed;
+		// Pinned to the raw viewport corner rather than the header tokens: the
+		// header can sit on any edge, --header-inset-block-start is `auto` in
+		// the bottom placements, and --header-offset-block-start is rewritten at
+		// runtime by stickyHeader.js, so a token-pinned link would drift while
+		// scrolling.
+		inset-block-start: var( --space-xs );
+		inset-inline-start: var( --space-xs );
+		// Above the header ( @z-index-fixed, 200 ) and any open dropdown card ( 350 ).
+		z-index: @z-index-overlay;
+		padding: var( --space-xs ) var( --space-md );
+		font-weight: var( --font-weight-medium );
+		color: var( --color-emphasized );
+		background-color: var( --color-surface-2 );
+		// The border is what keeps this legible under forced-colors, where the
+		// background is overridden.
+		border-width: var( --border-width-base );
+		border-radius: var( --border-radius-medium );
+		box-shadow: var( --box-shadow-drop-medium );
+	}
+}

--- a/resources/skins.citizen.styles/skin.less
+++ b/resources/skins.citizen.styles/skin.less
@@ -28,6 +28,7 @@
 	// Components
 	@import 'components/Button.less';
 	@import 'components/Header.less';
+	@import 'components/JumpLink.less';
 	@import 'components/Drawer.less';
 	@import 'components/Drawer__button.less';
 	@import 'components/UserMenu.less';

--- a/skin.json
+++ b/skin.json
@@ -79,6 +79,7 @@
 					"messages": [
 						"citizen-actions-more-toggle",
 						"citizen-drawer-toggle",
+						"citizen-jumptocontent",
 						"citizen-jumptotop",
 						"citizen-languages-toggle",
 						"citizen-notifications-label",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,3 +7,13 @@ sonar.exclusions=node_modules/**/*
 sonar.tests=tests
 sonar.php.coverage.reportPaths=coverage/php/coverage.xml
 sonar.javascript.lcov.reportPaths=coverage/js/lcov.info
+
+# css:S8778 "Invalid position for @import rule" does not apply to LESS. In CSS an
+# @import must precede other rules because the browser resolves it at load time;
+# in LESS it is a compile-time include that less.php inlines, so the stylesheet
+# ResourceLoader serves contains no @import at all. The rule fires on every
+# component import in skins.citizen.styles/skin.less, which is how this skin is
+# structured by design.
+sonar.issue.ignore.multicriteria=less-import
+sonar.issue.ignore.multicriteria.less-import.ruleKey=css:S8778
+sonar.issue.ignore.multicriteria.less-import.resourceKey=**/*.less

--- a/templates/Drawer.mustache
+++ b/templates/Drawer.mustache
@@ -8,13 +8,13 @@
 	</details>
 	<div id="citizen-drawer__card" class="citizen-drawer__card citizen-menu__card">
 		<div class="citizen-menu__card-content">
-			<header class="citizen-drawer__header">
+			<div class="citizen-drawer__header">
 				{{>Drawer__logo}}
 				<div class="citizen-drawer__siteinfo">
 					{{#data-site-stats}}{{>SiteStats}}{{/data-site-stats}}
 					{{>Wordmark}}
 				</div>
-			</header>
+			</div>
 			{{#data-main-menu}}
 				{{>MainMenu}}
 			{{/data-main-menu}}

--- a/templates/Menu.mustache
+++ b/templates/Menu.mustache
@@ -1,6 +1,10 @@
 <nav
 	id="{{id}}"
 	class="citizen-menu{{#class}} {{.}}{{/class}}"
+	{{! Named with aria-label rather than aria-labelledby pointing at the heading
+		below: the sticky header clones these menus and strips ids from the clone,
+		which would leave the copy with a dangling IDREF. }}
+	{{#label}}aria-label="{{.}}"{{/label}}
 	{{{html-tooltip}}}
 	{{{html-userlangattributes}}}
 >

--- a/templates/PageTools__languages.mustache
+++ b/templates/PageTools__languages.mustache
@@ -17,10 +17,10 @@
 			<span>{{msg-citizen-languages-toggle}}</span>
 		</summary>
 	</details>
-	<aside id="citizen-languages__card" class="citizen-menu__card">
+	<div id="citizen-languages__card" class="citizen-menu__card">
 		<div class="citizen-menu__card-content">
 			{{#data-portlets.data-languages}}{{>Menu}}{{/data-portlets.data-languages}}
 			{{#data-portlets.data-variants}}{{>Menu}}{{/data-portlets.data-variants}}
 		</div>
-	</aside>
+	</div>
 </div>

--- a/templates/PageTools__more.mustache
+++ b/templates/PageTools__more.mustache
@@ -11,12 +11,12 @@
 			<span>{{msg-citizen-actions-more-toggle}}</span>
 		</summary>
 	</details>
-	<aside id="citizen-page-actions-more__card" class="citizen-menu__card">
+	<div id="citizen-page-actions-more__card" class="citizen-menu__card">
 		<div class="citizen-menu__card-content">
 			{{#is-visible}}
 					{{#data-portlets.data-actions}}{{>Menu}}{{/data-portlets.data-actions}}
 			{{/is-visible}}
 			{{#data-article-tools}}{{>Menu}}{{/data-article-tools}}
 		</div>
-	</aside>
+	</div>
 </div>

--- a/templates/TableOfContents.mustache
+++ b/templates/TableOfContents.mustache
@@ -9,13 +9,13 @@
 			<span>{{msg-toc}}</span>
 		</summary>
 	</details>
-	<nav id="mw-panel-toc" class="citizen-toc-card citizen-menu__card" role="navigation" aria-labelledby="mw-panel-toc-label">
+	<nav id="mw-panel-toc" class="citizen-toc-card citizen-menu__card" aria-labelledby="mw-panel-toc-label">
 		<div class="citizen-menu__card-content">
 			<a class="citizen-toc-top citizen-toc-link cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" title="{{html-citizen-jumptotop}}" href="#top" role="button">
 				<div class="citizen-ui-icon mw-ui-icon-wikimedia-arrowUp"></div>
 				<div class="citizen-toc-text">{{msg-citizen-jumptotop}}</div>
 			</a>
-			<div class="citizen-menu__heading">{{msg-toc}}</div>
+			<div id="mw-panel-toc-label" class="citizen-menu__heading">{{msg-toc}}</div>
 			{{>TableOfContents__list}}
 		</div>
 	</nav>

--- a/templates/TableOfContents.mustache
+++ b/templates/TableOfContents.mustache
@@ -11,7 +11,7 @@
 	</details>
 	<nav id="mw-panel-toc" class="citizen-toc-card citizen-menu__card" aria-labelledby="mw-panel-toc-label">
 		<div class="citizen-menu__card-content">
-			<a class="citizen-toc-top citizen-toc-link cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" title="{{html-citizen-jumptotop}}" href="#top" role="button">
+			<a class="citizen-toc-top citizen-toc-link cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" title="{{msg-citizen-jumptotop}}" href="#top" role="button">
 				<div class="citizen-ui-icon mw-ui-icon-wikimedia-arrowUp"></div>
 				<div class="citizen-toc-text">{{msg-citizen-jumptotop}}</div>
 			</a>

--- a/templates/skin.mustache
+++ b/templates/skin.mustache
@@ -7,10 +7,12 @@
 	string html-body-content--formatted
 	string html-categories
 	string html-after-content
+	string msg-citizen-jumptocontent label for the link that skips the site header and jumps to the page content
 	bool is-mainpage whether this is a view of the wiki's main page
 	object data-footer for footer template partial. see Footer.mustache for documentation.
 }}
 
+<a class="mw-jump-link citizen-jump-link" href="#bodyContent">{{msg-citizen-jumptocontent}}</a>
 {{>Header}}
 <div class="citizen-page-container">
 	<div class="citizen-sitenotice-container">{{{html-site-notice}}}</div>

--- a/templates/skin.mustache
+++ b/templates/skin.mustache
@@ -22,7 +22,7 @@
 			mid-stream paints from shifting the header. }}
 		{{^is-mainpage}}{{>PageHeader}}{{/is-mainpage}}
 		<div class="citizen-body-container">
-			<div id="bodyContent" class="citizen-body" aria-labelledby="firstHeading">
+			<div id="bodyContent" class="citizen-body">
 				<div id="contentSub"{{{html-user-language-attributes}}}>{{{html-subtitle}}}</div>
 				{{#html-undelete-link}}<div id="contentSub2">{{{.}}}</div>{{/html-undelete-link}}
 				{{{html-user-message}}}


### PR DESCRIPTION
Closes #1673.

Adds a "Skip to content" link, plus the accessibility defects found in the markup around it.

## The skip link

`<a class="mw-jump-link citizen-jump-link" href="#bodyContent">` as the first element in `<body>`, visually hidden until it receives keyboard focus, then drawn at the viewport corner above the fixed header.

**Why it's worth having, given Citizen already has landmarks.** Landmarks alone already satisfy the letter of WCAG 2.4.1 — [ARIA11](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11) is an independently sufficient technique and axe's `bypass` rule passes on `<main>` alone. So this is not a conformance fix. It is a fix for the population landmarks do nothing for: no browser ships landmark navigation, so a sighted keyboard-only user has exactly one primitive, <kbd>Tab</kbd>. [WebAIM's screen reader survey](https://webaim.org/projects/screenreadersurvey10/) puts landmark navigation at 3.7% even among screen reader users, against 71.6% for headings.

**Target is `#bodyContent`, not `#content`.** Citizen's `<main id="content">` contains the page header — the `<h1>` *and* the page tools — before `#bodyContent`, the same shape as Vector 2022. Targeting `#content` would leave 6–8 repeated tool controls between the user and the article, which is precisely the block SC 2.4.1 exists to bypass. `#bodyContent` clears both the site header and the tools in one step.

The trade-off, stated plainly: the `<h1>` ends up above the landing point, so after activating the link no page title is visible. Verified in-browser rather than assumed — Citizen's sticky header is direction-observer driven and does not engage on a downward jump. This matches Vector's behaviour, no success criterion is violated, and it was accepted knowingly. If it is ever revisited, `scroll-margin-block-start` on `#bodyContent` restores the title visually without touching tab order.

**No JavaScript and no `tabindex` on the target.** All current engines move the sequential focus navigation starting point on fragment navigation, so the next <kbd>Tab</kbd> lands inside `#bodyContent` on its own. None of the six design systems surveyed ship a static `tabindex` on the target, and making a container focusable has real costs — assistive technology announces it as an empty group, and it has been reported to break scroll restoration on iOS back-navigation.

**Other details:** `:focus` rather than `:focus-visible` (the link is unreachable by pointer, so `:focus-visible` buys nothing while risking an invisible focused element); pinned to the raw viewport corner rather than the header tokens, because the header can sit on any of four edges and `--header-offset-block-start` is rewritten at runtime by `stickyHeader.js`; and `.mw-jump-link` joins the print hide-list so it does not print.

## Accessibility fixes found alongside it

| Commit | Defect |
| --- | --- |
| `fix(drawer)` | The drawer's `<header>` was nested inside the site `<header>` — invalid HTML, and it mapped to a **second `banner` landmark**. |
| `fix(toc)` | The TOC nav's `aria-labelledby` pointed at an id that existed **nowhere in the skin**, so it was an unnamed navigation landmark. Also dropped a redundant `role="navigation"`. |
| `fix(toc)` | The "Back to top" button's `title` referenced a template key with **no producer**, so it shipped `title=""`. |
| `fix(pagetools)` | Two dropdown popovers used `<aside>`; scoped to `main` that maps to `complementary` unconditionally, giving **two spurious landmarks**. |
| `fix(skin)` | `#bodyContent` carried an `aria-labelledby` that is **inert** — a bare `div` has role `generic`, which prohibits naming. |
| `fix(menu)` | Portlet menus rendered as **unnamed navigation landmarks**. Named with `aria-label`, not `aria-labelledby`: `stickyHeader.js` strips ids from menu clones, so an IDREF would be left dangling in the copy. |

Net effect on an article page: landmarks go to exactly one `banner`, one `main`, one `contentinfo`, zero `complementary`, and unnamed `nav` landmarks drop from 10 to 3.

## Testing

No PHP and no JavaScript in this change, so there is nothing for PHPUnit or Vitest to bind to. Worth saying explicitly: **automated accessibility tooling cannot validate this feature** — axe's `bypass` rule passed before this change too. The evidence is the keyboard walk.

Verified in a browser:

- One <kbd>Tab</kbd> from a fresh load reveals the link, fully within the viewport and not obscured (`elementFromPoint` at its centre returns the link), across **all six header placements** — `$wgCitizenHeaderPosition` left/top/bottom/right and `$wgCitizenHeaderPositionMobile` bottom/top.
- <kbd>Enter</kbd> then <kbd>Tab</kbd> puts focus inside `#bodyContent`, never back in the header. Position is invariant while scrolled and during sticky-header autohide.
- Legible under **both token pipelines** — contrast 17.16:1 with `$wgCitizenPreview = 4`, 16.43:1 with `0`.
- Print preview contains no "Jump to content" at desktop and mobile widths; RTL reveals at the top-right with no horizontal scrollbar in either state; `?uselang=x-xss` injects nothing; dark theme, `forced-colors: active` and 400% zoom at 320px all fine.
- Regression pass over everything the markup fixes touched: drawer, both page-tool dropdowns, their sticky-header clones, and the TOC at desktop and mobile.

Not run: real screen reader testing (NVDA/JAWS/VoiceOver) — no screen reader available in the dev environment.

Lints: `lint:styles`, `lint:i18n` and `eslint` clean; Vitest 1083/1083.

## Follow-ups filed

- #1697 — sticky header dropdown clones are never re-initialised (duplicate id, cross-wired `aria-details`, <kbd>Esc</kbd> does not dismiss). All three reproduced locally.
- #1698 — `associated-pages` and `user-interface-preferences` expose raw internal keys as their accessible name, because core's `getMenuLabel()` never learned the `associated-pages` → `namespaces` rename.

Deliberately out of scope here: both are pre-existing, and #1697 is a JavaScript bug in a branch that otherwise contains none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added a keyboard-accessible “Jump to content” link for faster navigation past the header.
  * Improved menu and content labeling for assistive technologies.
* **UI Improvements**
  * Styled the jump link to appear clearly when focused and remain hidden otherwise.
  * Prevented navigation links from appearing in printed pages.
* **Bug Fixes**
  * Improved accessibility behavior for menus in cloned or sticky headers.
  * Updated table-of-contents navigation markup and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->