### PR TITLE
fix(commandPalette): restore palette loading after a broken style import

### DIFF
--- a/resources/skins.citizen.commandPalette/components/CommandPaletteEmptyState.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteEmptyState.vue
@@ -48,7 +48,7 @@ module.exports = exports = defineComponent( {
 
 <style lang="less">
 @import 'mediawiki.skin.variables.less';
-@import '../mixins.less';
+@import '../../mixins.less';
 
 .citizen-command-palette-empty-state {
 	display: flex;


### PR DESCRIPTION
## Problem

The command palette does not load. Pressing <kbd>/</kbd> or clicking the search button produces the "could not load" notification instead of the palette, so search — and every mode behind it — is unreachable for anyone with JavaScript enabled.

`CommandPaletteEmptyState.vue` imports `'../mixins.less'`. The file it wants lives at `resources/mixins.less`, two levels up from `components/`, which is why every other component in that directory imports `'../../mixins.less'`.

less.php cannot resolve the path, so ResourceLoader fails to build `skins.citizen.commandPalette` and serves the whole module in the `error` state:

```
$ curl 'http://localhost:8080/w/load.php?modules=skins.citizen.commandPalette&only=scripts'
mw.loader.state({"skins.citizen.commandPalette":"error"});
Less_Exception_Parser: File `../mixins.less` not found. in CommandPaletteEmptyState.vue
```

One component's import path takes down the entire module, and nothing in CI compiles it — the failure only surfaces at runtime.

## Change

Correct the import path to `'../../mixins.less'`, matching every sibling component.

## Verification

With the fix applied, the module builds and the palette mounts and renders — including the empty state this component is responsible for:

```
$ curl 'http://localhost:8080/w/load.php?modules=skins.citizen.commandPalette&only=scripts'
mw.loader.impl(function(){return["skins.citizen.commandPalette@q4x3p", …
```

Confirmed in a browser against a local MediaWiki: <kbd>/</kbd> opens the palette, typing returns results, and the console is clean.

## Notes

Introduced in 6ad9dc52. Worth considering a follow-up that compiles each ResourceLoader module in CI, since a broken LESS import in any single file silently disables everything bundled with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the command palette’s empty state styling by correcting the Less mixin import path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->