### PR TITLE
fix(commandPalette): announce search results to screen readers

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -120,6 +120,8 @@
 
 	"citizen-command-palette-action-view": "View",
 	"citizen-command-palette-back": "Back",
+	"citizen-command-palette-label": "Command palette",
+	"citizen-command-palette-results": "Results",
 	"citizen-command-palette-heading-recent": "Recent",
 	"citizen-command-palette-heading-related": "Related",
 

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -115,6 +115,8 @@
 	"citizen-user-info-joined-label": "Label for the registration date in the user info",
 	"citizen-command-palette-action-view": "Label for the per-item action button that opens the result's page for reading. Used on category results to provide access to the actual Category: page (since clicking the result drills into it instead of navigating).",
 	"citizen-command-palette-back": "Aria label for the back button in the command palette header when a mode is active.",
+	"citizen-command-palette-label": "Accessible name of the command palette overlay, announced when a screen reader user enters it. Not visible on screen.",
+	"citizen-command-palette-results": "Accessible name of the list of results inside the command palette. Not visible on screen.\n{{Identical|Result}}",
 	"citizen-command-palette-heading-recent": "Label for the recently searched results in the command palette",
 	"citizen-command-palette-heading-related": "Label for the related results in the command palette",
 	"citizen-command-palette-load-error": "Toast notification surfaced via mw.notify when the command palette module fails to load.",

--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -14,6 +14,8 @@
 			v-if="isOpen"
 			ref="paletteRoot"
 			class="citizen-command-palette"
+			role="search"
+			:aria-label="$i18n( 'citizen-command-palette-label' ).text()"
 			:data-palette-layout="paletteLayout"
 			@keydown="keyboard.handleKeydown"
 		>
@@ -27,6 +29,8 @@
 				:active-mode="activeMode"
 				:active-mode-context="activeModeContext"
 				:help-visible="helpVisible"
+				:expanded="flatItems.length > 0"
+				:active-descendant-id="activeDescendantId"
 				@exit-mode="exitMode"
 				@close-help="orchCloseHelp"
 				@update:free-text="handleFreeTextUpdate( $event )"
@@ -527,6 +531,10 @@ module.exports = exports = defineComponent( {
 			handleRemoveToken,
 			// Keyboard
 			keyboard,
+			// Exposed at the top level so Vue unwraps the ref for the template.
+			// Reading it off `keyboard` would bind the Ref object itself, which
+			// renders as "[object Object]" and resolves to no element.
+			activeDescendantId: keyboard.activeDescendantId,
 			highlightedHelpMode,
 			viewportHasDetail,
 			uniformItemType,

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteEmptyState.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteEmptyState.vue
@@ -1,5 +1,10 @@
 <template>
-	<div class="citizen-command-palette-empty-state">
+	<!-- role="status" so a query that returns nothing is announced rather
+		than leaving the combobox silently collapsed. -->
+	<div
+		class="citizen-command-palette-empty-state"
+		role="status"
+	>
 		<div class="citizen-command-palette-empty-state__icon">
 			<slot name="icon">
 				<cdx-icon :icon="icon"></cdx-icon>

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteGallery.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteGallery.vue
@@ -1,8 +1,10 @@
 <template>
 	<div
+		id="citizen-command-palette-listbox"
 		ref="galleryRef"
 		class="citizen-command-palette-gallery"
 		role="listbox"
+		:aria-label="$i18n( 'citizen-command-palette-results' ).text()"
 		tabindex="-1"
 	>
 		<template
@@ -13,11 +15,15 @@
 			<div
 				v-if="section.heading"
 				class="citizen-command-palette-gallery__heading"
+				role="presentation"
 			>
 				{{ $i18n( section.heading ).text() }}
 			</div>
 			<!-- eslint-enable mediawiki/msg-doc, mediawiki/no-vue-dynamic-i18n -->
-			<div class="citizen-command-palette-gallery__grid">
+			<div
+				class="citizen-command-palette-gallery__grid"
+				role="presentation"
+			>
 				<command-palette-gallery-item
 					v-for="( item, localIndex ) in section.items"
 					:key="item.id"

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteHeader.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteHeader.vue
@@ -36,11 +36,24 @@
 			>
 				{{ token.label }}
 			</cdx-info-chip>
+			<!--
+				CdxTextInput sets `inheritAttrs: false` so these land on the
+				real <input>, not the wrapper. That input is the combobox: focus
+				stays on it while the arrow keys move `aria-activedescendant`
+				through the listbox, which is what lets a screen reader announce
+				the highlighted result.
+			-->
 			<cdx-text-input
 				ref="searchInputRef"
 				:model-value="freeText"
 				class="citizen-command-palette-header__input"
 				input-type="search"
+				role="combobox"
+				aria-autocomplete="list"
+				:aria-label="currentPlaceholder"
+				aria-controls="citizen-command-palette-listbox"
+				:aria-expanded="expanded"
+				:aria-activedescendant="activeDescendantId || undefined"
 				:clearable="true"
 				:placeholder="currentPlaceholder"
 				@update:model-value="$emit( 'update:freeText', $event )"
@@ -99,6 +112,16 @@ module.exports = exports = defineComponent( {
 		helpVisible: {
 			type: Boolean,
 			default: false
+		},
+		/** Whether the listbox is showing results, for `aria-expanded`. */
+		expanded: {
+			type: Boolean,
+			default: false
+		},
+		/** Id of the highlighted option, or null when nothing is highlighted. */
+		activeDescendantId: {
+			type: String,
+			default: null
 		}
 	},
 	emits: [ 'update:freeText', 'select-token', 'exit-mode', 'close-help' ],

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
@@ -1,8 +1,10 @@
 <template>
 	<div
+		id="citizen-command-palette-listbox"
 		ref="listRef"
 		class="citizen-command-palette-list"
 		role="listbox"
+		:aria-label="$i18n( 'citizen-command-palette-results' ).text()"
 		tabindex="-1"
 	>
 		<template
@@ -13,6 +15,7 @@
 			<div
 				v-if="section.heading"
 				class="citizen-command-palette-list__heading"
+				role="presentation"
 			>
 				{{ $i18n( section.heading ).text() }}
 			</div>

--- a/skin.json
+++ b/skin.json
@@ -502,6 +502,8 @@
 				"action-edit",
 				"citizen-command-palette-action-view",
 				"citizen-command-palette-back",
+				"citizen-command-palette-label",
+				"citizen-command-palette-results",
 				"citizen-command-palette-command-action-description",
 				"citizen-command-palette-command-action-label",
 				"citizen-command-palette-command-category-description",

--- a/tests/vitest/commandPalette/components/CommandPaletteHeader.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteHeader.test.js
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+const { mount } = require( '@vue/test-utils' );
+const mw = require( '../../mocks/mw.js' );
+globalThis.mw = mw;
+
+// CdxTextInput sets `inheritAttrs: false` so that ARIA attributes land on the
+// real <input> rather than the wrapper. The stub has to do the same, or these
+// tests would pass against markup a screen reader never sees.
+mw.loader.require = vi.fn( () => ( {
+	CdxButton: {
+		name: 'CdxButton',
+		template: '<button><slot></slot></button>'
+	},
+	CdxInfoChip: {
+		name: 'CdxInfoChip',
+		template: '<div class="cdx-info-chip-stub"><slot></slot></div>'
+	},
+	CdxIcon: {
+		name: 'CdxIcon',
+		template: '<span class="cdx-icon-stub"></span>',
+		props: [ 'icon', 'size' ]
+	},
+	CdxTextInput: {
+		name: 'CdxTextInput',
+		inheritAttrs: false,
+		props: [ 'modelValue', 'inputType', 'clearable', 'placeholder' ],
+		template: '<div class="cdx-text-input-stub"><input v-bind="$attrs"></div>'
+	}
+} ) );
+
+let CommandPaletteHeader;
+
+function mountHeader( props = {} ) {
+	return mount( CommandPaletteHeader, {
+		props: {
+			tokens: [],
+			freeText: '',
+			...props
+		},
+		global: {
+			mocks: { $i18n: ( key ) => ( { text: () => key } ) }
+		}
+	} );
+}
+
+beforeAll( async () => {
+	CommandPaletteHeader = (
+		await import( '../../../../resources/skins.citizen.commandPalette/components/CommandPaletteHeader.vue' )
+	).default;
+} );
+
+describe( 'CommandPaletteHeader combobox wiring', () => {
+	it( 'marks the input as a combobox controlling the listbox', () => {
+		const wrapper = mountHeader();
+
+		const input = wrapper.get( 'input' );
+		expect( input.attributes( 'role' ) ).toBe( 'combobox' );
+		expect( input.attributes( 'aria-autocomplete' ) ).toBe( 'list' );
+		expect( input.attributes( 'aria-controls' ) ).toBe( 'citizen-command-palette-listbox' );
+	} );
+
+	it( 'reflects whether results are showing in aria-expanded', () => {
+		expect( mountHeader( { expanded: false } ).get( 'input' ).attributes( 'aria-expanded' ) )
+			.toBe( 'false' );
+		expect( mountHeader( { expanded: true } ).get( 'input' ).attributes( 'aria-expanded' ) )
+			.toBe( 'true' );
+	} );
+
+	it( 'points aria-activedescendant at the highlighted option', () => {
+		const wrapper = mountHeader( { activeDescendantId: 'citizen-command-palette-item-page-Foo' } );
+
+		expect( wrapper.get( 'input' ).attributes( 'aria-activedescendant' ) )
+			.toBe( 'citizen-command-palette-item-page-Foo' );
+	} );
+
+	it( 'reports expanded while the help overlay is up, which also lists options', () => {
+		// The help view renders the same command-palette-list, so a listbox is
+		// on screen; saying aria-expanded="false" there would be a lie.
+		const wrapper = mountHeader( { helpVisible: true, expanded: true } );
+
+		expect( wrapper.get( 'input' ).attributes( 'aria-expanded' ) ).toBe( 'true' );
+	} );
+
+	it( 'omits aria-activedescendant when nothing is highlighted', () => {
+		// An empty or stringified value ("[object Object]" from an unwrapped
+		// ref) resolves to no element, which is worse than omitting it.
+		const wrapper = mountHeader( { activeDescendantId: null } );
+
+		expect( wrapper.get( 'input' ).attributes( 'aria-activedescendant' ) ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Fixes #1745.

## Problem

The palette rendered a listbox of results that assistive technology was never told about. `role="listbox"` and `role="option"` were present, but nothing connected them to the input — no `role="combobox"`, no `aria-expanded`, no `aria-controls`, and nothing pointing at the highlighted row.

A screen reader user could open the palette, type a query, and hear nothing back — then press <kbd>Enter</kbd> and navigate somewhere they were never told existed.

## Change

Most of the missing piece already existed. `useKeyboard` computed an `activeDescendantId` and returned it, and every result row already carried a stable `id`; the value was just bound to no element.

- The input is described as the combobox it is: `role="combobox"`, `aria-autocomplete="list"`, `aria-controls`, `aria-expanded`, and `aria-activedescendant` following the highlight. Focus stays on the input while the arrow keys move the active option — the pattern this widget was already built for.
- Both listboxes get the id `aria-controls` points at. They are mutually exclusive (`v-else-if`), so sharing one id is valid.
- The palette root becomes a `search` landmark with an accessible name, instead of an unlabelled `div`. It reuses `searchsuggest-search`, already registered on the module and already the input's placeholder, so no new message is needed.

**The subtle part, called out because it looked like it worked:** the id is exposed at the top level of `App.vue`'s setup return rather than read off `keyboard`. Vue only unwraps refs one level deep, so `:active-descendant-id="keyboard.activeDescendantId"` binds the Ref object and renders the literal string `[object Object]` — a valid-looking attribute that resolves to no element, i.e. exactly as broken as having nothing.

## Deliberately not included

`inert` / `aria-hidden` on the page behind the palette. The palette is functionally modal — dimming, click-blocking backdrop — so a virtual-cursor user can still read straight past it into the page. That is a real gap, but it is a separable concern with a different risk profile, and the combobox wiring stands on its own.

## Verification

Checked against **Chromium's computed accessibility tree** (`Accessibility.getFullAXTree`), not by asserting that attributes exist — this confirms the browser actually resolves the relationships:

```
combobox   name="Search MediaWiki"  autocomplete=list  expanded=true
                                    controls=citizen-command-palette-listbox
                                    activedescendant=citizen-command-palette-item-page-Main_Page
search     name="Search MediaWiki"
listbox    3 options
```

After one <kbd>↓</kbd>, `activedescendant` moves to `citizen-command-palette-item-fulltext-search` — the highlight and the announced option stay in step.

- 1176 Vitest tests, including 4 new component tests that pin the wiring. Their stub reproduces `CdxTextInput`'s `inheritAttrs: false`, so they assert against the real `<input>` rather than markup a screen reader never sees.
- Mutation-checked: removing the ARIA wiring fails 3 of the 4.
- eslint and stylelint clean.

Cache status: **clean** — no PHP, template, `skin.json` or module changes, so no compat slice.

## What still needs a human

I can confirm the browser exposes the relationships correctly, but not how NVDA, JAWS or VoiceOver phrase the result. A pass with a real screen reader would be worth doing before this is considered closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Review round 2

A code review and a browser smoke test were run against this branch. Both independently found the same **Critical** defect, now fixed, plus four smaller ones.

**`aria-expanded` was lying while the help overlay was open.** The binding was `!helpVisible && flatItems.length > 0`, on the assumption that help replaces the results. It does not — `CommandPaletteHelpView` renders the *same* `command-palette-list`. So pressing <kbd>?</kbd> produced a combobox reporting `aria-expanded="false"` while a populated, arrow-navigable listbox was on screen with `aria-activedescendant` pointing into it. Screen readers gate activedescendant announcements on the combobox being expanded, so that was the very bug this PR closes, left intact for one reachable view. The `!helpVisible` term is simply wrong; removed.

Also addressed:

- **The listbox had no accessible name** — `role="listbox"` requires one. Both listboxes now carry `aria-label`.
- **The combobox's name came only from `placeholder`**, the last-resort step of accname computation, and silently changed identity per mode. It now has an explicit `aria-label`.
- **`role="search"` reused the placeholder message** as its label, so a reader announced "Search MediaWiki" twice and translators could not tune either use. It now has a dedicated message, which also describes the overlay more honestly than "search" does for something with action/user/history/file modes.
- **A query returning nothing was silent** — the listbox unmounted, `aria-expanded` went false, and nothing announced the empty state. It is now `role="status"`.
- **Section headings and the gallery grid were invalid owned content** for a listbox. Both are now presentational. Confirmed against the accessibility tree: gallery options were previously two levels below the listbox under a `none` node, and are now direct children.

### Verification of round 2

Chromium accessibility tree, all three layouts:

| Layout | listbox name | direct children | options |
| --- | --- | --- | --- |
| list | `Results` | 3 × `option` | 3 |
| gallery | `Results` | 2 × `option` | 2 |
| help | `Results` | `StaticText` + 7 × `option` | 7 |

`aria-expanded` re-checked against listbox presence in eight states — empty palette, typed query, after ↓, after ↑, help overlay, mode with no sub-query, mode with results, gallery — and matches in all of them. The Codex clear button, per-mode placeholders and console cleanliness were also re-checked.

### Two gaps left open deliberately

**No App-level integration test.** The two bugs both lived in `App.vue`'s template, and the `CommandPaletteHeader` tests here mount that component directly with props, so neither would have been caught. I attempted the harness and stopped: `App.vue` takes eleven injections plus nine composables, and a mock faithful enough to exercise the real binding semantics would itself need to replicate the orchestrator. A mock that drifts would give false confidence, which is worse than a stated gap. Both defects were instead caught by browser verification against the accessibility tree. Worth doing properly as its own piece of work.

**The help view's section heading is still a stray `StaticText` child of the listbox.** Making it presentational removed the element's semantics but not its text node. The conformant fix is `role="group"` + `aria-labelledby`, which needs a per-section wrapper element — a DOM restructure with CSS implications, out of proportion here. In practice it is unreachable while arrowing, since navigation moves by `aria-activedescendant`.
