### PR TITLE
fix(commandPalette): stop reopening from discarding the query, and keep focus in

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -538,8 +538,12 @@ module.exports = exports = defineComponent( {
 			highlightedItemDetail,
 			copyTrigger,
 			// Methods
-			// eslint-disable-next-line vue/no-unused-properties -- Used externally by init.js
+			// eslint-disable-next-line vue/no-unused-properties -- Used by skins.citizen.scripts/commandPalette.js
 			open,
+			// Restore focus to the search input without resetting anything, for
+			// a trigger fired while the palette is already on screen.
+			// eslint-disable-next-line vue/no-unused-properties -- Used by skins.citizen.scripts/commandPalette.js
+			focus: () => nextTick( focusInput ),
 			close,
 			selectResult,
 			handleAction,

--- a/resources/skins.citizen.commandPalette/composables/useKeyboard.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboard.js
@@ -92,6 +92,23 @@ const coreBindings = [
 		},
 		hint: null
 	},
+	// Tab steps back to the input rather than closing, mirroring the Escape
+	// ladder above: one key to leave the action row, a second to leave the
+	// palette. Without a binding here the browser would walk focus out of the
+	// palette from the action row instead.
+	{
+		id: 'action-tab-to-input',
+		zone: 'action',
+		keys: [ 'Tab' ],
+		when: () => true,
+		worksDuringHelp: true,
+		handle: ( state, event ) => {
+			event.preventDefault();
+			state.actionNav.deactivate();
+			state.focusInput();
+		},
+		hint: null
+	},
 	// Action-zone navigate hint variants. Mutually exclusive `when` clauses
 	// produce one of: `↑↓`, `↑↓←`, or `↑↓←→` depending on action count and
 	// focused index.
@@ -339,11 +356,16 @@ const coreBindings = [
 	},
 
 	// --- INPUT ZONE: Tab closes the palette ---
+	// `worksDuringHelp` is load-bearing rather than a nicety: without it the
+	// binding is inactive while the help overlay is up, nothing else claims
+	// Tab, and the browser walks focus out of a palette that can no longer be
+	// dismissed — this handler is bound to the palette itself.
 	{
 		id: 'input-tab-close',
 		zone: 'input',
 		keys: [ 'Tab' ],
 		when: () => true,
+		worksDuringHelp: true,
 		handle: ( state, event ) => {
 			event.preventDefault();
 			state.onClose();
@@ -755,7 +777,11 @@ function useKeyboard( options ) {
 		) {
 			return;
 		}
-		if ( event.shiftKey && event.key.length !== 1 ) {
+		// Tab is exempt: it has a binding of its own, and dropping Shift+Tab
+		// here would skip that binding's preventDefault() and let the browser
+		// walk focus out of the open palette — where Escape no longer reaches
+		// it, since this handler is bound to the palette itself.
+		if ( event.shiftKey && event.key.length !== 1 && event.key !== 'Tab' ) {
 			return;
 		}
 

--- a/resources/skins.citizen.scripts/commandPalette.js
+++ b/resources/skins.citizen.scripts/commandPalette.js
@@ -28,7 +28,12 @@ function createCommandPalette( { document, mw } ) {
 	let cancelled = false;
 
 	let detailsEl = null;
+	let summaryEl = null;
 	let overlay = null;
+	// Whether the palette is on screen. Distinct from `state`, which tracks
+	// whether the bundle has loaded — the palette can be closed and reopened
+	// any number of times while `state` stays 'mounted'.
+	let isOpen = false;
 
 	/**
 	 * Mirror palette open/closed state onto the `<details>` element. The
@@ -56,6 +61,15 @@ function createCommandPalette( { document, mw } ) {
 		// inner DOM after the leave transition completes.
 		setOpenState( false );
 		pendingPrefill = null;
+		// Hand focus back to the control that opened the palette. Without
+		// this it lands on <body>, so the next Tab restarts from the top of
+		// the document — the palette's own dismissal keys (Esc, Tab) would
+		// otherwise cost a keyboard user their place on the page.
+		const wasOpen = isOpen;
+		isOpen = false;
+		if ( wasOpen && summaryEl ) {
+			summaryEl.focus();
+		}
 	}
 
 	/**
@@ -103,6 +117,7 @@ function createCommandPalette( { document, mw } ) {
 				state = 'mounted';
 				if ( !cancelled ) {
 					paletteApp.open( pendingPrefill );
+					isOpen = true;
 				}
 				pendingPrefill = null;
 				cancelled = false;
@@ -134,7 +149,20 @@ function createCommandPalette( { document, mw } ) {
 		cancelled = false;
 
 		if ( state === 'mounted' ) {
+			// `open()` is unconditionally a reset — it closes help, exits the
+			// active mode and clears the query and token chips. Running it on
+			// a palette that is already on screen would throw away what the
+			// user has typed. The shortcuts stay reachable while the palette
+			// is open (focus only has to be off the input for `isFormField`
+			// to let them through), so a repeat trigger just restores focus.
+			// A prefill is an explicit request to replace the query, so it
+			// still goes through.
+			if ( isOpen && text === null ) {
+				paletteApp.focus();
+				return;
+			}
 			paletteApp.open( text );
+			isOpen = true;
 			return;
 		}
 		if ( state === 'loading' ) {
@@ -161,6 +189,7 @@ function createCommandPalette( { document, mw } ) {
 		if ( !summary ) {
 			return;
 		}
+		summaryEl = summary;
 		detailsEl = document.getElementById( 'citizen-search-details' );
 
 		// `templates/Search.mustache` renders a `<div id="citizen-search__card">`

--- a/tests/vitest/commandPalette/composables/useKeyboard.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboard.test.js
@@ -196,6 +196,51 @@ describe( 'useKeyboard', () => {
 			expect( listNav.highlightNext ).not.toHaveBeenCalled();
 		} );
 
+		it( 'should close on Shift+Tab, so focus cannot leave the open palette', () => {
+			var event = createKeyEvent( 'Tab' );
+			event.shiftKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onClose ).toHaveBeenCalled();
+			expect( event.preventDefault ).toHaveBeenCalled();
+		} );
+
+		it( 'should still claim Tab while the help overlay is up', () => {
+			deps.helpVisible = ref( true );
+			deps.onToggleHelp = vi.fn();
+			deps.onCloseHelp = vi.fn();
+			keyboard = useKeyboard( toGrouped( deps ) );
+
+			[ false, true ].forEach( ( shift ) => {
+				const event = createKeyEvent( 'Tab' );
+				event.shiftKey = shift;
+
+				keyboard.handleKeydown( event );
+
+				expect( event.preventDefault ).toHaveBeenCalled();
+			} );
+			expect( deps.onClose ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'should step Tab back to the input from the action zone, not out of the palette', () => {
+			const actionTarget = {
+				closest: vi.fn( ( selector ) => (
+					selector === '.citizen-command-palette-list-item__action' ? actionTarget : null
+				) )
+			};
+			actionNav.isActive.value = true;
+
+			const event = createKeyEvent( 'Tab', actionTarget );
+			event.shiftKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( actionNav.deactivate ).toHaveBeenCalled();
+			expect( deps.onClose ).not.toHaveBeenCalled();
+		} );
+
 		it( 'should ignore Shift for non-printable keys', () => {
 			var event = createKeyEvent( 'ArrowDown' );
 			event.shiftKey = true;

--- a/tests/vitest/skins.citizen.scripts/commandPalette.test.js
+++ b/tests/vitest/skins.citizen.scripts/commandPalette.test.js
@@ -13,6 +13,7 @@ describe( 'createCommandPalette', () => {
 	let resolveLoad;
 	let rejectLoad;
 	let mockOpen;
+	let mockFocus;
 	let mockClose;
 	let mockInitApp;
 
@@ -23,7 +24,12 @@ describe( 'createCommandPalette', () => {
 
 		mockOpen = vi.fn();
 		mockClose = vi.fn();
-		mockInitApp = vi.fn().mockReturnValue( { open: mockOpen, close: mockClose } );
+		mockFocus = vi.fn();
+		mockInitApp = vi.fn().mockReturnValue( {
+			open: mockOpen,
+			focus: mockFocus,
+			close: mockClose
+		} );
 		// `mw.loader.using` resolves with a `req` function that returns the
 		// loaded module's exports. Mirrors the real MediaWiki API contract
 		// and matches the SMW-mode-load pattern in palette init.js.
@@ -147,6 +153,47 @@ describe( 'createCommandPalette', () => {
 
 		expect( mw.loader.using ).not.toHaveBeenCalled();
 		expect( mockOpen ).toHaveBeenCalledWith( 'second' );
+	} );
+
+	it( 'a repeat trigger on an open palette restores focus without resetting it', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+		mockOpen.mockClear();
+
+		cp.triggerOpen();
+
+		expect( mockOpen ).not.toHaveBeenCalled();
+		expect( mockFocus ).toHaveBeenCalled();
+	} );
+
+	it( 'a repeat trigger carrying a prefill still replaces the query', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+		mockOpen.mockClear();
+
+		cp.triggerOpen( 'Ship:' );
+
+		expect( mockOpen ).toHaveBeenCalledWith( 'Ship:' );
+		expect( mockFocus ).not.toHaveBeenCalled();
+	} );
+
+	it( 'closing returns focus to the search trigger', async () => {
+		const cp = createCommandPalette( { document, mw } );
+		cp.init();
+		cp.triggerOpen();
+		resolveLoad();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+		document.body.focus();
+
+		mockInitApp.mock.calls[ 0 ][ 1 ].onClose();
+
+		expect( document.activeElement.id ).toBe( 'citizen-search-summary' );
 	} );
 
 	it( 'cp.close() from mounted state delegates to paletteApp.close', async () => {


### PR DESCRIPTION
Fixes #1738. Fixes #1739.

## Problem

Both issues come from the palette not tracking whether it is already on screen.

**#1738** — triggering the palette while it is open re-ran `App.open()`, which is unconditionally a reset: help closed, active mode exited, query and token chips cleared. The global shortcuts stay reachable whenever focus is off the search input, and one click on the palette's own chrome is enough to do that. The realistic path is not pressing <kbd>/</kbd> deliberately — it is clicking in the palette and then typing a query that contains a slash, like `AC/DC`.

**#1739** — <kbd>Tab</kbd> could walk focus out of the still-open palette, onto page content behind the backdrop. Escape then could not reach the palette at all, because `handleKeydown` is bound to the palette element, leaving an overlay that could not be dismissed from the keyboard.

## Behaviour

A repeat trigger on an open palette restores focus to the input instead of resetting. A prefill is an explicit request to replace the query, so `.citizen-search-trigger` links with `data-citizen-search-prefill` still work as before.

Focus can no longer leave the palette by <kbd>Tab</kbd>. **Three separate holes**, only the first of which was in the original issue:

| Where | Before | After |
| --- | --- | --- |
| input, <kbd>Shift</kbd>+<kbd>Tab</kbd> | dropped by the Shift guard, focus escaped | closes, like <kbd>Tab</kbd> |
| help overlay open | binding inactive (`worksDuringHelp` missing), focus escaped | closes |
| action row | no Tab binding at all, focus escaped | steps back to the input |

Tab from the action row deliberately returns to the input rather than closing, mirroring the Escape ladder: one key to leave the row, a second to leave the palette.

Closing now hands focus back to the search button. Previously it landed on `<body>`, so dismissing the palette cost a keyboard user their place on the page — that already applied to the existing <kbd>Tab</kbd> and <kbd>Esc</kbd> paths, and would have applied to every new <kbd>Shift</kbd>+<kbd>Tab</kbd> dismissal. Without it this change would have traded "focus escapes somewhere random" for "focus is lost entirely", which is different rather than better for the users the issue is about.

## Contract

`isOpen` in `commandPalette.js` tracks whether the palette is on screen, deliberately separate from `state`, which tracks whether the bundle has loaded — the palette opens and closes many times while `state` stays `mounted`. It is cleared before the focus call so a throwing `focus()` could not strand it as `true`, which would make the palette permanently unopenable.

Cache status: **clean** — JS only, no markup, classes, IDs or module names changed. No compat slice required.

## Verification

- 1172 Vitest tests; PHPCS and lints clean; every new guard mutation-checked (reverting its fix makes it fail).
- Real browser, trusted CDP events, each against the original repro with a control:

| Scenario | Before | After |
| --- | --- | --- |
| click chrome → <kbd>/</kbd> | query `"Main"` → `""` | query kept, focus back in input |
| <kbd>Shift</kbd>+<kbd>Tab</kbd> at root | open, focus on a page `<a>`, Escape dead | closes, focus on search button |
| <kbd>?</kbd> then <kbd>Tab</kbd> | focus escaped | closes, focus on search button |
| action row, <kbd>Shift</kbd>+<kbd>Tab</kbd> | focus escaped | back to input, palette open, query intact |
| <kbd>Esc</kbd> close | focus on `<body>` | focus on search button |
| normal typing | 3 results | 3 results |

- The 10-case keyboard layout matrix from #1731 still passes.

## Notes for review

**One deliberate product decision worth confirming:** <kbd>Shift</kbd>+<kbd>Tab</kbd> in the input zone now *closes*, discarding the query, and nothing in the footer advertises that. It is symmetric with <kbd>Tab</kbd>, which has always behaved this way — but <kbd>Shift</kbd>+<kbd>Tab</kbd> universally means "go back one control", so an alternative is to contain focus (preventDefault, stay put) and leave the query alone. Containing would also be closer to #1738's premise. Happy to switch if preferred; the action-row ladder is unaffected either way.

**Not addressed here, found while reviewing:** `activeDescendantId` is computed in `useKeyboard.js` and returned, but bound to no element — `aria-activedescendant` appears nowhere in `resources/`. The input also has no `role="combobox"`, `aria-expanded` or `aria-controls`, and the palette root has no role or accessible name. Arrow-key navigation therefore moves a purely visual highlight that screen readers never announce. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved command palette focus management when opening, closing, and triggering it repeatedly.
  - Added keyboard navigation support for returning focus to the search input without closing the palette.
  - Enhanced `Tab` and `Shift+Tab` behavior, including while help content is visible.

- **Bug Fixes**
  - Prevented repeated triggers from unnecessarily reopening or resetting an already open palette.

- **Tests**
  - Added coverage for focus restoration, keyboard navigation, repeated triggers, and closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->