### PR TITLE
fix(search): trigger shortcuts on the character typed, not the key position

### DIFF
--- a/resources/skins.citizen.commandPalette/composables/useKeyboard.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboard.js
@@ -1,10 +1,17 @@
 const { computed, nextTick } = require( 'vue' );
 const { resolveBinding, resolveHints } = require( './useKeyboardBindings.js' );
+// keyboardLayout.js is listed in both this module's and
+// skins.citizen.scripts' packageFiles — keep the two in sync
+const {
+	isMacPlatform,
+	isLetterPressed,
+	isAltGraphChar,
+	isComposing
+} = require( '../../skins.citizen.scripts/keyboardLayout.js' );
 
 // Mac vs everywhere-else copy shortcut, computed once. Mac users
 // recognise ⌘C; Windows/Linux users recognise Ctrl+C.
-const IS_MAC = typeof navigator !== 'undefined' &&
-	/Mac|iPhone|iPad/i.test( navigator.platform || '' );
+const IS_MAC = isMacPlatform( typeof navigator !== 'undefined' ? navigator : null );
 const COPY_KBD = IS_MAC ? '⌘C' : 'Ctrl+C';
 
 /**
@@ -708,6 +715,12 @@ function useKeyboard( options ) {
 	}
 
 	function handleKeydown( event ) {
+		// Acting on the key that commits or cancels a composition would
+		// navigate away from (Enter) or clear (Escape) the query being typed.
+		if ( isComposing( event ) ) {
+			return;
+		}
+
 		// Cmd/Ctrl+C: when nothing is selected and the highlighted item
 		// declares `detail.header.copyValue`, hijack the shortcut to copy
 		// that value. With a selection present, the browser's native copy
@@ -716,7 +729,7 @@ function useKeyboard( options ) {
 			( event.metaKey || event.ctrlKey ) &&
 			!event.altKey &&
 			!event.shiftKey &&
-			( event.key === 'c' || event.key === 'C' ) &&
+			isLetterPressed( event, 'c' ) &&
 			!hasTextSelection() &&
 			core.requestHeaderCopy
 		) {
@@ -733,8 +746,13 @@ function useKeyboard( options ) {
 		}
 
 		// Ignore events with modifier keys (Shift is allowed for printable chars
-		// like @, >, :, ?).
-		if ( event.altKey || event.ctrlKey || event.metaKey ) {
+		// like @, >, :, ?). A character composed with AltGr is not a chord —
+		// that is how `@`, `~` and `#` are typed on many European layouts, and
+		// all three are mode triggers.
+		if (
+			( event.altKey || event.ctrlKey || event.metaKey ) &&
+			!isAltGraphChar( event, IS_MAC )
+		) {
 			return;
 		}
 		if ( event.shiftKey && event.key.length !== 1 ) {

--- a/resources/skins.citizen.scripts/keyboardLayout.js
+++ b/resources/skins.citizen.scripts/keyboardLayout.js
@@ -1,0 +1,134 @@
+/**
+ * Keyboard-layout helpers shared by the global search shortcuts and the
+ * command palette dispatcher.
+ *
+ * `event.code` names a position on a US QWERTY reference layout, not the
+ * character that was typed, so matching on it fires a shortcut from whatever key
+ * happens to sit there. Character shortcuts match `event.key` instead.
+ *
+ * Listed in both `skins.citizen.scripts` and `skins.citizen.commandPalette` in
+ * skin.json.
+ */
+
+/**
+ * Whether the user is on a Mac, which composes characters with Option where
+ * other platforms use AltGr, and uses Control+Option where they use Alt+Shift.
+ *
+ * `userAgentData` is Chromium-only; `platform` is deprecated but universal.
+ *
+ * @param {Navigator|null} [navigator]
+ * @return {boolean}
+ */
+function isMacPlatform( navigator ) {
+	if ( !navigator ) {
+		return false;
+	}
+	const platform = ( navigator.userAgentData && navigator.userAgentData.platform ) ||
+		navigator.platform || '';
+	return /mac|iphone|ipad/i.test( platform );
+}
+
+/**
+ * Whether a letter shortcut was pressed, by the letter typed rather than the
+ * key position.
+ *
+ * Position is the better guess in the one case where no Latin letter is typed
+ * at all: Cyrillic, Greek and Arabic keycaps carry a Latin legend that follows
+ * the US positions. macOS rewrites `event.key` into a glyph for every Option
+ * chord (Option+Shift+F reports "Ï"), which lands in the same fallback.
+ *
+ * The regex is deliberately ASCII-only — full Unicode case folding maps U+017F
+ * and U+212A onto "s" and "k".
+ *
+ * @param {KeyboardEvent} event
+ * @param {string} letter lowercase ASCII letter
+ * @return {boolean}
+ */
+function isLetterPressed( event, letter ) {
+	if ( /^[a-z]$/i.test( event.key ) ) {
+		return event.key.toLowerCase() === letter;
+	}
+	return event.code === `Key${ letter.toUpperCase() }`;
+}
+
+/**
+ * Whether the event is a character composed with AltGr rather than a chord.
+ *
+ * Windows delivers AltGr as Ctrl+Alt; Macs compose the same characters with
+ * Option alone, which the modifier flags cannot tell apart from an Alt chord.
+ * Both have to read as "the user typed a character".
+ *
+ * The single-character test is what keeps real chords out — Ctrl+Alt+ArrowDown
+ * and Option+ArrowLeft are both live elsewhere. A plain space is excluded with
+ * them: Ctrl+Alt+Space is a chord, and layouts that put a space on the AltGr
+ * layer emit U+00A0, never U+0020.
+ *
+ * @param {KeyboardEvent} event
+ * @param {boolean} isMac
+ * @return {boolean}
+ */
+function isAltGraphChar( event, isMac ) {
+	if (
+		event.metaKey ||
+		!event.altKey ||
+		( event.key || '' ).length !== 1 ||
+		event.key === ' '
+	) {
+		return false;
+	}
+	if ( typeof event.getModifierState === 'function' && event.getModifierState( 'AltGraph' ) ) {
+		return true;
+	}
+	return event.ctrlKey || isMac;
+}
+
+/**
+ * Whether the event carries the modifiers MediaWiki uses for access keys.
+ *
+ * There is no single chord — `mediawiki.util`'s `getAccessKeyModifiers`
+ * resolves it per platform. It also returns a bare Alt for legacy Edge and a
+ * bare Ctrl for unrecognised browsers on a Mac; neither is claimed here,
+ * because Alt+F is the Windows File menu and Ctrl+F is find-in-page.
+ *
+ * @param {KeyboardEvent} event
+ * @param {boolean} isMac
+ * @return {boolean}
+ */
+function isAccessKeyChord( event, isMac ) {
+	if ( event.metaKey ) {
+		return false;
+	}
+	if ( event.altKey && event.shiftKey && !event.ctrlKey ) {
+		return true;
+	}
+	return isMac && event.ctrlKey && event.altKey && !event.shiftKey;
+}
+
+/**
+ * Whether an input method is composing text, rather than the user pressing a
+ * key meant for the page. The key that commits or cancels a candidate still
+ * dispatches keydown.
+ *
+ * The legacy `keyCode === 229` tell is deliberately not read: Chrome on Android
+ * reports it for almost every non-printable key, Enter included, whether or not
+ * anything is composing, so trusting it disables Enter and Backspace there.
+ *
+ * That leaves engines which end the composition just before the commit keydown,
+ * where `isComposing` is already false. Closing that needs
+ * `compositionstart`/`compositionend` tracked on the input, cleared a tick after
+ * the end so the commit still sees it.
+ *
+ * @param {KeyboardEvent} event
+ * @return {boolean}
+ */
+function isComposing( event ) {
+	return Boolean( event.isComposing );
+}
+
+module.exports = {
+	isMacPlatform,
+	isLetterPressed,
+	isAltGraphChar,
+	isAccessKeyChord,
+	isComposing
+};

--- a/resources/skins.citizen.scripts/search.js
+++ b/resources/skins.citizen.scripts/search.js
@@ -1,3 +1,10 @@
+const {
+	isMacPlatform,
+	isLetterPressed,
+	isAltGraphChar,
+	isAccessKeyChord
+} = require( './keyboardLayout.js' );
+
 /**
  * Check if the element is a HTML form element or content editable.
  * Used to gate keyboard shortcuts so typing in an input does not
@@ -19,6 +26,33 @@ function isFormField( element ) {
 }
 
 /**
+ * The chords that open the command palette.
+ *
+ * A flat list rather than a branching chain, so each entry sees the untouched
+ * event and adding one cannot change what another matches.
+ *
+ * @type {Array<function( KeyboardEvent, boolean ): boolean>}
+ */
+const OPEN_SHORTCUTS = [
+	// "/". A bare Ctrl or Command means a chord, but AltGr types "/" on some
+	// layouts and Windows delivers that as Ctrl+Alt.
+	( event, isMac ) => event.key === '/' &&
+		!event.metaKey &&
+		( !event.ctrlKey || isAltGraphChar( event, isMac ) ),
+
+	// Ctrl+K, or Command+K on a Mac. Any further modifier makes it someone
+	// else's chord — Ctrl+Shift+K opens the browser console.
+	( event ) => ( event.ctrlKey || event.metaKey ) &&
+		!event.altKey &&
+		!event.shiftKey &&
+		isLetterPressed( event, 'k' ),
+
+	// "F" is the access key MediaWiki assigns to search; its modifiers are
+	// platform-dependent.
+	( event, isMac ) => isAccessKeyChord( event, isMac ) && isLetterPressed( event, 'f' )
+];
+
+/**
  * Bind keyboard shortcuts that open the command palette.
  *
  * @param {Window} window
@@ -26,22 +60,11 @@ function isFormField( element ) {
  * @return {void}
  */
 function bindOpenOnSlash( window, triggerOpen ) {
+	const isMac = isMacPlatform( window.navigator );
+
 	const onExpandOnSlash = ( /** @type {KeyboardEvent} */ event ) => {
-		const isKeyPressed = () => {
-			// "/" key is standard on many sites
-			if ( event.code === 'Slash' ) {
-				return true;
-			// "Ctrl" + "K" (or "Command" + "K" on Mac)
-			} else if ( ( event.ctrlKey || event.metaKey ) && event.code === 'KeyK' ) {
-				return true;
-			// "Alt" + "Shift" + "F" is the MW standard key
-			} else if ( event.altKey && event.shiftKey && event.code === 'KeyF' ) {
-				return true;
-			} else {
-				return false;
-			}
-		};
-		if ( isKeyPressed() && !isFormField( event.target ) ) {
+		const isKeyPressed = OPEN_SHORTCUTS.some( ( matches ) => matches( event, isMac ) );
+		if ( isKeyPressed && !isFormField( event.target ) ) {
 			// Firefox quickfind would otherwise intercept "/"
 			event.preventDefault();
 			triggerOpen();

--- a/skin.json
+++ b/skin.json
@@ -495,7 +495,8 @@
 				{
 					"name": "resources/skins.citizen.commandPalette/config.json",
 					"callback": "MediaWiki\\Skins\\Citizen\\Hooks\\ResourceLoaderHooks::getCitizenCommandPaletteResourceLoaderConfig"
-				}
+				},
+				"resources/skins.citizen.scripts/keyboardLayout.js"
 			],
 			"messages": [
 				"action-edit",

--- a/skin.json
+++ b/skin.json
@@ -198,6 +198,7 @@
 				"resources/skins.citizen.scripts/dropdown.js",
 				"resources/skins.citizen.scripts/notifications.js",
 				"resources/skins.citizen.scripts/intentPrefetch.js",
+				"resources/skins.citizen.scripts/keyboardLayout.js",
 				"resources/skins.citizen.scripts/lastModified.js",
 				"resources/skins.citizen.scripts/overflowElements/index.js",
 				"resources/skins.citizen.scripts/overflowElements/wrapper.js",

--- a/tests/vitest/commandPalette/composables/useKeyboard.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboard.test.js
@@ -82,7 +82,11 @@ describe( 'useKeyboard', () => {
 			altKey: false,
 			ctrlKey: false,
 			metaKey: false,
-			shiftKey: false
+			shiftKey: false,
+			// Browsers always supply this; the AltGr detection consults it
+			// before falling back to the modifier flags, so a fixture without
+			// it would leave that branch unreachable.
+			getModifierState: vi.fn( () => false )
 		};
 	}
 
@@ -215,6 +219,184 @@ describe( 'useKeyboard', () => {
 			keyboard.handleKeydown( event );
 
 			expect( deps.onEnterMode ).toHaveBeenCalledWith( mode );
+		} );
+	} );
+
+	describe( 'AltGr characters', () => {
+		it( 'should treat a Ctrl+Alt character as typed, not as a chord', () => {
+			deps.query = ref( '' );
+			deps.activeMode = ref( null );
+			const mode = { id: 'user', triggers: [ '@' ] };
+			deps.findModeByTrigger = vi.fn( () => mode );
+			deps.onEnterMode = vi.fn();
+			keyboard = useKeyboard( toGrouped( deps ) );
+
+			// German and Nordic layouts type "@" as AltGr+Q, which Windows
+			// reports as Ctrl+Alt.
+			var event = createKeyEvent( '@' );
+			event.ctrlKey = true;
+			event.altKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onEnterMode ).toHaveBeenCalledWith( mode );
+		} );
+
+		it( 'should still ignore Ctrl+Alt with a non-printable key', () => {
+			// Ctrl+Alt+Arrow is a live desktop shortcut; AltGr cannot produce it.
+			var event = createKeyEvent( 'ArrowDown' );
+			event.ctrlKey = true;
+			event.altKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( listNav.highlightNext ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should redirect an AltGr character typed in the action zone to the input', () => {
+			const actionTarget = {
+				closest: vi.fn( ( selector ) => (
+					selector === '.citizen-command-palette-list-item__action' ? actionTarget : null
+				) )
+			};
+			actionNav.isActive.value = true;
+
+			var event = createKeyEvent( '@', actionTarget );
+			event.ctrlKey = true;
+			event.altKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( actionNav.deactivate ).toHaveBeenCalled();
+		} );
+
+		it( 'should treat a character Firefox reports via getModifierState as typed', () => {
+			deps.query = ref( '' );
+			deps.activeMode = ref( null );
+			const mode = { id: 'user', triggers: [ '@' ] };
+			deps.findModeByTrigger = vi.fn( () => mode );
+			deps.onEnterMode = vi.fn();
+			keyboard = useKeyboard( toGrouped( deps ) );
+
+			// Firefox flags AltGr without setting ctrlKey.
+			var event = createKeyEvent( '@' );
+			event.altKey = true;
+			event.getModifierState = vi.fn( ( m ) => m === 'AltGraph' );
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onEnterMode ).toHaveBeenCalledWith( mode );
+		} );
+
+		it( 'should not let Ctrl+Alt+Space activate the focused action', () => {
+			const actionTarget = {
+				closest: vi.fn( ( selector ) => (
+					selector === '.citizen-command-palette-list-item__action' ? actionTarget : null
+				) )
+			};
+			actionNav.isActive.value = true;
+
+			// Space is a real action-zone binding, and no AltGr layer types a
+			// plain U+0020 — the layouts that map it emit U+00A0.
+			var event = createKeyEvent( ' ', actionTarget );
+			event.ctrlKey = true;
+			event.altKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( actionNav.clickFocused ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should still ignore a Command chord', () => {
+			const actionTarget = {
+				closest: vi.fn( ( selector ) => (
+					selector === '.citizen-command-palette-list-item__action' ? actionTarget : null
+				) )
+			};
+			actionNav.isActive.value = true;
+
+			var event = createKeyEvent( '@', actionTarget );
+			event.metaKey = true;
+			event.altKey = true;
+			event.ctrlKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( actionNav.deactivate ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'input method composition', () => {
+		it( 'should ignore the Enter that commits an IME candidate', () => {
+			listNav.highlightedIndex.value = 0;
+
+			var event = createKeyEvent( 'Enter' );
+			event.isComposing = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onSelect ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should still act on a key that only reports the legacy keyCode 229', () => {
+			// Chrome on Android sets 229 for almost every non-printable key,
+			// Enter included, whether or not anything is being composed. Reading
+			// it would disable the palette's Enter and Backspace on mobile.
+			var event = createKeyEvent( 'Escape' );
+			event.keyCode = 229;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onClose ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'copy shortcut', () => {
+		function withCopyValue() {
+			deps.items = ref( [
+				{ id: '1', detail: { header: { copyValue: 'File:Foo.png' } } }
+			] );
+			deps.requestHeaderCopy = vi.fn();
+			keyboard = useKeyboard( toGrouped( deps ) );
+			listNav.highlightedIndex.value = 0;
+		}
+
+		it( 'should copy the header value on Ctrl+C', () => {
+			withCopyValue();
+
+			var event = createKeyEvent( 'c' );
+			event.ctrlKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.requestHeaderCopy ).toHaveBeenCalled();
+		} );
+
+		it( 'should copy on a layout that types no Latin letter', () => {
+			withCopyValue();
+
+			// Russian keycaps carry a Latin legend on the US positions.
+			var event = createKeyEvent( 'с' );
+			event.code = 'KeyC';
+			event.ctrlKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.requestHeaderCopy ).toHaveBeenCalled();
+		} );
+
+		it( 'should not copy from the key position when the layout types c elsewhere', () => {
+			withCopyValue();
+
+			// Dvorak types "j" from the US QWERTY "c" position.
+			var event = createKeyEvent( 'j' );
+			event.code = 'KeyC';
+			event.ctrlKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.requestHeaderCopy ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/tests/vitest/skins.citizen.scripts/keyboardLayout.test.js
+++ b/tests/vitest/skins.citizen.scripts/keyboardLayout.test.js
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+/* global KeyboardEvent */
+
+const {
+	isMacPlatform,
+	isLetterPressed,
+	isAltGraphChar,
+	isAccessKeyChord,
+	isComposing
+} = require( '../../../resources/skins.citizen.scripts/keyboardLayout.js' );
+
+/**
+ * Build a real KeyboardEvent so the helpers see the same shape a browser
+ * gives them — `getModifierState` in particular, which an object literal
+ * would not have.
+ *
+ * @param {Object} init
+ * @return {KeyboardEvent}
+ */
+function keyEvent( init ) {
+	return new KeyboardEvent( 'keydown', init );
+}
+
+describe( 'keyboardLayout', () => {
+	describe( 'isMacPlatform', () => {
+		it( 'prefers userAgentData over the deprecated platform', () => {
+			const navigator = { userAgentData: { platform: 'macOS' }, platform: 'Win32' };
+
+			expect( isMacPlatform( navigator ) ).toBe( true );
+		} );
+
+		it( 'falls back to platform when userAgentData reports nothing', () => {
+			expect( isMacPlatform( { userAgentData: { platform: '' }, platform: 'MacIntel' } ) )
+				.toBe( true );
+			expect( isMacPlatform( { platform: 'MacIntel' } ) ).toBe( true );
+		} );
+
+		it( 'recognises iOS, which shares the Mac modifier conventions', () => {
+			expect( isMacPlatform( { platform: 'iPhone' } ) ).toBe( true );
+			expect( isMacPlatform( { platform: 'iPad' } ) ).toBe( true );
+		} );
+
+		it( 'returns false for other platforms and for a missing navigator', () => {
+			expect( isMacPlatform( { platform: 'Win32' } ) ).toBe( false );
+			expect( isMacPlatform( { platform: 'Linux x86_64' } ) ).toBe( false );
+			expect( isMacPlatform( {} ) ).toBe( false );
+			expect( isMacPlatform( null ) ).toBe( false );
+			expect( isMacPlatform() ).toBe( false );
+		} );
+	} );
+
+	describe( 'isLetterPressed', () => {
+		it( 'matches the letter the layout typed, whatever its position', () => {
+			// Dvorak types "k" from the US QWERTY "v" position.
+			expect( isLetterPressed( keyEvent( { key: 'k', code: 'KeyV' } ), 'k' ) ).toBe( true );
+			expect( isLetterPressed( keyEvent( { key: 't', code: 'KeyK' } ), 'k' ) ).toBe( false );
+		} );
+
+		it( 'ignores case, so Shift and CapsLock do not break the match', () => {
+			expect( isLetterPressed( keyEvent( { key: 'K', code: 'KeyK' } ), 'k' ) ).toBe( true );
+		} );
+
+		it( 'falls back to the key position when the layout types no Latin letter', () => {
+			// Cyrillic keycaps carry a Latin legend on the US positions.
+			expect( isLetterPressed( keyEvent( { key: 'л', code: 'KeyK' } ), 'k' ) ).toBe( true );
+			// macOS rewrites event.key into a glyph whenever Option is held.
+			expect( isLetterPressed( keyEvent( { key: 'Ï', code: 'KeyF' } ), 'f' ) ).toBe( true );
+		} );
+
+		it( 'does not case-fold Latin lookalikes into their ASCII counterpart', () => {
+			// U+017F long s and U+212A Kelvin sign fold to "s" and "k" under full
+			// Unicode case rules. A non-unicode regex must not fold them, or a
+			// layout typing either would fire the wrong shortcut. The code is
+			// deliberately mismatched so only the key value can decide.
+			expect( isLetterPressed( keyEvent( { key: '\u017F', code: 'KeyZ' } ), 's' ) )
+				.toBe( false );
+			expect( isLetterPressed( keyEvent( { key: '\u212A', code: 'KeyZ' } ), 'k' ) )
+				.toBe( false );
+		} );
+
+		it( 'survives keys that produce no character at all', () => {
+			expect( isLetterPressed( keyEvent( { key: 'Dead', code: 'KeyK' } ), 'k' ) ).toBe( true );
+			expect( isLetterPressed( keyEvent( { key: '', code: 'KeyK' } ), 'k' ) ).toBe( true );
+			expect( isLetterPressed( { code: 'KeyK' }, 'k' ) ).toBe( true );
+			expect( isLetterPressed( { }, 'k' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isAltGraphChar', () => {
+		it( 'trusts getModifierState when the browser reports AltGraph', () => {
+			// Firefox reports AltGr this way without setting ctrlKey.
+			const event = keyEvent( { key: '@', altKey: true, modifierAltGraph: true } );
+
+			expect( isAltGraphChar( event, false ) ).toBe( true );
+		} );
+
+		it( 'reads Ctrl+Alt as AltGr, which is how Windows delivers it', () => {
+			const event = keyEvent( { key: '@', code: 'KeyQ', ctrlKey: true, altKey: true } );
+
+			expect( isAltGraphChar( event, false ) ).toBe( true );
+		} );
+
+		it( 'reads a bare Option character as AltGr on a Mac only', () => {
+			const event = keyEvent( { key: '@', code: 'KeyL', altKey: true } );
+
+			expect( isAltGraphChar( event, true ) ).toBe( true );
+			expect( isAltGraphChar( event, false ) ).toBe( false );
+		} );
+
+		it( 'rejects chords that produce no character', () => {
+			// Ctrl+Alt+Arrow is a live desktop shortcut; Option+Arrow is
+			// word-wise text navigation on a Mac.
+			expect( isAltGraphChar(
+				keyEvent( { key: 'ArrowDown', ctrlKey: true, altKey: true } ), false
+			) ).toBe( false );
+			expect( isAltGraphChar(
+				keyEvent( { key: 'ArrowLeft', altKey: true } ), true
+			) ).toBe( false );
+		} );
+
+		it( 'rejects a plain space, which no AltGr layer produces', () => {
+			const event = keyEvent( { key: ' ', code: 'Space', ctrlKey: true, altKey: true } );
+
+			expect( isAltGraphChar( event, false ) ).toBe( false );
+		} );
+
+		it( 'rejects anything carrying Command, and anything without Alt', () => {
+			expect( isAltGraphChar(
+				keyEvent( { key: '@', ctrlKey: true, altKey: true, metaKey: true } ), true
+			) ).toBe( false );
+			expect( isAltGraphChar( keyEvent( { key: '@', ctrlKey: true } ), true ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isAccessKeyChord', () => {
+		it( 'accepts Alt+Shift on every platform', () => {
+			const event = keyEvent( { key: 'F', altKey: true, shiftKey: true } );
+
+			expect( isAccessKeyChord( event, false ) ).toBe( true );
+			expect( isAccessKeyChord( event, true ) ).toBe( true );
+		} );
+
+		it( 'accepts Ctrl+Option on a Mac only', () => {
+			// Off a Mac the same flags mean AltGr, not an access key.
+			const event = keyEvent( { key: 'ƒ', ctrlKey: true, altKey: true } );
+
+			expect( isAccessKeyChord( event, true ) ).toBe( true );
+			expect( isAccessKeyChord( event, false ) ).toBe( false );
+		} );
+
+		it( 'rejects the bare chords that belong to the browser', () => {
+			// Alt+F is the Windows File menu; Ctrl+F is find-in-page.
+			expect( isAccessKeyChord( keyEvent( { key: 'f', altKey: true } ), false ) ).toBe( false );
+			expect( isAccessKeyChord( keyEvent( { key: 'f', ctrlKey: true } ), true ) ).toBe( false );
+		} );
+
+		it( 'rejects anything carrying Command', () => {
+			const event = keyEvent( { key: 'F', altKey: true, shiftKey: true, metaKey: true } );
+
+			expect( isAccessKeyChord( event, true ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isComposing', () => {
+		it( 'reports a keystroke an input method is consuming', () => {
+			expect( isComposing( keyEvent( { key: 'Enter', isComposing: true } ) ) ).toBe( true );
+		} );
+
+		it( 'reports an ordinary keystroke as not composing', () => {
+			expect( isComposing( keyEvent( { key: 'Enter' } ) ) ).toBe( false );
+			expect( isComposing( {} ) ).toBe( false );
+		} );
+
+		it( 'ignores the legacy keyCode 229, which Android reports for Enter', () => {
+			// Chrome on Android sets 229 for almost every non-printable key
+			// whether or not anything is being composed, so reading it would
+			// disable Enter and Backspace across the palette on mobile.
+			const event = keyEvent( { key: 'Enter', keyCode: 229 } );
+
+			expect( isComposing( event ) ).toBe( false );
+		} );
+	} );
+} );

--- a/tests/vitest/skins.citizen.scripts/search.test.js
+++ b/tests/vitest/skins.citizen.scripts/search.test.js
@@ -5,6 +5,20 @@ function buildSearchDom() {
 	document.body.innerHTML = '<details id="citizen-search-details"></details>';
 }
 
+/**
+ * A stand-in for `window` that reports macOS. Only `navigator` and
+ * `addEventListener` are read by the module under test, and the listener still
+ * lands on the real window so `dispatchKeydown` reaches it.
+ *
+ * @return {Object}
+ */
+function macWindow() {
+	return {
+		navigator: { platform: 'MacIntel' },
+		addEventListener: window.addEventListener.bind( window )
+	};
+}
+
 function dispatchKeydown( target, opts ) {
 	target.dispatchEvent( new KeyboardEvent( 'keydown', {
 		bubbles: true,
@@ -40,7 +54,59 @@ describe( 'search', () => {
 			buildSearchDom();
 			init( { window, document, triggerOpen } );
 
-			dispatchKeydown( document.body, { code: 'Slash' } );
+			dispatchKeydown( document.body, { key: '/', code: 'Slash' } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'calls triggerOpen() when / needs Shift, as on German layouts', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			dispatchKeydown( document.body, { key: '/', code: 'Digit7', shiftKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'calls triggerOpen() from the numpad, which types the same character', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			// Deliberate: the shortcut is the "/" character, not a position, so
+			// excluding NumpadDivide would mean reintroducing position logic.
+			dispatchKeydown( document.body, { key: '/', code: 'NumpadDivide' } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'ignores the US slash position when it types another character (T1731)', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			// Nordic layouts put "-" where US QWERTY has "/".
+			dispatchKeydown( document.body, { key: '-', code: 'Slash' } );
+			// US QWERTY with Shift on that same key types "?".
+			dispatchKeydown( document.body, { key: '?', code: 'Slash', shiftKey: true } );
+
+			expect( triggerOpen ).not.toHaveBeenCalled();
+		} );
+
+		it( 'ignores Ctrl+/ and Command+/ so the chord stays free', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			dispatchKeydown( document.body, { key: '/', code: 'Slash', ctrlKey: true } );
+			dispatchKeydown( document.body, { key: '/', code: 'Slash', metaKey: true } );
+
+			expect( triggerOpen ).not.toHaveBeenCalled();
+		} );
+
+		it( 'calls triggerOpen() for a / typed with AltGr', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			// Windows reports AltGr as Ctrl+Alt.
+			dispatchKeydown( document.body, { key: '/', code: 'Minus', ctrlKey: true, altKey: true } );
 
 			expect( triggerOpen ).toHaveBeenCalled();
 		} );
@@ -50,6 +116,7 @@ describe( 'search', () => {
 			init( { window, document, triggerOpen } );
 
 			const event = new KeyboardEvent( 'keydown', {
+				key: 'k',
 				code: 'KeyK',
 				ctrlKey: true,
 				bubbles: true,
@@ -63,13 +130,99 @@ describe( 'search', () => {
 			expect( preventDefaultSpy ).toHaveBeenCalled();
 		} );
 
+		it( 'matches Ctrl+K by the letter typed, not the key position', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			// Dvorak types "k" from the US QWERTY "v" position...
+			dispatchKeydown( document.body, { key: 'k', code: 'KeyV', ctrlKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalledTimes( 1 );
+
+			// ...and types "t" from the US QWERTY "k" position.
+			dispatchKeydown( document.body, { key: 't', code: 'KeyK', ctrlKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'falls back to the key position on non-Latin layouts', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			// Cyrillic keycaps carry a Latin legend following the US positions.
+			dispatchKeydown( document.body, { key: 'л', code: 'KeyK', ctrlKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'ignores Ctrl+Shift+K, which browsers bind to devtools', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			dispatchKeydown( document.body, { key: 'K', code: 'KeyK', ctrlKey: true, shiftKey: true } );
+
+			expect( triggerOpen ).not.toHaveBeenCalled();
+		} );
+
 		it( 'calls triggerOpen() on Alt+Shift+F', () => {
 			buildSearchDom();
 			init( { window, document, triggerOpen } );
 
-			dispatchKeydown( document.body, { code: 'KeyF', altKey: true, shiftKey: true } );
+			dispatchKeydown( document.body, { key: 'F', code: 'KeyF', altKey: true, shiftKey: true } );
 
 			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'calls triggerOpen() on Command+K', () => {
+			buildSearchDom();
+			init( { window: macWindow(), document, triggerOpen } );
+
+			dispatchKeydown( document.body, { key: 'k', code: 'KeyK', metaKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'falls back to the key position when Alt rewrites the character', () => {
+			buildSearchDom();
+			init( { window: macWindow(), document, triggerOpen } );
+
+			// macOS types Option+Shift+F as "Ï", so no Latin letter is left
+			// to match on and only the position can decide.
+			dispatchKeydown( document.body, { key: 'Ï', code: 'KeyF', altKey: true, shiftKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'calls triggerOpen() on Ctrl+Option+F, the macOS access key chord', () => {
+			buildSearchDom();
+			init( { window: macWindow(), document, triggerOpen } );
+
+			dispatchKeydown( document.body, { key: 'ƒ', code: 'KeyF', altKey: true, ctrlKey: true } );
+
+			expect( triggerOpen ).toHaveBeenCalled();
+		} );
+
+		it( 'ignores Ctrl+Alt+F off macOS, where it is an AltGr character', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			dispatchKeydown( document.body, { key: 'f', code: 'KeyF', altKey: true, ctrlKey: true } );
+
+			expect( triggerOpen ).not.toHaveBeenCalled();
+		} );
+
+		it( 'ignores Alt+Shift+F once Ctrl or Command joins the chord', () => {
+			buildSearchDom();
+			init( { window, document, triggerOpen } );
+
+			dispatchKeydown( document.body, {
+				key: 'F', code: 'KeyF', altKey: true, shiftKey: true, ctrlKey: true
+			} );
+			dispatchKeydown( document.body, {
+				key: 'F', code: 'KeyF', altKey: true, shiftKey: true, metaKey: true
+			} );
+
+			expect( triggerOpen ).not.toHaveBeenCalled();
 		} );
 
 		it( 'ignores shortcuts when target is a form field', () => {
@@ -92,7 +245,7 @@ describe( 'search', () => {
 			document.body.appendChild( contentEditable );
 
 			[ textInput, textarea, select, contentEditable ].forEach( ( el ) => {
-				dispatchKeydown( el, { code: 'Slash' } );
+				dispatchKeydown( el, { key: '/', code: 'Slash' } );
 			} );
 
 			expect( triggerOpen ).not.toHaveBeenCalled();
@@ -106,14 +259,14 @@ describe( 'search', () => {
 			checkbox.setAttribute( 'type', 'checkbox' );
 			document.body.appendChild( checkbox );
 
-			dispatchKeydown( checkbox, { code: 'Slash' } );
+			dispatchKeydown( checkbox, { key: '/', code: 'Slash' } );
 
 			expect( triggerOpen ).toHaveBeenCalledTimes( 1 );
 
 			const button = document.createElement( 'button' );
 			document.body.appendChild( button );
 
-			dispatchKeydown( button, { code: 'Slash' } );
+			dispatchKeydown( button, { key: '/', code: 'Slash' } );
 
 			expect( triggerOpen ).toHaveBeenCalledTimes( 2 );
 		} );


### PR DESCRIPTION
Fixes #1731.

## Problem

Citizen matched its keyboard shortcuts on `event.code`, which names a position on a US QWERTY reference layout rather than the character a layout actually produces. On a Nordic keyboard the minus key opened search and the <kbd>/</kbd> key did nothing; on Dvorak and Colemak <kbd>Ctrl</kbd>+<kbd>K</kbd> answered to the key labelled <kbd>T</kbd>.

Auditing for the same class of bug — key matching that is wrong for some users because of their keyboard layout, input method, or platform — turned up three more, all in the command palette's own dispatcher.

## Behaviour

Shortcuts now match the character the user typed. The position is consulted only when a layout produces no Latin letter at all: Cyrillic, Greek and Arabic keycaps carry a Latin legend that follows the US positions, so <kbd>Ctrl</kbd>+<kbd>K</kbd> keeps working there rather than becoming unreachable.

In the palette:

- Typing a search term with a Japanese, Chinese or Korean input method works. Previously the <kbd>Enter</kbd> that commits a candidate was read as "open the highlighted result", so the palette navigated away mid-composition and <kbd>Esc</kbd> cleared the query.
- The copy shortcut fires on non-Latin layouts, where it previously did nothing while the footer kept advertising it.
- AltGr characters reach the palette. `@`, `~` and `#` are three of its own mode triggers and are AltGr characters on German, Nordic, Polish and AZERTY layouts; they were being discarded as chords, leaking into the query behind the help overlay and stranding keystrokes in the action zone.

### Changes worth a release note

| Chord | Before | After |
| --- | --- | --- |
| <kbd>?</kbd> (Shift+/ on US) | opened search | no longer does |
| <kbd>Ctrl</kbd>+<kbd>/</kbd>, <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd>, <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd> | opened search | no longer do — those chords are the browser's |
| numpad <kbd>/</kbd> | did nothing | opens search |
| <kbd>Ctrl</kbd>+<kbd>K</kbd> on Dvorak | the physical QWERTY-K position | the key labelled <kbd>K</kbd> |
| <kbd>Ctrl</kbd>+<kbd>Option</kbd>+<kbd>F</kbd> on macOS | did nothing | opens search |

The last row is the access key: there is no single chord for it, and `mediawiki.util` resolves it per platform. Citizen hardcoded the Windows/Linux one, so the chord MediaWiki advertises to Mac users never worked. Core also returns a bare <kbd>Alt</kbd> for legacy Edge and a bare <kbd>Ctrl</kbd> for unrecognised browsers on a Mac; those are deliberately not claimed, because <kbd>Alt</kbd>+<kbd>F</kbd> is the Windows File menu and <kbd>Ctrl</kbd>+<kbd>F</kbd> is find-in-page.

Numpad <kbd>/</kbd> is a consequence of matching the character rather than a separate decision, and is pinned by a test so it stays deliberate — suppressing it would mean reintroducing position logic into the fix that exists to remove it.

## Contract

`resources/skins.citizen.scripts/keyboardLayout.js` is the single place that decides what a keystroke means. It is shared with `skins.citizen.commandPalette` by registering it in both modules' `packageFiles`, the way `deferUntilFrame.js` already is between `skins.citizen.scripts` and `skins.citizen.toc`, with the matching "keep the two in sync" comment at each `require()`.

One deliberate omission is documented in the source so it does not get "fixed" later: the legacy `keyCode === 229` tell for IME composition is not read. Chrome on Android reports it for almost every non-printable key, <kbd>Enter</kbd> included, whether or not anything is composing, so trusting it would disable <kbd>Enter</kbd> and <kbd>Backspace</kbd> throughout the palette on mobile. That leaves engines which end the composition just before the commit keydown uncovered; closing that needs `compositionstart`/`compositionend` tracked on the input itself, and is noted in the code.

Cache status: **clean**. No class or ID renamed, no PHP-emitted markup restructured, no module renamed — no compat slice required.

## Verification

- 1166 Vitest tests, PHPUnit, PHPCS and lints clean. Each new guard was mutation-checked: reverting its fix makes it fail.
- Driven in a real browser against a local MediaWiki with trusted CDP key events across the layout matrix above — Nordic minus-at-slash, German Shift+7, Dvorak in both directions, Cyrillic, AltGr, and the chords that must stay free — plus AltGr `@` entering user mode in the palette.
- Both commits pass the suite independently, so the branch bisects.

## Follow-ups

Not addressed here, found while auditing:

- #1736 — <kbd>/</kbd> does not meet WCAG 2.1.4 Character Key Shortcuts (Level A). Pre-existing.
- <kbd>/</kbd> or <kbd>Ctrl</kbd>+<kbd>K</kbd> pressed while the palette is already open wipes the query, when focus is on a palette button or the body.
- <kbd>Shift</kbd>+<kbd>Tab</kbd> moves focus out of the open palette, which has no focus trap.
- Arrow keys are hardcoded LTR, so gallery and action-row navigation run backwards on RTL wikis.
- Dropdowns dismiss on Escape `keyup`, so one <kbd>Esc</kbd> aimed at a nested Codex select closes the whole panel.
- `templates/Search__button.mustache` interpolates `msg-citizen-search-toggle-shortcut`, which no longer exists, so the shortcut is advertised nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search and command palette keyboard shortcuts across different keyboard layouts.
  * Added better support for macOS Command/Option shortcuts, AltGr input, non-Latin characters, and dead keys.
  * Prevented shortcuts from triggering during text composition, including IME input.
  * Improved handling of MediaWiki access-key combinations and copy shortcuts.
  * Fixed shortcut behavior for browser-specific and legacy keyboard events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->