### PR TITLE
fix(overflow): stop the page shifting when tables and scroll boxes load

### DIFF
--- a/docs/src/features/overflow.md
+++ b/docs/src/features/overflow.md
@@ -26,6 +26,8 @@ Give any element the same treatment by adding the `citizen-overflow` class:
 </div>
 ```
 
+An element you opt in this way fills the width of the content column. Wikitables are the exception — they stay as wide as their contents and only scroll once they outgrow the column.
+
 ### Opting out
 
 To leave an element as-is — for example a table you lay out yourself — add the `citizen-table-nowrap` class:

--- a/resources/skins.citizen.styles/components/OverflowElements.less
+++ b/resources/skins.citizen.styles/components/OverflowElements.less
@@ -11,12 +11,21 @@
 
 // Elements enhanced by overflowElements.js
 .citizen-overflow {
+	// The wrapper this element is about to be moved into is a scroll
+	// container, so it contains the margins of everything inside it. Match
+	// that here or the block grows by those margins the moment the script
+	// runs. `.wikitable` is already a scroll container for the same reason.
+	overflow: auto hidden;
+
 	&-wrapper {
 		position: relative;
 		display: flex; /* So that it respects float elements (#878) */
-		max-width: max-content;
 
 		&:has( .citizen-overflow-content > .wikitable ) {
+			// Shrink to the table rather than filling the column, matching
+			// the `max-width` a bare `.wikitable` carries. Anything else
+			// opted in by hand is a plain block and stays full width.
+			max-width: max-content;
 			margin-block: var( --space-md );
 			margin-inline: var( --border-width-base ); // Fix clipping border
 			border-radius: var( --border-radius-medium );
@@ -27,8 +36,40 @@
 			max-width: none;
 		}
 
+		// The skin gives these elements a block margin of their own, and it
+		// has to be zeroed once they sit inside the scroll container, so the
+		// wrapper carries it instead. Same value, same place in the flow.
+		// `.wikitable` is not in the list: the card rule above already gives
+		// the wrapper this margin.
+		&:has( .citizen-overflow-content > :is( ul, ol, dl, blockquote ) ) {
+			margin-block: var( --space-md );
+
+			// hacks.less zeroes the margins of a `floatleft`/`floatright`
+			// element, and that class migrates to the wrapper — so the zero
+			// has to migrate with it. Floats detected from an inline style
+			// keep the margin: nothing zeroed it before the wrap either.
+			&.floatleft,
+			&.floatright {
+				margin-block: 0;
+			}
+		}
+
+		// typography.less pulls a list, table, or quote that directly follows
+		// a paragraph closer to it. Wrapping happens client-side, so from
+		// first paint onwards it is this element sitting in that position
+		// instead: without the same tightening the content, and everything
+		// below it, drops by that much the moment the script runs. Keep the
+		// element list in step with typography.less.
+		p:not( .mw-empty-elt ) + &:has( .citizen-overflow-content > :is( ul, ol, table, dl, blockquote ) ) {
+			margin-top: calc( var( --space-xs ) * -1 );
+		}
+
+		// Both spellings of a floated wrapper: `--float*` when the float was
+		// detected on the element, the bare class when it migrated over
 		&--floatleft,
-		&--floatright {
+		&--floatright,
+		&.floatleft,
+		&.floatright {
 			margin: 0;
 
 			// The float and its margins are re-expressed on the wrapper —
@@ -80,13 +121,29 @@
 			float: none !important;
 		}
 
+		// The wrapper is the scroll container now, so hand back the
+		// containment the element carries in its unwrapped state. Block
+		// margins go with it: kept here they would be trapped inside the
+		// scroll container instead of collapsing with the surrounding flow.
+		// Inline margins stay — they indent list markers.
+		> .citizen-overflow {
+			margin-block: 0;
+			overflow: initial;
+		}
+
 		> .wikitable {
 			display: table;
 			max-width: none;
 			// Handle margin and box-shadow on outer wrapper
-			margin-block: 0;
+			margin: 0;
 			overflow: initial;
 			box-shadow: none;
+
+			// A `table` box shrinks to its content, so `--fluid` has to ask
+			// for the full width here — unlike the unwrapped block box
+			&--fluid {
+				width: 100%;
+			}
 		}
 
 		.citizen-overflow--left > & {

--- a/resources/skins.citizen.styles/skinning/content.tables.less
+++ b/resources/skins.citizen.styles/skinning/content.tables.less
@@ -10,7 +10,12 @@
 .wikitable {
 	display: block;
 	max-width: max-content; // Needed for the border
-	margin: var( --space-md ) 0;
+	margin-block: var( --space-md );
+	// The border is a box-shadow, which paints outside the border box. The
+	// inline margin keeps it clear of an ancestor scroll container that
+	// would otherwise clip it, and keeps this box aligned with the wrapper
+	// overflowElements.js swaps in for it.
+	margin-inline: var( --border-width-base );
 	overflow-x: auto;
 	border-collapse: collapse;
 	border-color: var( --border-color-base );
@@ -132,7 +137,10 @@
 		}
 	}
 
+	// A block box already fills the inline axis, so dropping the
+	// max-content cap is all this needs. The wrapped copy is a `table` box
+	// instead and gets an explicit width in OverflowElements.less.
 	&--fluid {
-		width: 100%;
+		max-width: none;
 	}
 }


### PR DESCRIPTION
## Problem

`overflowElements.js` moves a wikitable (or a hand-tagged `.citizen-overflow` element) into a scroll container *after* first paint:

```html
<div class="citizen-overflow-wrapper">
  <div class="citizen-overflow-nav">…</div>
  <div class="citizen-overflow-content">   <!-- overflow: auto hidden -->
    <table class="wikitable">…</table>
  </div>
</div>
```

Any styling difference between the bare element and that structure becomes a layout shift the instant the script runs. There were five.

| Mismatch | Effect |
| --- | --- |
| The inserted `<div>` breaks `typography.less`'s `p + table` adjacency | table and everything below drops by `--space-xs` |
| A hand-tagged element wasn't a BFC; the wrapper's scroll container is | inner margins stop collapsing, block grows by them |
| A list or quote's own block margin gets trapped in the scroll container | up to `--space-md` either way |
| `.wikitable--fluid` asked for `width: 100%` under `max-width: max-content` | table jumped from shrink-to-fit to full width |
| The wrapper had an inline margin for its `box-shadow` border, the bare table didn't | 1px inline offset |

## Approach

Make the wrapped and unwrapped states geometrically identical, rather than papering over the symptom. Each mismatch is fixed on whichever side was wrong:

- The wrapper takes over the flow spacing of the element it replaces — the paragraph-adjacency tightening and the element's own block margin — because it is the box sitting in that position from first paint onwards. `typography.less` is deliberately untouched: a JS-component class does not belong in a generic typography file.
- The bare `.citizen-overflow` element becomes a scroll container, which is what `.wikitable` already was and what the wrapper always is.
- `max-width: max-content` moves off the base wrapper into the wikitable rule, so hand-tagged blocks stay full width in both states instead of shrink-wrapping on load.
- The `box-shadow` inline margin is mirrored onto the bare table. That margin is load-bearing, not cruft — without it the 1px ring clips against an `overflow: hidden` ancestor — and mirroring it fixes the same clipping for tables that are never wrapped (`citizen-table-nowrap`, and every table when scripts are unavailable).

## Verification

A/B on a fixture page carrying every variant, measured with a document-start `PerformanceObserver`:

- **Before:** CLS 0.0166, one shift burst, five paragraphs displaced by 8 / 16 / 24 / 56 / 96px.
- **After:** zero `layout-shift` entries, at 1265px and 500px viewports, and no horizontal document overflow.

A 26-variant unwrap/rewrap geometry harness (headings, paragraphs, lists, definition lists, quotes, captions, sticky headers, fluid tables, migrated float classes, floats detected from inline styles, wide and narrow) reports zero delta for every trailing-marker position and container height. Wide content still scrolls in the wrapper, the `--left`/`--right` gradient state still applies, and nav buttons and sticky headers still work.

`npm run lint:styles` and `npm run lint:md` clean.

## Known residuals, none of which move painted content

- A wide table's own box changes shape (`display: block` + its own scrollbar → `display: table` inside the wrapper's scroll container). Inherent to the no-JS `overflow-x: auto` fallback; no cell moves and Chrome records no shift.
- A `--fluid` short table's cells stretch on wrap, going from a block box to a real table box. The outer box no longer moves — that was a 719px jump.
- A hand-tagged element stops being a BFC inside the wrapper, so its own box edges move. Making it exact needs `display: flow-root`, which would break `.citizen-overflow` on a `<table>` or a flex container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal scrolling for wide tables and other overflowing content.
  * Tables now size correctly within content areas, including fluid tables that fill available space.
  * Fixed spacing and border clipping around tables, lists, blockquotes, paragraphs, and floated content.

* **Documentation**
  * Clarified how opting in to overflow handling affects content and wikitables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->