### PR TITLE
fix(commandPalette): recognize namespace aliases when tagging a search

### DIFF
--- a/resources/skins.citizen.commandPalette/modes/namespace.js
+++ b/resources/skins.citizen.commandPalette/modes/namespace.js
@@ -14,6 +14,12 @@ const MAIN_NAMESPACE_ID = '0';
 let cachedNamespaceEntries = null;
 
 /**
+ * Cached lookup of every name a namespace answers to, keyed by that name.
+ * Lazily populated on first use from wgFormattedNamespaces and wgNamespaceIds.
+ */
+let cachedNamespaceIndex = null;
+
+/**
  * Returns namespace entries from MediaWiki config, excluding the main namespace.
  * Results are cached after the first call.
  *
@@ -27,6 +33,45 @@ function getNamespaceEntries() {
 			.map( ( [ id, name ] ) => ( { id, name } ) );
 	}
 	return cachedNamespaceEntries;
+}
+
+/**
+ * Normalizes a namespace name so that names differing only in case, or in
+ * spaces versus underscores, compare equal — MediaWiki treats `Template`,
+ * `template` and `User_talk` / `User talk` as the same name.
+ *
+ * @param {string} name
+ * @return {string}
+ */
+function normalizeNamespaceName( name ) {
+	return name.replace( / /g, '_' ).toLowerCase();
+}
+
+/**
+ * Returns every name that resolves to a namespace, keyed by normalized name.
+ *
+ * wgNamespaceIds is MediaWiki's own name-to-ID table and carries the whole set:
+ * the wiki's names, the canonical English ones, and every alias (`T`, `CAT`,
+ * `Image`). The display names are seeded first so the lookup still degrades to
+ * the pre-alias behaviour if that config is ever unavailable, and because
+ * wgNamespaceIds is applied second it wins wherever the two disagree.
+ *
+ * Results are cached after the first call.
+ *
+ * @return {Map<string, string>} Normalized name to namespace ID.
+ */
+function getNamespaceIndex() {
+	if ( !cachedNamespaceIndex ) {
+		cachedNamespaceIndex = new Map();
+		getNamespaceEntries().forEach( ( entry ) => {
+			cachedNamespaceIndex.set( normalizeNamespaceName( entry.name ), entry.id );
+		} );
+		const namespaceIds = mw.config.get( 'wgNamespaceIds' ) || {};
+		Object.entries( namespaceIds ).forEach( ( [ name, id ] ) => {
+			cachedNamespaceIndex.set( normalizeNamespaceName( name ), String( id ) );
+		} );
+	}
+	return cachedNamespaceIndex;
 }
 
 /**
@@ -67,8 +112,6 @@ function getNamespaceResults( subQuery ) {
 		value: entry.id
 	} ) );
 
-	const lowerQuery = subQuery.toLowerCase();
-
 	// Combine results using a Map to handle duplicates based on namespace ID (value)
 	const combinedResults = new Map();
 
@@ -76,17 +119,37 @@ function getNamespaceResults( subQuery ) {
 		// If the query is empty, return all namespaces
 		allNamespaces.forEach( ( ns ) => combinedResults.set( ns.value, ns ) );
 	} else {
-		// If query is not empty, filter by label and ID prefixes
-		allNamespaces.forEach( ( ns ) => {
-			// Check label prefix (case-insensitive)
-			if ( ns.label.toLowerCase().startsWith( lowerQuery ) ) {
-				combinedResults.set( ns.value, ns );
-			}
-			// Check ID prefix (case-sensitive)
-			if ( ns.value.startsWith( subQuery ) ) {
-				combinedResults.set( ns.value, ns );
+		// Namespaces with any name matching the query, so "cat" finds Category
+		// and "image" finds File. Resolved to IDs up front, in one pass over the
+		// index, because the loop below runs per namespace and this runs on
+		// every keystroke.
+		const normalizedQuery = normalizeNamespaceName( subQuery );
+		const matchedIds = new Set();
+		getNamespaceIndex().forEach( ( id, name ) => {
+			if ( name.startsWith( normalizedQuery ) ) {
+				matchedIds.add( id );
 			}
 		} );
+
+		// Namespaces the query visibly resembles go first, then the ones it only
+		// reached through an alias. Every wiki carries the canonical English
+		// names, so without the split a renamed namespace would take the top row
+		// -- and the default Enter target -- from a namespace whose own name
+		// starts with what was typed.
+		const aliasedOnly = [];
+		allNamespaces.forEach( ( ns ) => {
+			if (
+				// Check name prefix (case, space and underscore insensitive)
+				normalizeNamespaceName( ns.label ).startsWith( normalizedQuery ) ||
+				// Check ID prefix (case-sensitive)
+				ns.value.startsWith( subQuery )
+			) {
+				combinedResults.set( ns.value, ns );
+			} else if ( matchedIds.has( ns.value ) ) {
+				aliasedOnly.push( ns );
+			}
+		} );
+		aliasedOnly.forEach( ( ns ) => combinedResults.set( ns.value, ns ) );
 	}
 
 	const results = Array.from( combinedResults.values(), adaptNamespaceResult );
@@ -95,22 +158,33 @@ function getNamespaceResults( subQuery ) {
 
 /**
  * Matches a known namespace prefix at the start of the given text.
- * Uses wgFormattedNamespaces from MediaWiki config, excluding the main namespace.
+ *
+ * The candidate is the text before the first colon, resolved through the
+ * namespace index, so aliases ("T:", "CAT:") and canonical English names are
+ * recognised alongside the names the wiki shows in page titles.
  *
  * @param {string} text The input text to check.
  * @return {{ label: string, raw: string } | null} Match result or null.
  */
 function matchNamespacePrefix( text ) {
-	const lowerText = text.toLowerCase();
-
-	for ( const entry of getNamespaceEntries() ) {
-		const prefix = entry.name.toLowerCase() + ':';
-		if ( lowerText.startsWith( prefix ) ) {
-			return { label: entry.name + ':', raw: entry.name + ':' };
-		}
+	const colonIndex = text.indexOf( ':' );
+	if ( colonIndex < 1 ) {
+		// No colon, or a leading colon, which is the main namespace.
+		return null;
 	}
 
-	return null;
+	const id = getNamespaceIndex().get( normalizeNamespaceName( text.slice( 0, colonIndex ) ) );
+	if ( id === undefined || id === MAIN_NAMESPACE_ID ) {
+		return null;
+	}
+
+	// `raw` is exactly the text that was consumed — the tokenizer strips it off
+	// the input by length, and removing the tag types it back. That leaves
+	// `label` free to carry the display name, so typing an alias shows the
+	// namespace it resolved to.
+	const raw = text.slice( 0, colonIndex + 1 );
+	const name = ( mw.config.get( 'wgFormattedNamespaces' ) || {} )[ id ];
+	return { label: name ? `${ name }:` : raw, raw };
 }
 
 /** @type {PaletteMode} */

--- a/tests/vitest/commandPalette/composables/useTokenizedInput.test.js
+++ b/tests/vitest/commandPalette/composables/useTokenizedInput.test.js
@@ -374,7 +374,17 @@ describe( 'useTokenizedInput', () => {
 						1: 'Talk',
 						2: 'User',
 						3: 'User talk',
-						4: 'Project'
+						10: 'Template'
+					};
+				}
+				if ( key === 'wgNamespaceIds' ) {
+					return {
+						'': 0,
+						talk: 1,
+						user: 2,
+						user_talk: 3,
+						template: 10,
+						t: 10
 					};
 				}
 				return null;
@@ -418,6 +428,30 @@ describe( 'useTokenizedInput', () => {
 			expect( ti.tokens.value ).toHaveLength( 1 );
 			expect( ti.tokens.value[ 0 ].label ).toBe( 'User talk:' );
 			expect( ti.freeText.value ).toBe( 'SomePage' );
+		} );
+
+		it( 'should tag an alias with the canonical name and keep the rest of the query', () => {
+			const ti = useTokenizedInput( () => [ namespaceMode.tokenPattern ] );
+
+			ti.setFreeText( 'T:Infobox' );
+
+			expect( ti.tokens.value ).toHaveLength( 1 );
+			expect( ti.tokens.value[ 0 ].label ).toBe( 'Template:' );
+			expect( ti.freeText.value ).toBe( 'Infobox' );
+			expect( ti.fullQuery.value ).toBe( 'T:Infobox' );
+		} );
+
+		it( 'should restore the alias the user typed when the tag is removed', () => {
+			const ti = useTokenizedInput( () => [ namespaceMode.tokenPattern ] );
+			ti.setFreeText( 'T:Infobox' );
+			const token = ti.tokens.value[ 0 ];
+
+			// Mirrors what App.vue does when a tag is turned back into text
+			ti.removeToken( 0 );
+			ti.setFreeText( token.raw + ti.freeText.value );
+
+			expect( ti.tokens.value ).toHaveLength( 0 );
+			expect( ti.freeText.value ).toBe( 'T:Infobox' );
 		} );
 
 		it( 'should not match unknown namespace prefixes', () => {

--- a/tests/vitest/commandPalette/modes/namespace.test.js
+++ b/tests/vitest/commandPalette/modes/namespace.test.js
@@ -9,13 +9,42 @@ beforeEach( () => {
 	mw.config.get = vi.fn( ( key ) => {
 		if ( key === 'wgFormattedNamespaces' ) {
 			return {
+				'-2': 'Media',
+				'-1': 'Special',
 				0: '',
 				1: 'Talk',
 				2: 'User',
 				3: 'User talk',
+				4: 'My Wiki',
 				6: 'File',
 				10: 'Template',
-				14: 'Category'
+				14: 'Category',
+				100: 'Portal'
+			};
+		}
+		// Mirrors what MediaWiki exposes: localised names, canonical English
+		// names and aliases, lower-cased. Modelled on a wiki that renamed its
+		// project namespace and defined the usual T and CAT aliases.
+		if ( key === 'wgNamespaceIds' ) {
+			return {
+				media: -2,
+				special: -1,
+				'': 0,
+				// A $wgNamespaceAliases entry pointing at the main namespace.
+				main: 0,
+				talk: 1,
+				user: 2,
+				user_talk: 3,
+				// $wgMetaNamespace written with a space keys with a space too.
+				'my wiki': 4,
+				project: 4,
+				file: 6,
+				image: 6,
+				template: 10,
+				t: 10,
+				category: 14,
+				cat: 14,
+				portal: 100
 			};
 		}
 		return null;
@@ -105,10 +134,58 @@ describe( 'namespace mode', () => {
 			} );
 		} );
 
+		it( 'should filter by an alias that shares no prefix with the label', async () => {
+			const results = await namespaceMode.getResults( 'image' );
+
+			expect( results.map( ( r ) => r.label ) ).toEqual( [ 'File' ] );
+		} );
+
+		it( 'should filter by the canonical name of a renamed namespace', async () => {
+			const results = await namespaceMode.getResults( 'project' );
+
+			expect( results.map( ( r ) => r.label ) ).toEqual( [ 'My Wiki' ] );
+		} );
+
+		it( 'should list a namespace once when its label and an alias both match', async () => {
+			const results = await namespaceMode.getResults( 'cat' );
+
+			expect( results.map( ( r ) => r.label ) ).toEqual( [ 'Category' ] );
+		} );
+
+		it( 'should filter by a name written with underscores', async () => {
+			const results = await namespaceMode.getResults( 'user_t' );
+
+			expect( results.map( ( r ) => r.label ) ).toEqual( [ 'User talk' ] );
+		} );
+
+		it( 'should list namespaces named after the query before ones only aliased to it', async () => {
+			// "project" is a canonical name every wiki carries, so on this wiki
+			// it points at My Wiki (4) — which must not outrank Portal (100).
+			const results = await namespaceMode.getResults( 'p' );
+
+			expect( results.map( ( r ) => r.label ) ).toEqual( [ 'Portal', 'My Wiki' ] );
+		} );
+
 		it( 'should return empty array when no namespaces match', async () => {
 			const results = await namespaceMode.getResults( 'zzz' );
 
 			expect( results ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'a namespace whose configured name contains spaces', () => {
+		// MediaWiki keys such a name with the space intact, so it only lines up
+		// with the name on the row once both sides are normalized.
+		it( 'should still be found by that name', async () => {
+			const results = await namespaceMode.getResults( 'my w' );
+
+			expect( results.map( ( r ) => r.label ) ).toEqual( [ 'My Wiki' ] );
+		} );
+
+		it( 'should still be tagged by that name', () => {
+			const result = namespaceMode.tokenPattern.match( 'My Wiki:About' );
+
+			expect( result ).toEqual( { label: 'My Wiki:', raw: 'My Wiki:' } );
 		} );
 	} );
 
@@ -119,10 +196,44 @@ describe( 'namespace mode', () => {
 			expect( result ).toEqual( { label: 'Talk:', raw: 'Talk:' } );
 		} );
 
-		it( 'should match case-insensitively', () => {
+		it( 'should match case-insensitively and label with the canonical name', () => {
 			const result = namespaceMode.tokenPattern.match( 'file:image.png' );
 
-			expect( result ).toEqual( { label: 'File:', raw: 'File:' } );
+			expect( result ).toEqual( { label: 'File:', raw: 'file:' } );
+		} );
+
+		it( 'should match a namespace alias', () => {
+			const result = namespaceMode.tokenPattern.match( 'T:Infobox' );
+
+			expect( result ).toEqual( { label: 'Template:', raw: 'T:' } );
+		} );
+
+		it( 'should match an alias longer than its namespace name', () => {
+			const result = namespaceMode.tokenPattern.match( 'Image:Example.png' );
+
+			expect( result ).toEqual( { label: 'File:', raw: 'Image:' } );
+		} );
+
+		it( 'should match a canonical English name for a renamed namespace', () => {
+			const result = namespaceMode.tokenPattern.match( 'Project:About' );
+
+			expect( result ).toEqual( { label: 'My Wiki:', raw: 'Project:' } );
+		} );
+
+		it( 'should match a name written with underscores', () => {
+			const result = namespaceMode.tokenPattern.match( 'User_talk:Example' );
+
+			expect( result ).toEqual( { label: 'User talk:', raw: 'User_talk:' } );
+		} );
+
+		it( 'should consume only the text the user typed', () => {
+			// An alias is a different length from the namespace it resolves to,
+			// so the tokenizer would eat or strand text if `raw` were the label.
+			const shorter = namespaceMode.tokenPattern.match( 'CAT:Cities' );
+			const longer = namespaceMode.tokenPattern.match( 'Image:Example.png' );
+
+			expect( 'CAT:Cities'.slice( shorter.raw.length ) ).toBe( 'Cities' );
+			expect( 'Image:Example.png'.slice( longer.raw.length ) ).toBe( 'Example.png' );
 		} );
 
 		it( 'should return null for unknown prefixes', () => {
@@ -137,8 +248,37 @@ describe( 'namespace mode', () => {
 			expect( result ).toBeNull();
 		} );
 
+		it( 'should match a namespace outside the article space', () => {
+			expect( namespaceMode.tokenPattern.match( 'Special:Search' ) )
+				.toEqual( { label: 'Special:', raw: 'Special:' } );
+			expect( namespaceMode.tokenPattern.match( 'Media:Clip.ogg' ) )
+				.toEqual( { label: 'Media:', raw: 'Media:' } );
+		} );
+
 		it( 'should not match main namespace (empty string)', () => {
 			const result = namespaceMode.tokenPattern.match( ':something' );
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'should not match an alias of the main namespace', () => {
+			const result = namespaceMode.tokenPattern.match( 'Main:something' );
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'should not match names inherited from Object.prototype', () => {
+			// The lookup key is user input, so a plain-object lookup would tag
+			// these as namespaces.
+			for ( const text of [ 'constructor:x', '__proto__:x', 'Constructor:x' ] ) {
+				expect( namespaceMode.tokenPattern.match( text ) ).toBeNull();
+			}
+		} );
+
+		it( 'should not match a prefix MediaWiki would not resolve either', () => {
+			// MediaWiki turns spaces into underscores before resolving, so a
+			// stray space next to the colon is not a namespace prefix.
+			const result = namespaceMode.tokenPattern.match( 'Talk :something' );
 
 			expect( result ).toBeNull();
 		} );


### PR DESCRIPTION
Closes #1730

## Problem

The palette turns a namespace prefix into a filter tag, but it only recognised the name a namespace shows in page titles. Every other name the wiki accepts was ignored, so on a wiki with the usual aliases `Template:` produced a tag while `T:` did not — even though the search backend resolves both identically.

## Behaviour

Namespace names now resolve the way the wiki resolves them, so aliases (`T:`, `CAT:`, `Image:`) and the canonical English names (`Project:` on a wiki that renamed its project namespace) all produce a tag. The tag shows the namespace the name resolved to, not the name that was typed — type `CAT:` and you get a `Category:` tag.

The `/ns:` suggestion list matches those names too, so `image` finds File. Namespaces the query actually spells are listed before ones it only reached through an alias: every wiki carries the canonical English names, so without that split a renamed namespace would quietly take the top row — and the default <kbd>Enter</kbd> target — from a namespace whose own name starts with what was typed.

## Contract

A token's `raw` is now the text the user typed rather than the namespace's display name. The tokenizer strips a match off the input by `raw.length` and putting a tag back into text re-inserts `raw`, so `raw` has to be exactly what was consumed. That was invisible before because case-folding preserves length; an alias does not, and `CAT:Cities` with a `Category:` raw would have eaten `Cities`. `label` carries the display name instead — the two fields were already independent.

Prefixes are matched the way `SearchEngine::parseNamespacePrefixes` does: text before the first colon, spaces to underscores, case-folded. Deliberately no more lenient than that — a prefix the backend would refuse must not get a tag that promises a filter it will not apply.

## Testing

Covers aliases shorter and longer than the name they resolve to, canonical names, underscore forms, multi-word names, the suggestion-list ordering, and the previously untested main-namespace and prototype-chain edges.

Smoke-tested against a local wiki with `T` and `CAT` aliases: tags resolve, results are namespace-scoped, backspacing a tag restores the typed alias, and canonical prefixes are unchanged.

## Follow-ups

None required. The help string could mention that aliases work, purely for discoverability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved namespace search to recognize canonical names and aliases.
  * Added case-insensitive matching with support for spaces and underscores.
  * Prioritized direct namespace matches over alias-only matches.
  * Preserved the original namespace prefix as entered by the user.

* **Bug Fixes**
  * Improved namespace token labeling and restoration when aliases are removed.
  * Added safer handling for special namespaces, invalid prefixes, and main-namespace aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->