### PR TITLE
fix(tokens): stop Codex icons and buttons rendering dark in dark mode

### DIFF
--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -34,6 +34,9 @@
 	--border-color-base: rgba( 255, 255, 255, 0.1 );
 	--border-color-subtle: rgba( 255, 255, 255, 0.05 );
 	--border-color-interactive: rgba( 255, 255, 255, 0.15 );
+	// Keep the +0.10 / +0.20 step of the night ramp off the raised base.
+	--border-color-interactive--hover: rgba( 255, 255, 255, 0.25 );
+	--border-color-interactive--active: rgba( 255, 255, 255, 0.35 );
 
 	// ----- new mode: redeclare neutral primitives at zero chroma -----
 	// In the new pipeline, surfaces and text neutrals come from --color-neutral-N

--- a/resources/skins.citizen.tokens.new/dark-overrides.less
+++ b/resources/skins.citizen.tokens.new/dark-overrides.less
@@ -13,4 +13,6 @@
 	--font-grade: 0;
 	--filter-invert: invert( 1 ) hue-rotate( 180deg );
 	--color-progressive-hsl__l: 60%;
+	// Codex blends quiet controls with `multiply` on light, `screen` on dark.
+	--mix-blend-mode-blend: screen;
 }

--- a/resources/skins.citizen.tokens/tokens-codex.less
+++ b/resources/skins.citizen.tokens/tokens-codex.less
@@ -93,6 +93,10 @@
 		--background-color-tab-list-item-framed--active: rgba( 255, 255, 255, 0.65 );
 		--opacity-icon-base: 0.6;
 		--opacity-icon-base--hover: 0.74;
+		// Citizen extension, not a Codex token — placed here by sibling
+		// adjacency. Consumed by --background-color-icon--active in both
+		// theme files, which are invalid without it.
+		--opacity-icon-base--active: 0.87;
 		--opacity-icon-base--selected: 1;
 		--opacity-icon-base--disabled: 0.51;
 		--opacity-icon-placeholder: 0.51;

--- a/resources/skins.citizen.tokens/tokens-codex.less
+++ b/resources/skins.citizen.tokens/tokens-codex.less
@@ -21,6 +21,9 @@
 		--color-subtle: ~'oklch( var( --color-subtle-oklch__l ) var( --color-subtle-oklch__c ) var( --color-progressive-oklch__h ) )';
 		--color-placeholder: ~'oklch( var( --color-placeholder-oklch__l ) var( --color-placeholder-oklch__c ) var( --color-progressive-oklch__h ) )';
 		--color-disabled: ~'oklch( var( --color-disabled-oklch__l ) var( --color-disabled-oklch__c ) var( --color-progressive-oklch__h ) )';
+		// Deprecated upstream in favour of --color-subtle, but still emitted
+		// by Codex and read by skinStyles/jquery/jsonview.less.
+		--color-base--subtle: var( --color-subtle );
 		--color-inverted: #fff;
 		--color-inverted-fixed: #fff;
 		--color-progressive: ~'oklch( var( --color-progressive-oklch__l ) var( --color-progressive-oklch__c ) var( --color-progressive-oklch__h ) )';
@@ -130,33 +133,63 @@
 		--border-color-input-binary--focus: var( --border-color-progressive--focus );
 		--border-color-input-binary--checked: var( --border-color-progressive );
 
-		// @since Codex Design Tokens v1.20.1 (MediaWiki master)
-		//--color-disabled-emphasized: #a2a9b1;
+		// @since Codex Design Tokens v1.20.1 (MediaWiki 1.44)
+		// Upstream keeps this level with --color-disabled in light and one
+		// rung brighter in dark; the dark rung lives in tokens-theme-dark.less.
+		--color-disabled-emphasized: var( --color-disabled );
 		--color-visited--hover: var( --color-progressive--hover );
 		--color-visited--active: var( --color-progressive--active );
 		--color-destructive--visited--hover: var( --color-destructive--hover );
 		--color-destructive--visited--active: var( --color-destructive--active );
-		//--color-error--hover: #9f3526;
-		//--color-error--active: #612419;
-		//--color-icon-error: #f54739;
-		//--color-icon-warning: #ab7f2a;
-		//--color-icon-success: #099979;
-		//--color-icon-notice: #72777d;
-		//--mix-blend-mode-base: normal;
-		//--mix-blend-mode-blend: multiply;
+		--color-error--hover: var( --color-destructive--hover );
+		--color-error--active: var( --color-destructive--active );
+		--color-icon-error: var( --color-destructive );
+		--color-icon-warning: var( --color-warning );
+		--color-icon-success: var( --color-success );
+		--color-icon-notice: var( --color-placeholder );
+		--mix-blend-mode-base: normal;
+		// Dark half is `screen`, in tokens-theme-dark.less.
+		--mix-blend-mode-blend: multiply;
 		--background-color-interactive--hover: var( --color-surface-2--hover );
 		--background-color-interactive--active: var( --color-surface-2--active );
-		//--background-color-progressive-subtle--hover: #dce3f9;
-		//--background-color-progressive-subtle--active: #cbd6f6;
-		//--background-color-destructive-subtle--hover: #ffdad3;
-		//--background-color-destructive-subtle--active: #ffc8bd;
-		//--background-color-error-subtle--hover: #ffdad3;
-		//--background-color-error-subtle--active: #ffc8bd;
-		//--border-color-interactive--hover: #27292d;
-		//--border-color-interactive--active: #202122;
-		//--border-color-error--active: #612419;
+		// Subtle state fills step away from the resting subtle lightness
+		// using --delta-lightness-surface-base, which is negative in light
+		// and positive in dark, so one declaration gets both directions.
+		// The multipliers clear Citizen's own surface ramp — at *2 the dark
+		// hover fill lands below --color-surface-1--hover and the state
+		// reads as recessed.
+		--background-color-progressive-subtle--hover: ~'hsl( var( --color-progressive-hsl__h ), var( --color-progressive-hsl__s ), calc( var( --background-color-subtle__l ) + ( var( --delta-lightness-surface-base ) * 3 ) ) )';
+		--background-color-progressive-subtle--active: ~'hsl( var( --color-progressive-hsl__h ), var( --color-progressive-hsl__s ), calc( var( --background-color-subtle__l ) + ( var( --delta-lightness-surface-base ) * 6 ) ) )';
+		--background-color-destructive-subtle--hover: ~'hsl( var( --color-destructive__h ), var( --background-color-subtle__s ), calc( var( --background-color-subtle__l ) + ( var( --delta-lightness-surface-base ) * 3 ) ) )';
+		--background-color-destructive-subtle--active: ~'hsl( var( --color-destructive__h ), var( --background-color-subtle__s ), calc( var( --background-color-subtle__l ) + ( var( --delta-lightness-surface-base ) * 6 ) ) )';
+		--background-color-error-subtle--hover: var( --background-color-destructive-subtle--hover );
+		--background-color-error-subtle--active: var( --background-color-destructive-subtle--active );
+		--border-color-interactive--hover: ~'rgb( 0 0 0 / 0.2 )';
+		--border-color-interactive--active: ~'rgb( 0 0 0 / 0.3 )';
+		// Citizen's borders are alpha, not palette reds — the rest of the
+		// state border family already collapses to --border-color-base.
+		--border-color-error--active: var( --border-color-base );
 		--color-link-red--visited--hover: var( --color-destructive--visited--hover );
 		--color-link-red--visited--active: var( --color-destructive--visited--active );
+		--border-color-inverted-fixed: #fff;
+
+		// @since Codex Design Tokens v2.3.2 (MediaWiki 1.45)
+		--border-color-emphasized: var( --color-base );
+		--border-color-warning--hover: var( --border-color-base );
+		--border-color-warning--active: var( --border-color-base );
+		--color-link--focus: var( --color-progressive--focus );
+		--color-link--visited: var( --color-visited );
+		--color-link--visited--hover: var( --color-visited--hover );
+		--color-link--visited--active: var( --color-visited--active );
+
+		// @since Codex Design Tokens v2.5.1 (MediaWiki 1.46)
+		// --color-neutral is the enabled Codex button label and CSS-icon
+		// mask fill. Codex 1.14 coloured the same selector with
+		// --color-base, so aliasing it keeps buttons identical across a
+		// 1.43 -> 1.46 upgrade.
+		--color-neutral: var( --color-base );
+		--color-icon-progressive: var( --color-progressive );
+		--background-color-target-text: ~'hsl( var( --color-warning__h ), var( --background-color-subtle__s ), calc( var( --background-color-subtle__l ) + ( var( --delta-lightness-surface-base ) * 3 ) ) )';
 
 		--background-color-interactive-subtle--hover: var( --color-surface-1--hover );
 		--background-color-interactive-subtle--active: var( --color-surface-1--active );

--- a/resources/skins.citizen.tokens/tokens-theme-dark.less
+++ b/resources/skins.citizen.tokens/tokens-theme-dark.less
@@ -67,6 +67,15 @@
 	--border-color-subtle: ~'rgb( 255 255 255 / 0.05 )';
 	--border-color-muted: ~'rgb( 255 255 255 / 0.03 )';
 	--border-color-interactive: ~'rgb( 255 255 255 / 0.1 )';
+	--border-color-interactive--hover: ~'rgb( 255 255 255 / 0.2 )';
+	--border-color-interactive--active: ~'rgb( 255 255 255 / 0.3 )';
+
+	// Upstream keeps the emphasized rung brighter than --color-disabled in
+	// dark so disabled radio dots and indeterminate checkboxes stay legible.
+	--color-disabled-emphasized: var( --color-placeholder );
+
+	// Codex blends quiet controls with `multiply` on light, `screen` on dark.
+	--mix-blend-mode-blend: screen;
 
 	--opacity-glass: 0.8;
 


### PR DESCRIPTION
Closes #1690

## Root cause

Citizen does not import Codex's `:root` token sheet — it hand-writes its own. `mediawiki.skin.variables.less` pulls in `theme-wikimedia-ui.less`, which emits **zero CSS rules**, only LESS variables shaped `@color-neutral: var( --color-neutral, #404244 );`.

So every Codex token reaches the page only as `var( --token, <light literal> )`. Any token Citizen never declares resolves to its hard-coded **light** value in *every* theme — invisible in light mode, visibly broken in dark.

`--color-neutral` (new in MW 1.46) is the loud one because `skins.citizen.codex.styles` is in the skin's always-loaded `styles` array, so Codex's `CdxButton.css` ships on **every** page. Its base rule sets both the label `color` and the `.cdx-button__icon` `background-color` to `var( --color-neutral, #404244 )`.

This is not one token. Auditing `theme-wikimedia-ui-root.css` across REL1_43…REL1_46 against Citizen's declarations found the default (legacy) pipeline **30 tokens behind**, accumulated across MW 1.44, 1.45 and 1.46. The v4 pipeline already declares all 30 — which is why the reporter found `$wgCitizenPreview = 4;` fixes it.

15 of the 30 already had commented-out placeholders in `tokens-codex.less` marking them as known-missing.

## What changed

Declare all 30 in the legacy pipeline, expressed through Citizen's own palette so they flip with the theme instead of restating Wikimedia hex.

`--color-neutral` aliases `--color-base`: Codex 1.14 already coloured that same selector with `--color-base`, so the mapping keeps buttons identical across a 1.43 → 1.46 upgrade.

Value notes:

- **Subtle state fills** step off `--delta-lightness-surface-base`, which is negative in light and positive in dark, so one declaration covers both directions. Multipliers are `*3`/`*6` rather than `*2`/`*4` because at `*2` the dark hover fill measures *below* `--color-surface-1--hover` — a progressive quiet-button hover would read recessed, dimmer than a plain button's hover.
- **`--color-disabled-emphasized`** tracks `--color-disabled` in light and `--color-placeholder` in dark, mirroring upstream, which keeps the emphasized rung brighter so disabled radio dots and indeterminate checkboxes stay legible (WCAG 1.4.11).
- **`--border-color-error--active`** and the `--border-color-warning--*` pair collapse to `--border-color-base`, completing the family the way `--border-color-error`/`--warning`/`--success`/`--notice` already do. Citizen's borders are alpha, not palette reds.
- **`.feature-pure-black()`** gets matching `--border-color-interactive--hover/--active` rungs, since it raises the base alpha to 0.15 and would otherwise halve the first step.
- **`--mix-blend-mode-blend`** gains its dark `screen` half in *both* pipelines, so the one being retired isn't left more correct than its replacement.

### Second commit

`--opacity-icon-base--active` was declared only in the v4 pipeline, but both legacy theme files build `--background-color-icon--active` from it — so on the default theme that `rgba()` was invalid and its consumers (SemanticMediaWiki modal close button, tooltip icons) inherited their parent's colour. Separate root cause, so separate commit; drop it if you'd rather it went on its own.

## Light-mode changes

Everything below currently renders with a Codex hex and will now render with a Citizen-palette value. Not regressions — the skin reasserting its own palette — but they are visible on existing wikis.

| token | before → after | where |
| --- | --- | --- |
| `--border-color-interactive--hover/--active` | `#27292d`/`#202122` → `rgb(0 0 0 / 0.2)`/`0.3` | **most visible.** Hover/press border on every Codex control; near-opaque black → the skin's own alpha border |
| `--color-icon-error/success/notice/warning` | Codex hexes → Citizen destructive/success/placeholder/warning | CdxMessage + CdxInfoChip glyphs |
| `--background-color-destructive-subtle--hover/--active` | `#ffdad3`/`#ffc8bd` → pink | matches the existing `--background-color-destructive-subtle` |
| `--color-neutral` | `#404244` → `--color-base` | every enabled non-primary Codex button label and mask icon |
| `--color-icon-progressive` | `#36c` → `--color-progressive` | byte-identical, no visual change |

Also fixes three of Citizen's own stylesheets that referenced these tokens with **no fallback** and were silently dead in both themes: the ArticleFeedbackv5 feedback buttons and back arrow (`--color-neutral`), the WSSearchFront hover border (`--border-color-interactive--hover`), and the jsonview muted text (`--color-base--subtle`).

## Test plan

The original symptom is **not locally reproducible** — local MW is 1.43.6 / Codex 1.14, which never emits `--color-neutral`. Verified by assertion instead, on both pipelines via `?citizenpreview=0` / `?citizenpreview=4`.

- [x] Reproduced the bug on legacy: probe `color: var(--color-neutral, #404244)` stayed `rgb(64,66,68)` while the page background flipped `oklch(0.96…)` → `oklch(0.14…)`.
- [x] After: all 30 tokens defined and flipping across day / night / black. No sentinel leaks.
- [x] Dark ladder measured by canvas luminance (`oklch()` does not serialize to rgb, so eyeballing computed values is unreliable): resting `0.0030` → hover `0.0083` → active `0.0175`, monotonic, and hover clears `--color-surface-1--hover` (`0.0079`) at 1.054×.
- [x] Black theme border ramp even: 0.15 → 0.25 → 0.35.
- [x] `--background-color-icon--active` resolves in both themes (previously fell through).
- [x] Compiled `skins.citizen.tokens.new` diffed against pre-patch output — only the three intended `screen` insertions, no leak from the legacy edits.
- [x] `npm run lint:styles` exit 0; 1096 Vitest tests pass. (`lint:js` errors on this tree are pre-existing and in unrelated files — no JS changed.)
- [x] No new console errors; all stylesheets 200.

No PHP, JS, i18n or markup changed, so `composer preflight` is not implicated.

## Out of scope

- The `--*-option-*` colour family — present only on `master`, no released branch emits it.
- `--line-height-xx-small` / `-xxx-small` — already declared in `skins.citizen.styles/tokens-citizen.less` with stale Codex 1.x unitless values. Real but separate, cosmetic, and only bites third-party LESS on MW 1.45+.
- A sweep for the same defect class found ~15 dangling `var()` references elsewhere in `skinStyles/` (typos like `--bordder-color-base`, single-dash names, a foreign token vocabulary in `WSSearchFront`) — all silently dead CSS today. Worth its own cleanup issue plus a stylelint rule, which would have caught this bug's Citizen-side symptoms too.

## Cache considerations

Single commit is safe — this adds custom-property *declarations* to `:root`, which exists in every cached page. No renamed classes, no restructured markup, so the two-commit rule in `AGENTS.md` does not apply. Legacy-side only, works identically in both worlds, so no preview gate and no `(preview)` suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode contrast and readability for disabled controls, interactive borders, icons, links, and blended surfaces.
  * Improved compatibility between Citizen styling and newer Codex design tokens.
  * Added missing hover and active states for progressive, destructive, error, and interactive elements.
* **Style**
  * Refined dark-theme rendering for blended surfaces and legacy pure-black styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->