### PR TITLE
ci(docs): skip preview deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -65,18 +65,30 @@ jobs:
           DOCS_VERSION: main
         run: npm run docs:build
 
+      # Keep in sync with the preview job's condition below — no point uploading
+      # a dist nothing will deploy.
       - name: Upload dist for preview deploy
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && github.event.pull_request.user.login != 'dependabot[bot]'
         uses: actions/upload-artifact@v7
         with:
           name: docs-dist
           path: docs/.vitepress/dist
           retention-days: 1
 
+  # Forks and Dependabot are both excluded because neither can read the
+  # Cloudflare secrets: forks get no secrets at all, and Dependabot-triggered
+  # runs read a separate Dependabot secret store that does not hold them.
+  # Without this the deploy fails with an empty CLOUDFLARE_API_TOKEN.
   preview:
     name: 🔍 Preview
     needs: build
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Problem

Docs CI has failed on every Dependabot PR since preview deployments were added in `8d29c127` — eight runs so far (oxfmt, jsdom, `@types/node`, less, oxlint ×2, and #1718). In all of them lint and build pass and only `🔍 Preview` fails.

The cause is not the dependency bump and not the docs build. Dependabot-triggered `pull_request` runs read a **separate Dependabot secret store**, which does not hold `CLOUDFLARE_API_TOKEN`. The token interpolates to an empty string and wrangler aborts before deploying.

This is permanent for as long as the job is reachable from a Dependabot PR — it is not flakiness, and re-running does not help.

## Behaviour

`🔍 Preview` is now gated on the PR author and skips for Dependabot, alongside the existing fork guard. Docs dependency bumps are merged on green rather than reviewed through the preview URL, so the deploy had no audience on those PRs.

Human PRs are unaffected. Required status checks on `main` are empty, so a skipped job blocks nothing.

## Contract

Preview deployments require Actions secrets, so they run only for same-repo, non-Dependabot pull requests. Anything else — forks today, Dependabot now — skips the deploy rather than failing it.

The artifact upload carries the same condition, so a `dist` nothing will deploy is no longer uploaded. The two conditions are meant to stay identical; a comment on each says so.

## Rejected alternative

Copying the Cloudflare credentials into the Dependabot secret store would restore previews without a workflow change, but it hands a live deploy token to the install and build scripts of whichever package Dependabot has just bumped. That is the supply-chain surface the two separate stores exist to prevent.

## Follow-ups

- Merging this does not clear the red X already on #1718. Re-running replays the workflow file from the original commit, so it fails identically — comment `@dependabot rebase` on #1718 once this lands to get a fresh run that picks up the guard.
- Neither forks nor Dependabot get docs previews. If that becomes worth having, the fix is to move the deploy into a `workflow_run` workflow, which runs in the base-repo context with full secrets and handles only the built artifact. Deliberately not done here: it is materially more machinery, and `workflow_run` only fires from the default branch, so it cannot be validated in a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143Vn9WcQgRX9qSrKmruKph