### PR TITLE
refactor(commandPalette): let keybindings declare the modifiers they claim

### DIFF
--- a/docs/src/features/command-palette.md
+++ b/docs/src/features/command-palette.md
@@ -295,6 +295,7 @@ keybindings: [
 | `id` | `string` | Unique binding identifier (used for debugging). |
 | `zone` | `'input' \| 'action'` | Which focus zone the binding applies to. |
 | `keys` | `string[]` | Event `key` values that fire `handle`. An empty array marks the binding as hint-only. Declare `ArrowLeft`/`ArrowRight` logically (previous/next) — the physical arrow is mirrored on RTL interface languages. |
+| `modifiers` | `string \| string[]` | Which modifier state the binding claims: `none` (the default), `shift`, `accel` (Ctrl, or Command on a Mac), `accel+shift`, or `any`. An array accepts several. A character composed with AltGr and a capital typed with Shift both count as `none` — they are typed text, not chords — so a binding on `?` or `@` needs nothing special. Anything not named stays with the browser. |
 | `when` | `function` | `(state) => boolean` — predicate over the dispatch state. False suppresses both the handler and the hint. |
 | `handle` | `function` | `(state, event) => void` — called when a `keys` entry matches and `when` passes. Call `event.preventDefault()` to claim the keystroke. |
 | `worksDuringHelp` | `boolean` | When true, the binding fires even with the help overlay open. Defaults to false. |

--- a/resources/skins.citizen.commandPalette/composables/useKeyboard.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboard.js
@@ -1,5 +1,5 @@
 const { computed, nextTick } = require( 'vue' );
-const { resolveBinding, resolveHints } = require( './useKeyboardBindings.js' );
+const { modifierToken, resolveBinding, resolveHints } = require( './useKeyboardBindings.js' );
 // keyboardLayout.js is listed in both this module's and
 // skins.citizen.scripts' packageFiles — keep the two in sync
 const {
@@ -173,6 +173,7 @@ const coreBindings = [
 		id: 'action-tab-to-input',
 		zone: 'action',
 		keys: [ 'Tab' ],
+		modifiers: [ 'none', 'shift' ],
 		when: () => true,
 		worksDuringHelp: true,
 		handle: ( state, event ) => {
@@ -437,6 +438,7 @@ const coreBindings = [
 		id: 'input-tab-close',
 		zone: 'input',
 		keys: [ 'Tab' ],
+		modifiers: [ 'none', 'shift' ],
 		when: () => true,
 		worksDuringHelp: true,
 		handle: ( state, event ) => {
@@ -843,23 +845,13 @@ function useKeyboard( options ) {
 			}
 		}
 
-		// Ignore events with modifier keys (Shift is allowed for printable chars
-		// like @, >, :, ?). A character composed with AltGr is not a chord —
-		// that is how `@`, `~` and `#` are typed on many European layouts, and
-		// all three are mode triggers.
-		if (
-			( event.altKey || event.ctrlKey || event.metaKey ) &&
-			!isAltGraphChar( event, IS_MAC )
-		) {
-			return;
-		}
-		// Tab is exempt: it has a binding of its own, and dropping Shift+Tab
-		// here would skip that binding's preventDefault() and let the browser
-		// walk focus out of the open palette — where Escape no longer reaches
-		// it, since this handler is bound to the palette itself.
-		if ( event.shiftKey && event.key.length !== 1 && event.key !== 'Tab' ) {
-			return;
-		}
+		// One reading of the modifier state, shared by the binding lookup and
+		// by the fallbacks below. Bindings declare what they claim; anything
+		// unclaimed stays with the browser and the text field.
+		const modifiers = modifierToken( event, IS_MAC, isAltGraphChar );
+		// `none` is the only state in which a keystroke counts as typed text,
+		// which is what the fallbacks after the dispatcher all act on.
+		const isTypedText = modifiers === 'none';
 
 		const state = buildState();
 		// The actual focus zone is determined by the event target (an action
@@ -875,6 +867,7 @@ function useKeyboard( options ) {
 		// Typing with a chip selected: deselect the chip first, then let the
 		// character flow through to the dispatcher so it lands in the input.
 		if (
+			isTypedText &&
 			!state.actionsFocused &&
 			!state.helpVisible &&
 			tokens.selectedTokenIndex &&
@@ -894,7 +887,7 @@ function useKeyboard( options ) {
 		const logicalKey = MIRRORED_KEYS[ event.key ] ?
 			toLogicalKey( event.key, isRtlDirection( state.inputElement ) ) :
 			event.key;
-		const binding = resolveBinding( state, logicalKey, activeBindings.value );
+		const binding = resolveBinding( state, logicalKey, activeBindings.value, modifiers );
 		if ( binding ) {
 			binding.handle( state, event );
 			return;
@@ -902,13 +895,17 @@ function useKeyboard( options ) {
 
 		// Help-mode swallow: while the overlay is up, eat printable keys and
 		// Backspace so they neither modify input nor trigger modes/tokens.
-		if ( state.helpVisible && ( event.key.length === 1 || event.key === 'Backspace' ) ) {
+		if (
+			isTypedText && state.helpVisible &&
+			( event.key.length === 1 || event.key === 'Backspace' )
+		) {
 			event.preventDefault();
 			return;
 		}
 
 		// Action-zone fallback: typing redirects to the input field.
 		if (
+			isTypedText &&
 			state.actionsFocused &&
 			(
 				event.key.length === 1 ||
@@ -928,6 +925,7 @@ function useKeyboard( options ) {
 		// this fallback rather than relying on the help-swallow fallback above
 		// firing first.
 		if (
+			isTypedText &&
 			!state.actionsFocused &&
 			!state.helpVisible &&
 			!state.activeMode &&

--- a/resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js
@@ -1,9 +1,9 @@
 /**
  * Pure keybinding resolver for the command palette.
  *
- * A binding is data: { id, zone, keys, when, worksDuringHelp, handle, hint }.
- * Both the keydown dispatcher and the footer hints derive from the same list,
- * so a hint is visible iff its handler will fire.
+ * A binding is data: { id, zone, keys, modifiers, when, worksDuringHelp,
+ * handle, hint }. Both the keydown dispatcher and the footer hints derive from
+ * the same list, so a hint is visible iff its handler will fire.
  *
  * @typedef {Object} KeyHint
  * @property {string} msgKey i18n message key for the label.
@@ -16,11 +16,64 @@
  * @property {string[]} keys `event.key` values that trigger this binding. The
  *   two horizontal arrows are logical: the palette mirrors the physical arrow
  *   for RTL interface languages before resolving.
+ * @property {string|string[]} [modifiers='none'] Which modifier state the
+ *   binding claims, from `none`, `shift`, `accel` (Ctrl, or Command on a Mac),
+ *   `accel+shift`, or `any`. An array accepts several. Anything not named here
+ *   — an Alt chord, the Windows key — is unclaimable except via `any`, so it
+ *   stays with the browser.
  * @property {Function} when Predicate `(state) => boolean`; binding active iff true.
  * @property {boolean} [worksDuringHelp] If true, applies even when state.helpVisible.
  * @property {Function} handle Side effect `(state, event) => void`.
  * @property {KeyHint|null} [hint] Footer hint; omit/null for silent bindings.
  */
+
+/**
+ * Reduce a keyboard event to the modifier state a binding can claim.
+ *
+ * Two of these are normalisations rather than readings, and they are the point
+ * of the whole exercise: a character composed with AltGr, and a capital typed
+ * with Shift, are *typed text* rather than chords, so both report `none`. That
+ * knowledge used to live in a guard that spoke for every binding at once, which
+ * is why a plain space and a `?` picked up modifier states nobody chose.
+ *
+ * @param {KeyboardEvent} event
+ * @param {boolean} isMac
+ * @param {Function} isAltGraphChar
+ * @return {string} one of `none`, `shift`, `accel`, `accel+shift`, `other`
+ */
+function modifierToken( event, isMac, isAltGraphChar ) {
+	if ( isAltGraphChar( event, isMac ) ) {
+		return 'none';
+	}
+	const accel = isMac ? event.metaKey : event.ctrlKey;
+	// Alt on its own, and the Windows key, are nobody's to claim.
+	const foreign = event.altKey || ( isMac ? event.ctrlKey : event.metaKey );
+	// Shift only counts as a modifier on a key that produces no character —
+	// otherwise `?` and `@` would be unreachable.
+	const shift = event.shiftKey && ( event.key || '' ).length !== 1;
+	if ( foreign ) {
+		return 'other';
+	}
+	if ( accel ) {
+		return shift ? 'accel+shift' : 'accel';
+	}
+	return shift ? 'shift' : 'none';
+}
+
+/**
+ * Whether a binding claims the given modifier state.
+ *
+ * @param {KeyBinding} binding
+ * @param {string} token
+ * @return {boolean}
+ */
+function acceptsModifiers( binding, token ) {
+	const spec = binding.modifiers === undefined ? 'none' : binding.modifiers;
+	if ( spec === 'any' ) {
+		return true;
+	}
+	return Array.isArray( spec ) ? spec.includes( token ) : spec === token;
+}
 
 /**
  * Whether a binding is currently active in the given state.
@@ -47,15 +100,22 @@ function isActive( state, binding ) {
  * @param {Object} state
  * @param {string} key
  * @param {KeyBinding[]} bindings
+ * @param {string} [modifiers='none'] Modifier state from `modifierToken`.
  * @return {KeyBinding|null}
  */
-function resolveBinding( state, key, bindings ) {
+function resolveBinding( state, key, bindings, modifiers ) {
 	const zone = state.actionsFocused ? 'action' : 'input';
+	// Defaulting here matches the field's own default, so a caller that does
+	// not care is correct by construction rather than by omission.
+	const token = modifiers || 'none';
 	for ( const binding of bindings ) {
 		if ( binding.zone !== zone ) {
 			continue;
 		}
 		if ( !binding.keys.includes( key ) ) {
+			continue;
+		}
+		if ( !acceptsModifiers( binding, token ) ) {
 			continue;
 		}
 		if ( !isActive( state, binding ) ) {
@@ -101,4 +161,4 @@ function resolveHints( state, zone, bindings ) {
 	return hints;
 }
 
-module.exports = { resolveBinding, resolveHints };
+module.exports = { modifierToken, resolveBinding, resolveHints };

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -173,6 +173,7 @@
  * @property {string} id Unique binding identifier (used for debugging).
  * @property {'input'|'action'} zone Which focus zone the binding applies to.
  * @property {string[]} keys Event `key` values that fire `handle`. An empty array marks the binding as hint-only. Declare 'ArrowLeft'/'ArrowRight' logically (previous/next): the palette mirrors the physical arrow on RTL interface languages before resolving.
+ * @property {string|string[]} [modifiers='none'] Which modifier state the binding claims, from 'none', 'shift', 'accel' (Ctrl, or Command on a Mac), 'accel+shift', or 'any'. An array accepts several. A character composed with AltGr, and a capital typed with Shift, count as 'none' — they are typed text, not chords. Anything not named here stays with the browser.
  * @property {function(Object): boolean} when Predicate over the dispatch state — false suppresses both the handler and the hint.
  * @property {function(Object, KeyboardEvent)} handle Called when a `keys` entry matches and `when` passes. Should call `event.preventDefault()` to claim the keystroke.
  * @property {boolean} [worksDuringHelp] When true, the binding fires even with the help overlay open. Defaults to false.

--- a/tests/vitest/commandPalette/composables/useKeyboardBindings.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboardBindings.test.js
@@ -1,4 +1,5 @@
 const {
+	modifierToken,
 	resolveBinding,
 	resolveHints
 } = require( '../../../../resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js' );
@@ -169,5 +170,107 @@ describe( 'resolveHints', () => {
 
 		expect( hints ).toHaveLength( 1 );
 		expect( hints[ 0 ].kbd ).toBe( '↑↓' );
+	} );
+} );
+
+describe( 'modifierToken', () => {
+	const noAltGraph = () => false;
+
+	function event( overrides ) {
+		return Object.assign( {
+			key: 'a', altKey: false, ctrlKey: false, metaKey: false, shiftKey: false
+		}, overrides );
+	}
+
+	it( 'reports no modifiers for a bare key', () => {
+		expect( modifierToken( event(), false, noAltGraph ) ).toBe( 'none' );
+	} );
+
+	it( 'does not count Shift on a key that produces a character', () => {
+		// `?` is Shift+/ on a US layout; treating Shift as a modifier there
+		// would make the help shortcut unreachable.
+		expect( modifierToken( event( { key: '?', shiftKey: true } ), false, noAltGraph ) )
+			.toBe( 'none' );
+	} );
+
+	it( 'counts Shift on a key that produces no character', () => {
+		expect( modifierToken( event( { key: 'Tab', shiftKey: true } ), false, noAltGraph ) )
+			.toBe( 'shift' );
+	} );
+
+	it( 'reads the accelerator per platform', () => {
+		expect( modifierToken( event( { ctrlKey: true } ), false, noAltGraph ) ).toBe( 'accel' );
+		expect( modifierToken( event( { metaKey: true } ), true, noAltGraph ) ).toBe( 'accel' );
+		// The other one is a foreign chord on that platform.
+		expect( modifierToken( event( { metaKey: true } ), false, noAltGraph ) ).toBe( 'other' );
+		expect( modifierToken( event( { ctrlKey: true } ), true, noAltGraph ) ).toBe( 'other' );
+	} );
+
+	it( 'combines the accelerator with Shift', () => {
+		expect( modifierToken( event( { key: 'Tab', ctrlKey: true, shiftKey: true } ), false, noAltGraph ) )
+			.toBe( 'accel+shift' );
+	} );
+
+	it( 'reports an Alt chord as unclaimable', () => {
+		expect( modifierToken( event( { altKey: true } ), false, noAltGraph ) ).toBe( 'other' );
+	} );
+
+	it( 'treats an AltGr-composed character as typed text', () => {
+		// `@`, `~` and `#` are AltGr characters on European layouts, and all
+		// three are mode triggers.
+		const alwaysAltGraph = () => true;
+
+		expect( modifierToken( event( { key: '@', ctrlKey: true, altKey: true } ), false, alwaysAltGraph ) )
+			.toBe( 'none' );
+	} );
+} );
+
+describe( 'resolveBinding — modifiers', () => {
+	function binding( overrides ) {
+		return Object.assign(
+			{ id: 'b', zone: 'input', keys: [ 'Tab' ], when: () => true, handle: () => {} },
+			overrides
+		);
+	}
+
+	it( 'matches a binding with no declared policy only when none are held', () => {
+		const bindings = [ binding() ];
+
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'none' ) ).not.toBeNull();
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'shift' ) ).toBeNull();
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'accel' ) ).toBeNull();
+	} );
+
+	it( 'treats an omitted modifiers argument as none', () => {
+		expect( resolveBinding( makeState(), 'Tab', [ binding() ] ) ).not.toBeNull();
+	} );
+
+	it( 'matches a required modifier only when it is held', () => {
+		const bindings = [ binding( { keys: [ 'c' ], modifiers: 'accel' } ) ];
+
+		expect( resolveBinding( makeState(), 'c', bindings, 'accel' ) ).not.toBeNull();
+		expect( resolveBinding( makeState(), 'c', bindings, 'none' ) ).toBeNull();
+	} );
+
+	it( 'accepts any of several declared states', () => {
+		const bindings = [ binding( { modifiers: [ 'none', 'shift' ] } ) ];
+
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'none' ) ).not.toBeNull();
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'shift' ) ).not.toBeNull();
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'accel' ) ).toBeNull();
+	} );
+
+	it( 'lets a binding opt out of the policy entirely', () => {
+		const bindings = [ binding( { modifiers: 'any' } ) ];
+
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'other' ) ).not.toBeNull();
+	} );
+
+	it( 'leaves an unnameable chord to the browser', () => {
+		// `other` covers Alt chords and the Windows key; nothing but `any` can
+		// claim one, so they stay with the browser and the text field.
+		const bindings = [ binding( { modifiers: [ 'none', 'shift', 'accel', 'accel+shift' ] } ) ];
+
+		expect( resolveBinding( makeState(), 'Tab', bindings, 'other' ) ).toBeNull();
 	} );
 } );

--- a/tests/vitest/commandPalette/composables/useKeyboardModifiers.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboardModifiers.test.js
@@ -84,6 +84,7 @@ describe( 'dispatcher modifier policy', () => {
 			onClose: vi.fn(),
 			onClearQuery: vi.fn(),
 			onEnterMode: vi.fn(),
+			onToggleHelp: vi.fn(),
 			highlightNext: vi.fn(),
 			clickFocused: vi.fn(),
 			deactivate: vi.fn(),
@@ -121,6 +122,11 @@ describe( 'dispatcher modifier policy', () => {
 					deactivate: spies.deactivate,
 					clickFocused: spies.clickFocused
 				}
+			},
+			help: {
+				helpVisible: ref( false ),
+				onToggleHelp: spies.onToggleHelp,
+				onCloseHelp: vi.fn()
 			},
 			mode: {
 				activeMode: ref( null ),
@@ -167,7 +173,33 @@ describe( 'dispatcher modifier policy', () => {
 
 		// Typing in the action zone redirects to the input.
 		[ 'a', 'none', 'action', 'deactivate' ],
-		[ 'a', 'ctrl', 'action', 'ignored' ]
+		[ 'a', 'ctrl', 'action', 'ignored' ],
+		[ 'Tab', 'none', 'action', 'deactivate (claimed)' ],
+
+		// `?` is Shift+/ on a US layout, so Shift must not suppress it.
+		[ '?', 'none', 'input', 'onToggleHelp (claimed)' ],
+		[ '?', 'shift', 'input', 'onToggleHelp (claimed)' ],
+
+		// Chords belong to the browser and the text field.
+		[ 'Tab', 'ctrl', 'input', 'ignored' ],
+		[ 'Home', 'shift', 'input', 'ignored' ],
+		[ 'End', 'shift', 'input', 'ignored' ],
+		[ 'ArrowLeft', 'shift', 'input', 'ignored' ],
+		[ 'ArrowLeft', 'alt', 'input', 'ignored' ],
+		[ 'ArrowLeft', 'ctrl', 'input', 'ignored' ],
+		[ 'Enter', 'shift', 'input', 'ignored' ],
+		[ 'Enter', 'meta', 'input', 'ignored' ],
+		[ 'Backspace', 'ctrl', 'input', 'ignored' ],
+		[ '@', 'meta', 'input', 'ignored' ],
+
+		// Two rows that record a defect rather than an intention. The guards
+		// classify by key shape, not by what the binding wants, so a real chord
+		// reaches a binding that only ever meant to claim a bare key.
+		// `Ctrl+Alt+?` is not AltGr on a US layout — it is a chord.
+		[ '?', 'altgr', 'input', 'onToggleHelp (claimed)' ],
+		// `action-select` lists `Enter` and `' '` together; the space picks up
+		// Shift because Guard B exempts single-character keys.
+		[ ' ', 'shift', 'action', 'clickFocused (claimed)' ]
 	];
 
 	TABLE.forEach( ( [ key, modifiers, zone, expected ] ) => {

--- a/tests/vitest/commandPalette/composables/useKeyboardModifiers.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboardModifiers.test.js
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+/**
+ * Characterisation table for the dispatcher's modifier policy.
+ *
+ * Which (key, modifier) combinations reach a binding is currently decided by
+ * two blanket guards in `handleKeydown` rather than by the bindings themselves,
+ * so the policy is invisible from the registry and has produced three bugs:
+ * Ctrl+Alt+Space clicking the focused action, Shift+Tab escaping the palette,
+ * and the copy chord needing to be hoisted above the guards entirely.
+ *
+ * This file pins the resulting behaviour as a table. It is deliberately about
+ * observable outcomes — which callback fired, whether the keystroke was claimed
+ * — so it survives a change in how the policy is expressed and fails only if
+ * what the user experiences changes.
+ */
+
+const mw = require( '../../mocks/mw.js' );
+globalThis.mw = mw;
+
+const { ref } = require( 'vue' );
+const useKeyboard = require(
+	'../../../../resources/skins.citizen.commandPalette/composables/useKeyboard.js'
+);
+
+const MODIFIER_SETS = {
+	none: {},
+	shift: { shiftKey: true },
+	ctrl: { ctrlKey: true },
+	alt: { altKey: true },
+	meta: { metaKey: true },
+	// Windows delivers AltGr as Ctrl+Alt; several layouts type `@`, `~` and `#`
+	// — all mode triggers — that way.
+	altgr: { ctrlKey: true, altKey: true }
+};
+
+describe( 'dispatcher modifier policy', () => {
+	let spies;
+	let deps;
+	let keyboard;
+
+	/**
+	 * Dispatch one key in one zone and report what the palette did, as a
+	 * stable signature.
+	 *
+	 * @param {string} key
+	 * @param {string} modifierSet
+	 * @param {string} zone 'input' or 'action'
+	 * @return {string}
+	 */
+	function outcome( key, modifierSet, zone ) {
+		Object.values( spies ).forEach( ( spy ) => spy.mockClear() );
+		const actionTarget = {
+			closest: vi.fn( ( selector ) => (
+				selector === '.citizen-command-palette-list-item__action' ? actionTarget : null
+			) )
+		};
+		const inputTarget = { closest: vi.fn( () => null ) };
+		const event = Object.assign( {
+			key,
+			target: zone === 'action' ? actionTarget : inputTarget,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			shiftKey: false,
+			getModifierState: vi.fn( () => false )
+		}, MODIFIER_SETS[ modifierSet ] );
+
+		keyboard.handleKeydown( event );
+
+		const fired = Object.keys( spies ).filter( ( name ) => spies[ name ].mock.calls.length > 0 );
+		if ( !fired.length ) {
+			return event.preventDefault.mock.calls.length ? 'claimed' : 'ignored';
+		}
+		return fired.sort().join( '+' ) +
+			( event.preventDefault.mock.calls.length ? ' (claimed)' : '' );
+	}
+
+	beforeEach( () => {
+		spies = {
+			onSelect: vi.fn(),
+			onClose: vi.fn(),
+			onClearQuery: vi.fn(),
+			onEnterMode: vi.fn(),
+			highlightNext: vi.fn(),
+			clickFocused: vi.fn(),
+			deactivate: vi.fn(),
+			focusFirst: vi.fn(),
+			requestHeaderCopy: vi.fn()
+		};
+
+		deps = {
+			core: {
+				inputRef: ref( { focus: vi.fn(), closest: vi.fn( () => null ) } ),
+				itemRefs: ref( new Map() ),
+				items: ref( [ { id: '1', actions: [ { id: 'edit' } ] } ] ),
+				query: ref( '' ),
+				requestHeaderCopy: spies.requestHeaderCopy,
+				onSelect: spies.onSelect,
+				onClose: spies.onClose,
+				onClearQuery: spies.onClearQuery
+			},
+			navigation: {
+				listNav: {
+					highlightedIndex: ref( 0 ),
+					highlightNext: spies.highlightNext,
+					highlightPrevious: vi.fn(),
+					highlightFirst: vi.fn(),
+					highlightLast: vi.fn(),
+					resetHighlight: vi.fn(),
+					scrollToHighlighted: vi.fn()
+				},
+				actionNav: {
+					isActive: ref( true ),
+					focusedIndex: ref( 0 ),
+					focusFirst: spies.focusFirst,
+					focusNext: vi.fn(),
+					focusPrevious: vi.fn(),
+					deactivate: spies.deactivate,
+					clickFocused: spies.clickFocused
+				}
+			},
+			mode: {
+				activeMode: ref( null ),
+				activeModeContext: ref( [] ),
+				findModeByTrigger: vi.fn( ( char ) => ( char === '@' ? { id: 'user' } : null ) ),
+				onEnterMode: spies.onEnterMode,
+				onExitMode: vi.fn(),
+				onPopModeContext: vi.fn()
+			}
+		};
+		keyboard = useKeyboard( deps );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	// Each row: [ key, modifiers, zone, expected outcome ].
+	// Read this as "what a user pressing that combination gets today".
+	const TABLE = [
+		// Bare keys do what the registry says.
+		[ 'Enter', 'none', 'input', 'onSelect (claimed)' ],
+		[ 'Escape', 'none', 'input', 'onClose (claimed)' ],
+		[ 'ArrowDown', 'none', 'input', 'highlightNext (claimed)' ],
+		[ 'Tab', 'none', 'input', 'onClose (claimed)' ],
+		[ ' ', 'none', 'action', 'clickFocused (claimed)' ],
+
+		// A command modifier suppresses them.
+		[ 'Enter', 'ctrl', 'input', 'ignored' ],
+		[ 'ArrowDown', 'ctrl', 'input', 'ignored' ],
+		[ 'ArrowDown', 'meta', 'input', 'ignored' ],
+		[ 'Escape', 'alt', 'input', 'ignored' ],
+
+		// Shift is allowed only for printable characters, plus Tab by exception.
+		[ 'ArrowDown', 'shift', 'input', 'ignored' ],
+		[ 'Tab', 'shift', 'input', 'onClose (claimed)' ],
+		[ '@', 'shift', 'input', 'onEnterMode (claimed)' ],
+
+		// AltGr composes printable characters, so it is not a chord — but a
+		// plain space is excluded, or Ctrl+Alt+Space clicks the focused action.
+		[ '@', 'altgr', 'input', 'onEnterMode (claimed)' ],
+		[ ' ', 'altgr', 'action', 'ignored' ],
+		[ 'ArrowDown', 'altgr', 'input', 'ignored' ],
+
+		// Typing in the action zone redirects to the input.
+		[ 'a', 'none', 'action', 'deactivate' ],
+		[ 'a', 'ctrl', 'action', 'ignored' ]
+	];
+
+	TABLE.forEach( ( [ key, modifiers, zone, expected ] ) => {
+		const label = `${ modifiers === 'none' ? '' : modifiers + '+' }${ key === ' ' ? 'Space' : key }`;
+		it( `${ label } in the ${ zone } zone → ${ expected }`, () => {
+			expect( outcome( key, modifiers, zone ) ).toBe( expected );
+		} );
+	} );
+
+	it( 'claims the copy chord only when the highlighted item offers a value', () => {
+		deps.core.items = ref( [
+			{ id: '1', detail: { header: { copyValue: 'File:Foo.png' } } }
+		] );
+		keyboard = useKeyboard( deps );
+
+		expect( outcome( 'c', 'ctrl', 'input' ) ).toBe( 'requestHeaderCopy (claimed)' );
+		// Without the value there is nothing to copy, so the browser keeps it.
+		deps.core.items = ref( [ { id: '1' } ] );
+		keyboard = useKeyboard( deps );
+
+		expect( outcome( 'c', 'ctrl', 'input' ) ).toBe( 'ignored' );
+	} );
+} );


### PR DESCRIPTION
Refs #1743.

## Problem

`resolveBinding` matched on `event.key` and focus zone only, so every modifier decision was made by two blanket guards in `handleKeydown` that spoke for all 34 bindings at once.

Which modifier state could reach a binding was therefore a pure function of the **key string's shape** — its length, whether it was `' '`, whether it was literally `'Tab'` — with no input from the binding:

| Key shape | Reachable with |
| --- | --- |
| `key.length > 1`, not `Tab` | bare only — 18 bindings |
| `key === 'Tab'` | bare, Shift — via a string literal in the guard |
| `key === ' '` | bare, Shift — because the guard exempts single-character keys |
| `key.length === 1` | bare, Shift, and the whole AltGr family |

Two bindings happened to get the right answer for unrelated reasons, and neither said anything. That produced three bugs in as many weeks — `Ctrl+Alt+Space` clicking the focused action, `Shift+Tab` escaping the palette, and the copy chord being hoisted above the guards because "requires the accelerator" was unrepresentable.

## Change

Bindings declare what they claim:

```js
{ id: 'input-tab-close', keys: [ 'Tab' ], modifiers: [ 'none', 'shift' ], … }
```

`none` (the default), `shift`, `accel` (Ctrl, or Command on a Mac), `accel+shift`, or `any`. **31 of the 34 entries take the default and are untouched.**

The event is read once into a single modifier state that both the lookup and everything after it consults. Two normalisations carry the knowledge the guards used to hold: a character composed with AltGr, and a capital typed with Shift, are *typed text* rather than chords. Keeping those in one place is what stops a `?` or a space from acquiring a policy nobody chose.

The four fallbacks after the dispatcher — the help-overlay swallow, the action-zone typing redirect, the mode-trigger lookup, and token deselection — previously inherited their protection from the guards by accident. Each now states that it acts on typed text.

## Verification

**The behaviour is unchanged, and that is the claim under test.** The first two commits add a 33-row characterisation table that pins today's policy as observable outcomes — which callback fired, whether the keystroke was claimed — and it passes as-is against the refactor. Removing the new matching step fails those rows, so they are guarding real behaviour rather than restating the implementation.

- 1233 tests; eslint, stylelint and markdownlint clean.
- Browser: palette smoke across empty / typed / arrow-navigated / help / mode / gallery states, `aria-expanded` still tracking listbox presence in all eight, and the 10-case keyboard layout matrix from #1731 still passing. Console clean.

## Two latent bugs found, both left as-is deliberately

The analysis turned up two more combinations the guards admit by accident. Both are recorded as marked rows in the table rather than silently fixed:

- **`Ctrl+Alt+?` toggles the help overlay.** On a US layout that is a chord, not AltGr — but Windows delivers AltGr *as* Ctrl+Alt, so the two are genuinely indistinguishable. Fixing it would break AltGr users to satisfy a chord nobody presses. The tradeoff belongs to `isAltGraphChar`, not here.
- **`Shift+Space` activates the focused action.** Shift+Space does type a space, so treating it as typed text is consistent; the outcome is harmless.

## Scope

This closes the guard problem. It does **not** move the Cmd/Ctrl+C copy shortcut into a binding, even though `modifiers: 'accel'` now makes that expressible — the copy chord additionally matches its letter layout-aware (so it works on Cyrillic and Greek keyboards), which needs the resolver to normalise non-Latin letters under a chord. That is a second design decision and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for modifier-aware command-palette keybindings, including Shift, Alt, Ctrl, Meta, AltGr, and key combinations.
  * Added flexible binding declarations for single or multiple modifier states.
  * Improved handling of typed characters, keyboard shortcuts, Tab navigation, and platform-specific inputs.

* **Documentation**
  * Documented modifier configuration and keyboard shortcut behavior.

* **Tests**
  * Added comprehensive coverage for modifier detection, binding resolution, and keyboard dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->