### PR TITLE
fix(search): advertise the / shortcut in the search button tooltip

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -16,6 +16,7 @@
 	"citizen-preferences-load-error": "Couldn't load preferences. Check your connection and try again.",
 	"citizen-preferences-load-retry": "Retry",
 	"citizen-search-toggle": "Toggle search",
+	"citizen-search-toggle-shortcut": "[/]",
 	"citizen-notifications-title": "Notifications",
 	"citizen-notifications-label": "Notifications",
 	"citizen-notifications-tab-all": "All",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -23,6 +23,7 @@
 	"citizen-preferences-load-error": "Error message shown in the preferences dropdown when the preferences ResourceLoader module fails to load.",
 	"citizen-preferences-load-retry": "Label of the retry button shown alongside the preferences load error.\n{{Identical|Retry}}",
 	"citizen-search-toggle": "Tooltip of search box toggle",
+	"citizen-search-toggle-shortcut": "Keyboard shortcut hint appended to the search button tooltip, after {{msg-citizen|citizen-search-toggle}}. The \"/\" is the key itself and must not be translated; adapt only the brackets if your language uses different ones.\n{{optional}}",
 	"citizen-notifications-title": "Heading of the notification panel that opens from the header notification button.\n{{Identical|Notifications}}",
 	"citizen-notifications-label": "Accessible label and tooltip for the single header notification button.\n{{Identical|Notifications}}",
 	"citizen-notifications-tab-all": "Label of the tab in the notification panel that shows both alerts and notices.\n{{Identical|All}}",

--- a/skin.json
+++ b/skin.json
@@ -90,6 +90,7 @@
 						"citizen-preferences-load-retry",
 						"citizen-preferences-toggle",
 						"citizen-search-toggle",
+						"citizen-search-toggle-shortcut",
 						"citizen-usermenu-toggle",
 						"randompage",
 						"search",


### PR DESCRIPTION
Fixes #1742.

## Problem

`templates/Search__button.mustache` interpolates `{{msg-citizen-search-toggle-shortcut}}`, but that field stopped being supplied when the legacy search components were removed in 5064659a. It has resolved to an empty string ever since:

```
title="Toggle search "     ← length 14, not 13
```

So the tooltip carried a stray trailing space, and the search shortcut was advertised **nowhere** in the interface — even though <kbd>/</kbd>, <kbd>Ctrl</kbd>+<kbd>K</kbd> and the access key all work. That was a loose end left by #1731, which fixed <kbd>/</kbd> for non-US layouts while its only advertisement stayed blank.

## Change

Restore it as a real message key. There is no PHP left to hang it on — the search components are gone, and the sibling `citizen-search-toggle` reaches the template purely through the `messages` array in `skin.json`, so this one does the same. The template is unchanged.

Registering it in `skin.json` is the step that actually matters: `SkinMustache::getTemplateData()` only populates `msg-*` for keys listed there, so without it the key resolves to an empty string and nothing changes. That is effectively the step that went missing originally.

The slash is the key itself rather than prose, so `qqq` marks the message `{{optional}}` and tells translators to adapt only the brackets if their language uses different ones.

## Verification

```
$ curl -s 'http://localhost:8080/wiki/Main_Page' | grep -oE 'title="Toggle search[^"]*"'
title="Toggle search [/]"
```

- `npm run lint:i18n` clean, 1172 Vitest tests pass.
- XSS-language check per AGENTS.md (`?uselang=x-xss`): payloads render HTML-escaped in the `title` attribute, so the new message is not an injection vector.

## Note

The access key is a separate matter and deliberately not touched here — see the "related, but not bundled" section of #1742. Putting `accesskey` on the summary would let core append its own hint, giving `Toggle search [/] [alt-shift-f]`, which needs a decision about which hint to keep. It also can't be regression-tested, since accesskey activation is unreachable from synthetic key events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/` keyboard shortcut indicator to the search button tooltip.
  * Added localization support for the shortcut across supported language resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->