### PR TITLE
fix(skinStyles): point dangling variable references at real tokens

### DIFF
--- a/resources/skins.citizen.tokens.new/syntax-color.less
+++ b/resources/skins.citizen.tokens.new/syntax-color.less
@@ -17,7 +17,10 @@
 	--color-syntax-brown: light-dark( @color-syntax-brown, @color-syntax-brown-dark );
 	--color-syntax-pink: light-dark( @color-syntax-pink, @color-syntax-pink-dark );
 	--color-syntax-violet: light-dark( @color-syntax-violet, @color-syntax-violet-dark );
-	--color-syntax-grey: @color-syntax-grey;
+	--color-syntax-gray: light-dark( @color-syntax-gray, @color-syntax-gray-dark );
+	// Deprecated alias — `grey` was the original spelling. Kept so wiki
+	// CSS written against it keeps working; drop at the next major.
+	--color-syntax-grey: var( --color-syntax-gray );
 }
 
 .new-syntax-color() {

--- a/resources/skins.citizen.tokens/tokens-theme-base.less
+++ b/resources/skins.citizen.tokens/tokens-theme-base.less
@@ -87,7 +87,10 @@
 	--color-syntax-brown: @color-syntax-brown;
 	--color-syntax-pink: @color-syntax-pink;
 	--color-syntax-violet: @color-syntax-violet;
-	--color-syntax-grey: @color-syntax-grey;
+	--color-syntax-gray: @color-syntax-gray;
+	// Deprecated alias — `grey` was the original spelling. Kept so wiki
+	// CSS written against it keeps working; drop at the next major.
+	--color-syntax-grey: var( --color-syntax-gray );
 
 	// Backdrop
 	--backdrop-filter-blur: blur( 2px );

--- a/resources/skins.citizen.tokens/tokens-theme-dark.less
+++ b/resources/skins.citizen.tokens/tokens-theme-dark.less
@@ -56,6 +56,7 @@
 	--color-syntax-brown: @color-syntax-brown-dark;
 	--color-syntax-pink: @color-syntax-pink-dark;
 	--color-syntax-violet: @color-syntax-violet-dark;
+	--color-syntax-gray: @color-syntax-gray-dark;
 
 	--background-color-button-quiet--hover: rgba( 255, 255, 255, 0.04 );
 	--background-color-button-quiet--active: rgba( 255, 255, 255, 0.08 );

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -53,7 +53,7 @@
 @color-syntax-brown: #916b53;
 @color-syntax-pink: #ff5370;
 @color-syntax-violet: #945eb8;
-@color-syntax-grey: #90a4ae;
+@color-syntax-gray: #90a4ae;
 
 // Syntax highlight colors
 // Based on Material Theme Palenight
@@ -69,7 +69,7 @@
 @color-syntax-brown-dark: #916b53;
 @color-syntax-pink-dark: #ff9cac;
 @color-syntax-violet-dark: #bb80b3;
-@color-syntax-grey-dark: #676E95;
+@color-syntax-gray-dark: #676E95;
 
 // Box model properties
 // `--*size` variables are used for `*width` & `*height` properties.

--- a/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
+++ b/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
@@ -82,6 +82,6 @@
 }
 
 .mw-special-AccountInfo tr.mw-accountinfo-current td:first-child {
-	color: var( --color-base--emphasized );
-	background: var( --color-text-success );
+	color: var( --color-emphasized );
+	background: var( --background-color-success-subtle );
 }

--- a/skinStyles/extensions/CodeEditor/ext.codeEditor.ace.less
+++ b/skinStyles/extensions/CodeEditor/ext.codeEditor.ace.less
@@ -172,7 +172,7 @@
 			}
 
 			&_indent-guide {
-				opacity: var( --opacity-base--disabled );
+				opacity: var( --opacity-icon-base--disabled );
 			}
 		}
 	}

--- a/skinStyles/extensions/CodeMirror/codemirror.mediawiki.less
+++ b/skinStyles/extensions/CodeMirror/codemirror.mediawiki.less
@@ -36,7 +36,7 @@
 	}
 
 	&-comment {
-		.mixin-citizen-css-theme-clientpref-all( color, var( --color-syntax-grey ) );
+		.mixin-citizen-css-theme-clientpref-all( color, var( --color-syntax-gray ) );
 	}
 
 	&-apostrophes-bold,

--- a/skinStyles/extensions/CodeMirror/ext.CodeMirror.lib.less
+++ b/skinStyles/extensions/CodeMirror/ext.CodeMirror.lib.less
@@ -138,7 +138,7 @@
 			}
 
 			&-bracket {
-				color: var( --color-syntax-grey );
+				color: var( --color-syntax-gray );
 			}
 
 			&-tag {

--- a/skinStyles/extensions/Flow/ext.flow.ui.less
+++ b/skinStyles/extensions/Flow/ext.flow.ui.less
@@ -25,7 +25,7 @@
 	}
 
 	// Override border-color and margin-top from OOUI MenuSelectWidget
-	border-color: var( --bordder-color-base );
+	border-color: var( --border-color-base );
 
 	&::-webkit-scrollbar-thumb {
 		border-color: var( --color-surface-1 );

--- a/skinStyles/extensions/MediaSearch/mediasearch.styles.less
+++ b/skinStyles/extensions/MediaSearch/mediasearch.styles.less
@@ -45,7 +45,7 @@
 	}
 
 	&__indicator {
-		color: var( --color-base-subtle );
+		color: var( --color-subtle );
 	}
 
 	&__input {
@@ -55,7 +55,7 @@
 		border-radius: var( --border-radius-base );
 
 		&::placeholder {
-			color: var( --color-base-subtle );
+			color: var( --color-subtle );
 		}
 
 		&:hover {
@@ -235,7 +235,7 @@
 		}
 
 		&:not( .sd-button--framed ) .sd-icon {
-			opacity: var( --opacity-base--disabled );
+			opacity: var( --opacity-icon-base--disabled );
 		}
 	}
 }

--- a/skinStyles/extensions/SemanticMediaWiki/ext.smw.vtabs.styles.less
+++ b/skinStyles/extensions/SemanticMediaWiki/ext.smw.vtabs.styles.less
@@ -81,5 +81,5 @@ div.smw-vtab-nav .smw-vtab-warning a {
 }
 
 div.smw-vtab-nav .smw-vtab-warning.active a {
-	color: var( --color-warning--active );
+	color: var( --color-warning );
 }

--- a/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
+++ b/skinStyles/extensions/SyntaxHighlight_GeSHi/ext.pygments.less
@@ -14,7 +14,7 @@
 		background: none;
 
 		.c {
-			color: var( --color-syntax-grey );
+			color: var( --color-syntax-gray );
 		}
 
 		.err {
@@ -31,11 +31,11 @@
 		}
 
 		.ch {
-			color: var( --color-syntax-grey );
+			color: var( --color-syntax-gray );
 		}
 
 		.cm {
-			color: var( --color-syntax-grey );
+			color: var( --color-syntax-gray );
 		}
 
 		.cp {
@@ -43,15 +43,15 @@
 		}
 
 		.cpf {
-			color: var( --color-syntax-grey );
+			color: var( --color-syntax-gray );
 		}
 
 		.c1 {
-			color: var( --color-syntax-grey );
+			color: var( --color-syntax-gray );
 		}
 
 		.cs {
-			color: var( --color-syntax-grey );
+			color: var( --color-syntax-gray );
 		}
 
 		.gd {

--- a/skinStyles/extensions/TemplateData/ext.templateDataGenerator.editTemplatePage.less
+++ b/skinStyles/extensions/TemplateData/ext.templateDataGenerator.editTemplatePage.less
@@ -41,7 +41,7 @@
 		color: var( --color-emphasized );
 		background-color: var( --color-surface-2 );
 		border: var( --border-width-base ) solid var( --border-color-base );
-		border-radius: var( --border-radius-small );
+		border-radius: var( --border-radius-base );
 
 		&:first-child {
 			background-color: var( --color-surface-2 );

--- a/skinStyles/extensions/Wikibase/jquery.wikibase.toolbar.styles.less
+++ b/skinStyles/extensions/Wikibase/jquery.wikibase.toolbar.styles.less
@@ -29,7 +29,7 @@
 }
 
 .wikibase-toolbar-button.ui-state-disabled a:hover .wb-icon {
-	opacity: var( --opacity-base--disabled );
+	opacity: var( --opacity-icon-base--disabled );
 }
 
 // Toolbar icons

--- a/skinStyles/jquery/datatables.less
+++ b/skinStyles/jquery/datatables.less
@@ -477,7 +477,7 @@ div.dtsp-panesContainer {
 			}
 
 			button.dtsp-disabledButton {
-				opacity: var( --opacity-base--disabled ) !important;
+				opacity: var( --opacity-icon-base--disabled ) !important;
 			}
 		}
 	}

--- a/skinStyles/jquery/jsonview.less
+++ b/skinStyles/jquery/jsonview.less
@@ -16,7 +16,7 @@
 
 .jsonview .prop {
 	font-weight: var( --font-weight-normal );
-	color: var( --color-base--emphasized );
+	color: var( --color-emphasized );
 }
 
 .jsonview .null {

--- a/skinStyles/lib/leaflet/leaflet.less
+++ b/skinStyles/lib/leaflet/leaflet.less
@@ -75,13 +75,13 @@
 
 		&:hover {
 			color: var( --color-emphasized );
-			background-color: var( --background-color-quiet--hover );
+			background-color: var( --background-color-button-quiet--hover );
 			border-bottom-color: var( --border-color-interactive );
 		}
 
 		&:active {
 			color: var( --color-emphasized );
-			background-color: var( --background-color-quiet--active );
+			background-color: var( --background-color-button-quiet--active );
 		}
 
 		&.leaflet-disabled {
@@ -106,11 +106,11 @@
 		border-radius: var( --border-radius-base );
 
 		&:hover {
-			background: var( --background-color-quiet--hover );
+			background: var( --background-color-button-quiet--hover );
 		}
 
 		&:has( input:checked ) {
-			background: var( --background-color-quiet--active );
+			background: var( --background-color-button-quiet--active );
 		}
 
 		/* Align leaflet controls */
@@ -208,7 +208,7 @@
 
 	&:hover {
 		color: var( --color-emphasized );
-		background-color: var( --background-color-quiet--hover );
+		background-color: var( --background-color-button-quiet--hover );
 	}
 }
 

--- a/skinStyles/mediawiki/action/mediawiki.action.history.styles.less
+++ b/skinStyles/mediawiki/action/mediawiki.action.history.styles.less
@@ -24,7 +24,7 @@
 
 	li {
 		&.selected {
-			color: var( --color-base--emphasized );
+			color: var( --color-emphasized );
 			outline-color: var( --border-color-base );
 
 			&.before {


### PR DESCRIPTION
Follow-up to #1709. That PR fixed Codex tokens Citizen never declared; this one fixes the mirror image — Citizen's own stylesheets referencing custom properties that exist nowhere in the skin.

## Why these aren't harmless

A `var()` pointing at an undeclared property **with no fallback** makes the whole declaration *invalid at computed-value time*. The property does not keep its previous value — it resets. Demonstrated in-browser on an element styled green-on-grey with a red border:

| declaration | intended | actual |
| --- | --- | --- |
| `color: var(--color-base--emphasized)` | `rgb(10,200,10)` | inherits parent |
| `background-color: var(--background-color-quiet--hover)` | `rgb(50,50,50)` | `rgba(0,0,0,0)` — transparent |
| `border-color: var(--bordder-color-base)` | `rgb(200,0,0)` | `currentColor` — **a visible wrong border** |
| `border-radius: var(--border-radius-small)` | `8px` | `0px` |

So: dead CSS at best, actively wrong at worst.

## Found by sweep

Collected every `--x` declared across `resources/` + `skinStyles/`, every `var( --x )` reference, and diffed. 15 tokens / 39 references across 13 files. (Three apparent hits in `resources/mixins.less` are LESS interpolation — `var( --color-surface-@{surface} )` — and are excluded.)

## Commit 1 — dangling references

Six were near-misses on tokens that do exist:

| wrong | right | files |
| --- | --- | --- |
| `--bordder-color-base` (typo) | `--border-color-base` | Flow |
| `--color-base--emphasized` | `--color-emphasized` | jsonview, AccountInfo, history |
| `--color-base-subtle` (one dash) | `--color-subtle` | MediaSearch ×2 |
| `--background-color-quiet--hover/--active` | `--background-color-button-quiet--…` | leaflet ×5 |
| `--opacity-base--disabled` | `--opacity-icon-base--disabled` | CodeEditor, Wikibase, datatables, MediaSearch |

Three had no counterpart at all and needed a judgement call — flagging these for review since they're the only non-mechanical part:

- **`--border-radius-small`** (TemplateData) → `--border-radius-base`. Citizen's scale is base/medium/large; there is no `small`.
- **`--color-text-success`** (AccountInfo) → `--background-color-success-subtle`. It was applied as `background:`, so a saturated foreground green would have poor contrast against the `color:` set in the same rule.
- **`--color-warning--active`** (SMW vtabs) → `--color-warning`. Citizen has no warning state variants. Today the declaration is invalid, so the active warning tab inherits `--color-emphasized` and loses the warning hue entirely; this restores it. The active state stays distinguished by the border and background rules that already apply.

## Commit 2 — `grey` → `gray` normalization

The palette declared `--color-syntax-grey`, but consumers were split across both spellings — `ext.CodeMirror.lib.less` used `gray` on line 117 and `grey` on line 141, so half that rule set was dead.

Settled on `gray` (matching the American spelling used everywhere else in the vocabulary) and renamed the LESS source variables to match. **`--color-syntax-grey` is kept as an alias** so wiki CSS written against it keeps working — say the word if you'd rather take the clean break instead, since it's undocumented and this would be the moment.

This also exposed a latent bug: grey was the **only** syntax colour with no dark value in either pipeline. `@color-syntax-grey-dark: #676E95` was declared in `variables.less` and never referenced, so code comments kept the light `#90a4ae` in dark mode. Now wired up like the other eleven.

## Deliberately not fixed: WSSearchFront

The remaining 5 tokens / 20 references are all in `skinStyles/extensions/WSSearchFront/` (`--base-color`, `--base-color-lighter`, `--base-color-darker`, `--back-icon`, `--next-icon`).

**I initially assumed these were dead too, and I no longer think that.** That file's own `:root` block re-points `--tint-1` and `--border-1` at Citizen tokens — and those are unmistakably WSSearch's vocabulary, not Citizen's. So the file's design is *redefine the extension's custom properties*, which means `--base-color` and friends are probably declared by the extension and resolve fine at runtime; the author simply re-pointed two of seven.

If that's right, the real defect is different — Citizen is inheriting the extension's hardcoded colours instead of the skin's accent — and the fix is to add the missing re-pointings to that `:root` block, not to rewrite 20 usages.

I could not confirm either way: WSSearch is not installed locally, and its source is not on GitHub (code search returns only Citizen forks). Guessing risks replacing styling that currently works, so I left it. Worth its own issue once someone can check the extension's CSS.

Same file, out of scope but noted: line 23 hardcodes `border-color: #72777d` and line 214 `#a2a9b1` — light-mode Codex greys that will be wrong in dark mode, the same defect class as #1690.

## Test plan

- [x] Sweep re-run after the fix: 15 tokens → 5, all confined to WSSearchFront.
- [x] `@color-syntax-gray-dark` no longer orphaned (was declared-but-unreferenced).
- [x] Browser, **legacy** pipeline (`?citizenpreview=0`): `--color-syntax-gray` now flips `#90a4ae` → `#676E95` (previously stuck light); `--color-syntax-grey` alias tracks it exactly in both themes.
- [x] Browser, **v4** pipeline (`?citizenpreview=4`): same, via `light-dark()`.
- [x] Every replacement token verified to resolve in both light and dark — no new dangling references introduced.
- [x] `npm run lint:styles` exit 0; 1096 Vitest tests pass.

## Follow-up worth filing

The sweep is ~30 lines and catches this whole class at CI time. It would have caught #1690's Citizen-side symptoms too. Happy to add it as a lint step if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized syntax highlighting gray color tokens, with compatibility retained for existing references.
  - Improved light and dark theme support for syntax colors.
  - Updated disabled-state opacity and subtle color usage across interface components.
  - Corrected button, warning, emphasis, border, and background color tokens for more consistent theming.
  - Refined selected history, account information, code editor, media search, and third-party component styling.
  - Fixed a menu border-color typo and adjusted template data alias corner rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->