### PR TITLE
fix(commandPalette): follow the reading direction when navigating with arrows

### DIFF
--- a/docs/src/features/command-palette.md
+++ b/docs/src/features/command-palette.md
@@ -294,7 +294,7 @@ keybindings: [
 | :--- | :--- | :--- |
 | `id` | `string` | Unique binding identifier (used for debugging). |
 | `zone` | `'input' \| 'action'` | Which focus zone the binding applies to. |
-| `keys` | `string[]` | Event `key` values that fire `handle`. An empty array marks the binding as hint-only. |
+| `keys` | `string[]` | Event `key` values that fire `handle`. An empty array marks the binding as hint-only. Declare `ArrowLeft`/`ArrowRight` logically (previous/next) — the physical arrow is mirrored on RTL interface languages. |
 | `when` | `function` | `(state) => boolean` — predicate over the dispatch state. False suppresses both the handler and the hint. |
 | `handle` | `function` | `(state, event) => void` — called when a `keys` entry matches and `when` passes. Call `event.preventDefault()` to claim the keystroke. |
 | `worksDuringHelp` | `boolean` | When true, the binding fires even with the help overlay open. Defaults to false. |
@@ -305,7 +305,7 @@ Hint shape:
 | Property | Type | Description |
 | :--- | :--- | :--- |
 | `msgKey` | `string` | i18n message key for the hint label. |
-| `kbd` | `string` | Keyboard glyph shown next to the label (e.g. `↵`, `↑↓`, `⌘C`). |
+| `kbd` | `string` | Keyboard glyph shown next to the label (e.g. `↵`, `↑↓`, `⌘C`). A lone `←` or `→` is swapped on RTL interface languages so the hint names the key the user actually presses; a hint offering both is left alone. |
 | `order` | `number` | Sort order within the footer (lower = leftmost). |
 
 Mode keybindings are prepended to the core bindings while the mode is active, so a mode binding wins on key collisions within its own focus zone. Footer hints derive from the same list, so a hint is visible iff its handler will fire — no risk of stale hints.

--- a/resources/skins.citizen.commandPalette/composables/useKeyboard.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboard.js
@@ -14,6 +14,79 @@ const {
 const IS_MAC = isMacPlatform( typeof navigator !== 'undefined' ? navigator : null );
 const COPY_KBD = IS_MAC ? '⌘C' : 'Ctrl+C';
 
+// Arrow keys are physical; the bindings below are logical (previous/next, and
+// input → action row). CSSJanus mirrors the inline axis for RTL interface
+// languages, so on an RTL wiki the two horizontal arrows have to be swapped
+// before a binding is resolved, or navigation runs backwards on screen.
+const MIRRORED_KEYS = Object.assign( Object.create( null ), {
+	ArrowLeft: 'ArrowRight',
+	ArrowRight: 'ArrowLeft'
+} );
+
+/**
+ * Whether the palette is laid out right-to-left.
+ *
+ * Prefers the element's computed direction so a palette inside a direction
+ * island still resolves correctly, and falls back to the document for the
+ * window between mount and the input existing.
+ *
+ * @param {HTMLElement|null} element
+ * @return {boolean}
+ */
+function isRtlDirection( element ) {
+	// getComputedStyle throws on anything that is not an Element, and the
+	// input reference is null until the header mounts.
+	if (
+		element && element.nodeType === 1 &&
+		typeof window !== 'undefined' && window.getComputedStyle
+	) {
+		// Sample the palette, not the input: it is the palette's inline axis
+		// that CSSJanus mirrors, and a search field is the one element here
+		// likely to acquire a direction of its own (`dir="auto"` resolves to
+		// ltr for a Latin query on an RTL wiki, which would silently switch
+		// the mirror off while the layout stayed flipped).
+		const root = typeof element.closest === 'function' ?
+			( element.closest( '.citizen-command-palette' ) || element ) :
+			element;
+		const direction = window.getComputedStyle( root ).direction;
+		if ( direction ) {
+			return direction === 'rtl';
+		}
+	}
+	return typeof document !== 'undefined' && document.dir === 'rtl';
+}
+
+/**
+ * Map a physical arrow onto the logical direction the bindings are written in.
+ *
+ * @param {string} key
+ * @param {boolean} rtl
+ * @return {string}
+ */
+function toLogicalKey( key, rtl ) {
+	return rtl && MIRRORED_KEYS[ key ] ? MIRRORED_KEYS[ key ] : key;
+}
+
+/**
+ * Mirror the arrow glyphs in a footer hint, so the key it advertises is the
+ * one the user actually has to press.
+ *
+ * @param {string} kbd
+ * @param {boolean} rtl
+ * @return {string}
+ */
+function mirrorHint( kbd, rtl ) {
+	if ( !rtl || typeof kbd !== 'string' ) {
+		return kbd;
+	}
+	// A hint offering both arrows already covers either direction, so swapping
+	// them would only shuffle the glyphs into a stranger order.
+	if ( kbd.includes( '←' ) && kbd.includes( '→' ) ) {
+		return kbd;
+	}
+	return kbd.replace( /[←→]/g, ( glyph ) => ( glyph === '←' ? '→' : '←' ) );
+}
+
 /**
  * Core keybinding registry for the command palette.
  *
@@ -652,7 +725,7 @@ function useKeyboard( options ) {
 			actionsFocused: false,
 			dispatchEscape: null
 		} );
-		const binding = resolveBinding( inputState, { key: 'Escape' }, activeBindings.value );
+		const binding = resolveBinding( inputState, 'Escape', activeBindings.value );
 		if ( binding ) {
 			binding.handle( inputState, event );
 		}
@@ -716,9 +789,12 @@ function useKeyboard( options ) {
 	const keyboardHints = computed( () => {
 		const state = buildState();
 		const zone = state.actionsFocused ? 'action' : 'input';
-		return resolveHints( state, zone, activeBindings.value ).map( ( hint ) => ( {
+		const hints = resolveHints( state, zone, activeBindings.value );
+		const rtl = hints.some( ( hint ) => /[←→]/.test( hint.kbd ) ) &&
+			isRtlDirection( state.inputElement );
+		return hints.map( ( hint ) => ( {
 			msgKey: hint.msgKey,
-			kbd: hint.kbd
+			kbd: mirrorHint( hint.kbd, rtl )
 		} ) );
 	} );
 
@@ -810,7 +886,15 @@ function useKeyboard( options ) {
 			state.selectedTokenIndex = -1;
 		}
 
-		const binding = resolveBinding( state, event, activeBindings.value );
+		// Resolve against the logical key, but hand the handler the real event —
+		// the only handler that re-reads event.key distinguishes ArrowUp from
+		// ArrowDown, which the mirror never touches. Direction is only sampled
+		// for the two keys that can be mirrored, so ordinary typing does not
+		// pay for a style read.
+		const logicalKey = MIRRORED_KEYS[ event.key ] ?
+			toLogicalKey( event.key, isRtlDirection( state.inputElement ) ) :
+			event.key;
+		const binding = resolveBinding( state, logicalKey, activeBindings.value );
 		if ( binding ) {
 			binding.handle( state, event );
 			return;

--- a/resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js
@@ -13,7 +13,9 @@
  * @typedef {Object} KeyBinding
  * @property {string} id Stable identifier (tests, debugging).
  * @property {'input'|'action'} zone Focus zone where this binding applies.
- * @property {string[]} keys Exact event.key values that trigger this binding.
+ * @property {string[]} keys `event.key` values that trigger this binding. The
+ *   two horizontal arrows are logical: the palette mirrors the physical arrow
+ *   for RTL interface languages before resolving.
  * @property {Function} when Predicate `(state) => boolean`; binding active iff true.
  * @property {boolean} [worksDuringHelp] If true, applies even when state.helpVisible.
  * @property {Function} handle Side effect `(state, event) => void`.
@@ -37,18 +39,23 @@ function isActive( state, binding ) {
 /**
  * Find the first binding that should fire for the given event.
  *
+ * Takes the key rather than the event: callers pass a direction-mirrored key
+ * under RTL, and accepting an event here would invite reading other properties
+ * off it — which would then diverge between RTL and LTR without anything
+ * failing.
+ *
  * @param {Object} state
- * @param {KeyboardEvent} event
+ * @param {string} key
  * @param {KeyBinding[]} bindings
  * @return {KeyBinding|null}
  */
-function resolveBinding( state, event, bindings ) {
+function resolveBinding( state, key, bindings ) {
 	const zone = state.actionsFocused ? 'action' : 'input';
 	for ( const binding of bindings ) {
 		if ( binding.zone !== zone ) {
 			continue;
 		}
-		if ( !binding.keys.includes( event.key ) ) {
+		if ( !binding.keys.includes( key ) ) {
 			continue;
 		}
 		if ( !isActive( state, binding ) ) {

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -159,6 +159,8 @@
  * @typedef {Object} KeyBindingHint
  * @property {string} msgKey i18n message key for the hint label.
  * @property {string} kbd Keyboard glyph shown next to the label (e.g. '↵', '↑↓', '⌘C').
+ *   A lone '←' or '→' is swapped on RTL interface languages so the hint names
+ *   the key the user actually presses.
  * @property {number} [order] Sort order within the footer (lower = leftmost).
  */
 
@@ -170,7 +172,7 @@
  * @typedef {Object} KeyBinding
  * @property {string} id Unique binding identifier (used for debugging).
  * @property {'input'|'action'} zone Which focus zone the binding applies to.
- * @property {string[]} keys Event `key` values that fire `handle`. An empty array marks the binding as hint-only.
+ * @property {string[]} keys Event `key` values that fire `handle`. An empty array marks the binding as hint-only. Declare 'ArrowLeft'/'ArrowRight' logically (previous/next): the palette mirrors the physical arrow on RTL interface languages before resolving.
  * @property {function(Object): boolean} when Predicate over the dispatch state — false suppresses both the handler and the hint.
  * @property {function(Object, KeyboardEvent)} handle Called when a `keys` entry matches and `when` passes. Should call `event.preventDefault()` to claim the keystroke.
  * @property {boolean} [worksDuringHelp] When true, the binding fires even with the help overlay open. Defaults to false.

--- a/resources/skins.citizen.styles/components/KeyboardHint.less
+++ b/resources/skins.citizen.styles/components/KeyboardHint.less
@@ -18,6 +18,14 @@
 		color: var( --color-subtle );
 		// stylelint-disable-next-line declaration-property-value-disallowed-list
 		text-transform: capitalize;
+		// Arrow glyphs are bidi-neutral, so a multi-key hint like `↑↓←` takes
+		// the paragraph direction and renders reversed on an RTL wiki. Isolate
+		// it so the authored order survives. @noflip because CSSJanus would
+		// otherwise rewrite this to `rtl` in the RTL build — the one place the
+		// flip must not happen.
+		/* @noflip */
+		direction: ltr;
+		unicode-bidi: isolate;
 	}
 }
 

--- a/tests/vitest/commandPalette/composables/useKeyboard.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboard.test.js
@@ -445,6 +445,180 @@ describe( 'useKeyboard', () => {
 		} );
 	} );
 
+	describe( 'right-to-left interface languages', () => {
+		function actionZoneTarget() {
+			const target = {
+				closest: vi.fn( ( selector ) => (
+					selector === '.citizen-command-palette-list-item__action' ? target : null
+				) )
+			};
+			actionNav.isActive.value = true;
+			return target;
+		}
+
+		afterEach( () => {
+			document.dir = '';
+		} );
+
+		it( 'steps the action row visually, so ArrowLeft advances under RTL', () => {
+			document.dir = 'rtl';
+			const target = actionZoneTarget();
+
+			keyboard.handleKeydown( createKeyEvent( 'ArrowLeft', target ) );
+
+			expect( actionNav.focusNext ).toHaveBeenCalled();
+			expect( actionNav.focusPrevious ).not.toHaveBeenCalled();
+		} );
+
+		it( 'sends ArrowRight backwards under RTL', () => {
+			document.dir = 'rtl';
+			const target = actionZoneTarget();
+
+			keyboard.handleKeydown( createKeyEvent( 'ArrowRight', target ) );
+
+			expect( actionNav.focusPrevious ).toHaveBeenCalled();
+			expect( actionNav.focusNext ).not.toHaveBeenCalled();
+		} );
+
+		it( 'leaves the action row unmirrored under LTR', () => {
+			document.dir = 'ltr';
+			const target = actionZoneTarget();
+
+			keyboard.handleKeydown( createKeyEvent( 'ArrowRight', target ) );
+
+			expect( actionNav.focusNext ).toHaveBeenCalled();
+			expect( actionNav.focusPrevious ).not.toHaveBeenCalled();
+		} );
+
+		it( 'prefers the input\'s own direction over the document', () => {
+			// A palette inside a direction island must follow the island.
+			document.dir = 'ltr';
+			// A real element: getComputedStyle rejects anything else.
+			const inputEl = document.createElement( 'input' );
+			deps.inputRef.value.getInputElement = vi.fn( () => inputEl );
+			const original = globalThis.getComputedStyle;
+			globalThis.getComputedStyle = vi.fn( () => ( { direction: 'rtl' } ) );
+			keyboard = useKeyboard( toGrouped( deps ) );
+			const target = actionZoneTarget();
+
+			try {
+				keyboard.handleKeydown( createKeyEvent( 'ArrowLeft', target ) );
+			} finally {
+				globalThis.getComputedStyle = original;
+			}
+
+			expect( actionNav.focusNext ).toHaveBeenCalled();
+			expect( actionNav.focusPrevious ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not mirror the vertical arrows', () => {
+			document.dir = 'rtl';
+
+			keyboard.handleKeydown( createKeyEvent( 'ArrowDown' ) );
+			keyboard.handleKeydown( createKeyEvent( 'ArrowUp' ) );
+
+			expect( listNav.highlightNext ).toHaveBeenCalledTimes( 1 );
+			expect( listNav.highlightPrevious ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'reaches the action row with ArrowLeft under RTL', () => {
+			// The input to action-row jump: one of the two paths in T1741.
+			document.dir = 'rtl';
+			var inputEl = {
+				selectionStart: 5,
+				selectionEnd: 5,
+				value: 'hello',
+				focus: vi.fn(),
+				closest: vi.fn( () => null )
+			};
+			deps.inputRef.value.getInputElement = vi.fn( () => inputEl );
+			listNav.highlightedIndex.value = 0;
+			keyboard = useKeyboard( toGrouped( deps ) );
+
+			keyboard.handleKeydown( createKeyEvent( 'ArrowLeft', inputEl ) );
+
+			expect( actionNav.focusFirst ).toHaveBeenCalled();
+		} );
+
+		it( 'steps gallery tiles with ArrowLeft under RTL', () => {
+			// Gallery tiles: the other path in T1741.
+			document.dir = 'rtl';
+			const gridNav = {
+				highlightNext: vi.fn(),
+				highlightPrevious: vi.fn(),
+				highlightUp: vi.fn(),
+				highlightDown: vi.fn(),
+				highlightFirst: vi.fn(),
+				highlightLast: vi.fn(),
+				highlightedIndex: ref( 0 ),
+				scrollToHighlighted: vi.fn()
+			};
+			deps.gridNav = gridNav;
+			deps.isGalleryLayout = ref( true );
+			keyboard = useKeyboard( toGrouped( deps ) );
+
+			keyboard.handleKeydown( createKeyEvent( 'ArrowLeft' ) );
+
+			expect( gridNav.highlightNext ).toHaveBeenCalled();
+			expect( gridNav.highlightPrevious ).not.toHaveBeenCalled();
+		} );
+
+		it( 'mirrors every arrow in a combined hint glyph', () => {
+			document.dir = 'rtl';
+			const actionTarget = {
+				closest: vi.fn( ( selector ) => (
+					selector === '.citizen-command-palette-list-item__action' ? actionTarget : null
+				) )
+			};
+			actionNav.isActive.value = true;
+			// focusedIndex at the last action selects the `↑↓←` hint variant.
+			actionNav.focusedIndex.value = 1;
+			deps.items = ref( [ { id: '1', actions: [ { id: 'a' }, { id: 'b' } ] } ] );
+			keyboard = useKeyboard( toGrouped( deps ) );
+			listNav.highlightedIndex.value = 0;
+
+			const kbds = keyboard.keyboardHints.value.map( ( hint ) => hint.kbd );
+
+			expect( kbds ).toContain( '↑↓→' );
+			expect( kbds ).not.toContain( '↑↓←' );
+		} );
+
+		it( 'leaves a hint offering both arrows untouched', () => {
+			// focusedIndex before the last action selects the `↑↓←→` variant,
+			// which already covers either direction — swapping would only
+			// shuffle the glyphs into a stranger order.
+			document.dir = 'rtl';
+			const actionTarget = {
+				closest: vi.fn( ( selector ) => (
+					selector === '.citizen-command-palette-list-item__action' ? actionTarget : null
+				) )
+			};
+			actionNav.isActive.value = true;
+			actionNav.focusedIndex.value = 0;
+			deps.items = ref( [ { id: '1', actions: [ { id: 'a' }, { id: 'b' } ] } ] );
+			keyboard = useKeyboard( toGrouped( deps ) );
+			listNav.highlightedIndex.value = 0;
+
+			const kbds = keyboard.keyboardHints.value.map( ( hint ) => hint.kbd );
+
+			expect( kbds ).toContain( '↑↓←→' );
+		} );
+
+		it( 'mirrors the arrow glyphs in the footer hints', () => {
+			document.dir = 'rtl';
+			deps.items = ref( [ { id: '1', actions: [ { id: 'edit' } ] } ] );
+			keyboard = useKeyboard( toGrouped( deps ) );
+			listNav.highlightedIndex.value = 0;
+
+			const kbds = keyboard.keyboardHints.value.map( ( hint ) => hint.kbd );
+
+			// The action row sits to the left under RTL, so the hint for
+			// reaching it must advertise the key the user actually presses.
+			expect( kbds ).toContain( '←' );
+			expect( kbds ).not.toContain( '→' );
+		} );
+	} );
+
 	describe( 'input zone — ArrowRight at end of input', () => {
 		it( 'should call actionNav.focusFirst when cursor is at end and item has actions', () => {
 			var inputEl = {

--- a/tests/vitest/commandPalette/composables/useKeyboardBindings.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboardBindings.test.js
@@ -7,17 +7,13 @@ function makeState( overrides ) {
 	return Object.assign( { helpVisible: false, actionsFocused: false }, overrides );
 }
 
-function makeEvent( key ) {
-	return { key };
-}
-
 describe( 'resolveBinding', () => {
 	it( 'returns null when no binding matches', () => {
 		const bindings = [
 			{ id: 'a', zone: 'input', keys: [ 'Enter' ], when: () => true, handle: () => {} }
 		];
 
-		const result = resolveBinding( makeState(), makeEvent( 'Tab' ), bindings );
+		const result = resolveBinding( makeState(), 'Tab', bindings );
 
 		expect( result ).toBeNull();
 	} );
@@ -27,7 +23,7 @@ describe( 'resolveBinding', () => {
 			{ id: 'a', zone: 'input', keys: [ 'Enter' ], when: () => true, handle: () => {} }
 		];
 
-		const result = resolveBinding( makeState(), makeEvent( 'Enter' ), bindings );
+		const result = resolveBinding( makeState(), 'Enter', bindings );
 
 		expect( result.id ).toBe( 'a' );
 	} );
@@ -38,7 +34,7 @@ describe( 'resolveBinding', () => {
 			{ id: 'second', zone: 'input', keys: [ 'Backspace' ], when: () => true, handle: () => {} }
 		];
 
-		const result = resolveBinding( makeState(), makeEvent( 'Backspace' ), bindings );
+		const result = resolveBinding( makeState(), 'Backspace', bindings );
 
 		expect( result.id ).toBe( 'first' );
 	} );
@@ -48,7 +44,7 @@ describe( 'resolveBinding', () => {
 			{ id: 'a', zone: 'action', keys: [ 'Enter' ], when: () => true, handle: () => {} }
 		];
 
-		const result = resolveBinding( makeState( { actionsFocused: false } ), makeEvent( 'Enter' ), bindings );
+		const result = resolveBinding( makeState( { actionsFocused: false } ), 'Enter', bindings );
 
 		expect( result ).toBeNull();
 	} );
@@ -59,7 +55,7 @@ describe( 'resolveBinding', () => {
 			{ id: 'help', zone: 'input', keys: [ 'Enter' ], when: () => true, worksDuringHelp: true, handle: () => {} }
 		];
 
-		const result = resolveBinding( makeState( { helpVisible: true } ), makeEvent( 'Enter' ), bindings );
+		const result = resolveBinding( makeState( { helpVisible: true } ), 'Enter', bindings );
 
 		expect( result.id ).toBe( 'help' );
 	} );
@@ -69,8 +65,8 @@ describe( 'resolveBinding', () => {
 			{ id: 'a', zone: 'input', keys: [ 'Backspace' ], when: ( s ) => s.tokens.length > 0, handle: () => {} }
 		];
 
-		expect( resolveBinding( makeState( { tokens: [] } ), makeEvent( 'Backspace' ), bindings ) ).toBeNull();
-		expect( resolveBinding( makeState( { tokens: [ 'a' ] } ), makeEvent( 'Backspace' ), bindings ).id ).toBe( 'a' );
+		expect( resolveBinding( makeState( { tokens: [] } ), 'Backspace', bindings ) ).toBeNull();
+		expect( resolveBinding( makeState( { tokens: [ 'a' ] } ), 'Backspace', bindings ).id ).toBe( 'a' );
 	} );
 
 	it( 'never returns a binding with empty keys array', () => {
@@ -78,7 +74,7 @@ describe( 'resolveBinding', () => {
 			{ id: 'hint-only', zone: 'input', keys: [], when: () => true, handle: () => {}, hint: { msgKey: 'a', kbd: 'x', order: 10 } }
 		];
 
-		const result = resolveBinding( makeState(), makeEvent( 'x' ), bindings );
+		const result = resolveBinding( makeState(), 'x', bindings );
 
 		expect( result ).toBeNull();
 	} );


### PR DESCRIPTION
Fixes #1741.

## Problem

The palette's <kbd>←</kbd>/<kbd>→</kbd> bindings were written as fixed logical directions — previous/next, and input → action row — while the components they drive are laid out with direction-aware CSS that CSSJanus mirrors for RTL interface languages. The stylesheet flipped; the key mapping did not.

So on an RTL wiki, pressing <kbd>→</kbd> moved the highlight **leftward**. Both affected paths were measured before the fix:

| Path | Language | Start x | After <kbd>→</kbd> |
| --- | --- | --- | --- |
| action row | Hebrew | 245 | 209 — left |
| gallery tiles | Hebrew | 937 | 758 — left |

## Change

Mirror the two horizontal arrows once, at the single point where a binding is resolved, rather than teaching each binding about direction. Vertical arrows, Home/End and everything else pass through untouched.

Three things that made this safe rather than invasive:

- **The handler still receives the real event.** Only one handler re-reads `event.key` (`action-back-to-list`, to tell up from down), and the mirror never touches those.
- **The caret gate needs no change.** The jump from input to action row requires the cursor at the logical end of the input, and `selectionStart` is a logical offset in every browser.
- **The footer hint is mirrored with it**, so the arrow it advertises is the one that works. Hebrew now reads `פעולות ←` where English reads `Actions →` — previously both said `→`.

Direction is read from the input's computed style, falling back to `document.dir` for the window between mount and the header existing.

## Verification

Re-measured in a real browser with trusted CDP events, pressing whichever key *should* advance in that direction:

| Path | Language | Forward key | Movement | Correct |
| --- | --- | --- | --- | --- |
| action row | Hebrew | <kbd>←</kbd> | 245 → 209 (left) | ✅ |
| action row | English | <kbd>→</kbd> | 1003 → 1039 (right) | ✅ |
| gallery | Hebrew | <kbd>←</kbd> | 937 → 758 (left) | ✅ |
| gallery | English | <kbd>→</kbd> | 177 → 355 (right) | ✅ |

In the gallery the highlight moves between the same two tiles either way, so it is the visual mapping that changed, not the item order.

- **6 new tests — the suite's first RTL coverage.** They cover both mirrored arrows, the LTR control, that vertical arrows are untouched, the hint glyphs, and that the input's own direction beats the document's.
- 1183 tests pass; eslint clean.

Cache status: **clean** — JS only, no markup, classes or module names changed.

## Note

Writing the tests caught a real bug in the first version of this fix: `getComputedStyle` throws a `TypeError` on anything that is not an `Element`, and the input reference is `null` until the header mounts. Eleven unrelated tests failed on it. The guard is now explicit, and the fallback to `document.dir` covers that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Review round 2

Acted on a code review. No Critical findings; the core approach held up — the reviewer independently confirmed that `useGridNavigation`, `useActionNavigation` and `useListNavigation` are all pure index math with no left/right notion, so one mirror is exactly one flip and there is no double-flip risk.

Four changes since:

- **The resolver takes a key, not an event.** It only ever read `event.key`, but the signature invited reading more — and any such read would diverge between RTL and LTR with nothing failing. Narrowing it also deletes a pre-existing fake event at the Escape dispatch site.
- **Direction is sampled from the palette, not the input.** It is the palette's inline axis that CSSJanus mirrors. Nothing sets `dir` on the input today (verified live: input and palette both compute `rtl`, no `dir` attribute), but a search box is the single element here most likely to gain `dir="auto"` — which resolves to `ltr` for a Latin query on an RTL wiki and would switch the mirror off while the layout stayed flipped.
- **A hint offering both arrows is no longer mirrored.** `↑↓←→` already covers either direction, so swapping only shuffled it to `↑↓→←`.
- **Direction is sampled only for the two keys that can be mirrored**, so ordinary typing no longer pays for a style read per keystroke.

### A bug the review surfaced, and its fix

Arrow glyphs are bidi-neutral, so a multi-key hint takes the paragraph direction and **renders reversed** on an RTL wiki. Measured per-character x-positions in the browser:

| | authored | rendered in RTL |
| --- | --- | --- |
| unstyled | `↑↓←` | `←↓↑` |
| isolated | `↑↓←` | `↑↓←` |

Fixed with `unicode-bidi: isolate` plus `direction: ltr`. The first attempt silently did nothing: **CSSJanus rewrote `direction: ltr` to `rtl`** in the RTL build — precisely its job, and precisely wrong here. It now carries `/* @noflip */`, verified against the served RTL stylesheet:

```
.citizen-keyboard-hint-key{…;direction:ltr;unicode-bidi:isolate}
```

This one is pre-existing rather than caused by the fix — unmirrored strings reversed too — but it is in the hints this change rewrites, and it is one line.

### Tests

Now 10, up from 6. The reviewer correctly noted that two of the original six pass against the base commit; they are regression guards, not coverage. Added the two paths #1741 actually names — the input→action-row jump and gallery stepping, both under RTL — plus the combined-glyph cases. One assertion I wrote was a tautology and has been replaced with a real one through the hint pipeline.

Docs and the `KeyBinding` / `KeyBindingHint` typedefs now state that horizontal arrows are declared logically and that hint glyphs are mirrored, since modes are a public extension point.

### Known limitation

On an RTL interface with a **Latin** query, physical <kbd>←</kbd> at the logical end of the input jumps to the action row (confirmed in the browser). In that mixed-bidi case the caret could arguably still move left through the Latin run instead. CDP cannot perform default editing actions, so whether a caret move is actually being stolen is not measurable here — flagging rather than guessing. It needs an RTL interface, a Latin query, and a highlighted result with actions; the pre-change behaviour was wrong in that configuration too, just differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command palette keyboard navigation for right-to-left interfaces.
  * Logical left/right arrow shortcuts now work correctly in RTL layouts.
  * Keyboard hints mirror standalone arrow icons appropriately while preserving paired hints.
  * Added support for detecting direction from the palette or document context.

* **Documentation**
  * Clarified RTL keyboard shortcut and hint behavior in the command palette documentation.

* **Tests**
  * Added coverage for RTL navigation, transitions, gallery controls, and keyboard hint rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->