### PR TITLE
fix(notifications): show notifications from other wikis

### DIFF
--- a/resources/skins.citizen.notifications/components/App.vue
+++ b/resources/skins.citizen.notifications/components/App.vue
@@ -191,8 +191,10 @@ module.exports = exports = defineComponent( {
 			() => itemsForSection( SECTION_BY_TAB[ activeTab.value ] )
 		);
 
+		// Summary rows are permanently unread and cannot be cleared from here,
+		// so they must not keep the mark-all button enabled forever.
 		const hasUnreadInScope = computed(
-			() => visibleItems.value.some( ( item ) => !item.read )
+			() => visibleItems.value.some( ( item ) => !item.read && !item.isSummary )
 		);
 
 		function reportCounts() {
@@ -206,10 +208,14 @@ module.exports = exports = defineComponent( {
 		function recountFromItems() {
 			const next = { alert: 0, message: 0, total: 0 };
 			items.value.forEach( ( item ) => {
-				if ( !item.read ) {
-					next[ item.section ] += 1;
-					next.total += 1;
-				}
+				// A summary row stands for unread notifications elsewhere.
+				// Nothing in this panel can clear those, so carry its count
+				// through untouched — otherwise the first local mark-read would
+				// drop the badge to a local-only figure and start disagreeing
+				// with the count the server renders.
+				const unread = item.isSummary ? item.count : ( item.read ? 0 : 1 );
+				next[ item.section ] += unread;
+				next.total += unread;
 			} );
 			counts.value = next;
 			reportCounts();
@@ -273,7 +279,9 @@ module.exports = exports = defineComponent( {
 			// refresh() refetches authoritative state).
 			source.markAllRead( section ).catch( () => {} );
 			visibleItems.value.forEach( ( item ) => {
-				item.read = true;
+				if ( !item.isSummary ) {
+					item.read = true;
+				}
 			} );
 			recountFromItems();
 		}

--- a/resources/skins.citizen.notifications/components/NotificationItem.vue
+++ b/resources/skins.citizen.notifications/components/NotificationItem.vue
@@ -144,9 +144,13 @@ module.exports = exports = defineComponent( {
 		 * clicked); the click bubbles here either way.
 		 */
 		function onClick() {
-			if ( !props.item.read ) {
-				emit( 'read', props.item.id );
+			// A summary row has no backend id and stands for notifications this
+			// panel cannot clear, so it is never marked read. The stretched
+			// link still navigates.
+			if ( props.item.isSummary || props.item.read ) {
+				return;
 			}
+			emit( 'read', props.item.id );
 		}
 
 		return { formattedTime, plainHeader, actionButtonClass: ACTION_BUTTON_CLASS, onClick };

--- a/resources/skins.citizen.notifications/sources/echo.js
+++ b/resources/skins.citizen.notifications/sources/echo.js
@@ -8,9 +8,15 @@
  *     id, section: 'alert'|'message', category, categoryLabel,
  *     read, timestamp (unix seconds), iconUrl,
  *     header (escaped HTML), body (escaped HTML),
- *     primaryUrl, secondaryLinks: [ { url, label } ]
+ *     primaryUrl, secondaryLinks: [ { url, label } ],
+ *     isSummary, count   // summary rows only; absent on real notifications
  *   }
  *   FetchResult { items: NotificationItem[], counts: { alert, message, total } }
+ *
+ * A summary row stands for unread notifications the user has somewhere else
+ * rather than for one notification here — today, Echo's cross-wiki roll-up. It
+ * carries no backend id, cannot be marked read, and `count` is how many
+ * notifications it speaks for.
  *
  * Category labels (`categoryLabel`) are resolved from the wiki's
  * echo-category-title-<key> messages, fetched in the same request via
@@ -27,6 +33,12 @@
 
 const SECTIONS = [ 'alert', 'message' ];
 const CATEGORY_TITLE_PREFIX = 'echo-category-title-';
+
+// Echo's synthetic "you have unread notifications on other wikis" row, one per
+// requested section. It is not a real notification — no primary link, no read
+// state, and every section's row carries the same id — so it is normalized
+// separately rather than run through normalizeEntry().
+const SUMMARY_TYPE = 'foreign';
 
 /**
  * Normalize one Echo list entry (notformat=model) into a backend-neutral
@@ -66,6 +78,67 @@ function normalizeEntry( entry, section, labels ) {
 }
 
 /**
+ * Link target for a cross-wiki summary. Echo hands back each wiki's article
+ * path with a `$1` placeholder; anything not shaped like that falls back to the
+ * local special page, which is the only surface with a cross-wiki view.
+ *
+ * @param {Object} source `sources` entry for one wiki
+ * @return {string}
+ */
+function foreignNotificationsUrl( source ) {
+	const base = ( source && source.base ) || '';
+	if ( !/^https?:\/\/\S*\$1/.test( base ) ) {
+		return mw.util.getUrl( 'Special:Notifications' );
+	}
+	// split/join rather than replace: '$1' is special in a replacement string.
+	return base.split( '$1' ).join( 'Special:Notifications' );
+}
+
+/**
+ * Normalize Echo's synthetic cross-wiki row into a summary NotificationItem.
+ *
+ * @param {Object} entry raw Echo notification of type 'foreign'
+ * @param {string} section 'alert' | 'message'
+ * @return {Object} NotificationItem carrying isSummary and count
+ */
+function normalizeSummary( entry, section ) {
+	const model = entry[ '*' ] || {};
+	const sources = entry.sources || {};
+	const wikis = Object.keys( sources );
+	const utcunix = entry.timestamp && entry.timestamp.utcunix;
+	return {
+		// Echo gives every summary row id -1. A stable per-section string keeps
+		// both sections renderable without a key collision, and can never
+		// address a real notification if it ever reached markRead.
+		id: `summary-${ section }`,
+		isSummary: true,
+		// How many notifications on other wikis this row stands for.
+		count: Number( entry.count || 0 ),
+		section: section,
+		// Echo files this row under a 'foreign' pseudo-category that is not a
+		// registered category and resolves to 'other', so a label here would
+		// read "Other". Leave it off rather than mislabel it.
+		category: '',
+		categoryLabel: '',
+		// It stands for notifications on other wikis, which this panel cannot
+		// clear, so it is always unread.
+		read: false,
+		timestamp: utcunix ? Number( utcunix ) : 0,
+		iconUrl: model.iconUrl || '',
+		// Echo's own localized strings: "More alerts from another wiki", with
+		// the wiki names as the body.
+		header: model.header || '',
+		body: model.body || '',
+		// Echo returns no primary link for this row. With one foreign wiki, go
+		// straight to its notifications; with several, the local special page.
+		primaryUrl: wikis.length === 1 ?
+			foreignNotificationsUrl( sources[ wikis[ 0 ] ] ) :
+			mw.util.getUrl( 'Special:Notifications' ),
+		secondaryLinks: []
+	};
+}
+
+/**
  * Create an Echo-backed notification source.
  *
  * @param {Function} ApiConstructor `mw.Api` constructor (injected for testability)
@@ -97,6 +170,13 @@ function createEchoSource( ApiConstructor ) {
 			// unread, so the panel shows recent activity with unread tinted.
 			// (notfilter only accepts read / !read, never 'all'.)
 			notprop: 'list|count',
+			// Ask Echo to prepend its "N unread on other wikis" row to each
+			// section, and to report cross-wiki-inclusive counts — the same
+			// figure the server already renders on the bell. Echo only
+			// registers this parameter where $wgEchoCrossWikiNotifications is
+			// on; elsewhere it is ignored with a harmless API warning, which
+			// is what Echo's own client does too.
+			notcrosswikisummary: 1,
 			// All category titles, parsed (resolves PLURAL etc.), in the
 			// viewer's language.
 			amprefix: CATEGORY_TITLE_PREFIX,
@@ -111,12 +191,17 @@ function createEchoSource( ApiConstructor ) {
 					( message[ '*' ] || '' ).trim();
 			} );
 			const items = [];
+			const summaries = [];
 			const counts = { alert: 0, message: 0, total: 0 };
 
 			SECTIONS.forEach( ( section ) => {
 				const group = notifications[ section ] || {};
 				( group.list || [] ).forEach( ( entry ) => {
-					items.push( normalizeEntry( entry, section, labels ) );
+					if ( entry.type === SUMMARY_TYPE ) {
+						summaries.push( normalizeSummary( entry, section ) );
+					} else {
+						items.push( normalizeEntry( entry, section, labels ) );
+					}
 				} );
 				counts[ section ] = Number( group.rawcount || 0 );
 			} );
@@ -133,7 +218,10 @@ function createEchoSource( ApiConstructor ) {
 				return b.timestamp - a.timestamp;
 			} );
 
-			return { items, counts };
+			// Cross-wiki summaries stay pinned above the list. Echo adds them
+			// after notlimit has been applied, so left to the sort they could
+			// sink below 25 items and out of view.
+			return { items: summaries.concat( items ), counts };
 		} );
 	}
 

--- a/tests/vitest/skins.citizen.notifications/App.test.js
+++ b/tests/vitest/skins.citizen.notifications/App.test.js
@@ -229,4 +229,93 @@ describe( 'notifications App', () => {
 		// Accessible name is the header with markup stripped.
 		expect( link.attributes( 'aria-label' ) ).toBe( 'NotifBot mentioned you' );
 	} );
+
+	describe( 'cross-wiki summary rows', () => {
+		function makeSummary( section, count ) {
+			return {
+				id: `summary-${ section }`,
+				isSummary: true,
+				count: count,
+				section: section,
+				category: '',
+				categoryLabel: '',
+				read: false,
+				timestamp: 1700000500,
+				iconUrl: '',
+				header: 'More alerts from another wiki',
+				body: 'Example Wiki',
+				primaryUrl: 'https://example.org/wiki/Special:Notifications',
+				secondaryLinks: []
+			};
+		}
+
+		function sourceWithSummary( extraItems = [] ) {
+			return makeSource( {
+				fetch: vi.fn().mockResolvedValue( {
+					items: [ makeSummary( 'alert', 3 ) ].concat( extraItems ),
+					counts: { alert: 3, message: 0, total: 3 }
+				} )
+			} );
+		}
+
+		it( 'never sends a summary row to markRead when clicked', async () => {
+			const source = sourceWithSummary();
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			await inTab( wrapper, 'all' )[ 0 ].trigger( 'click' );
+
+			expect( source.markRead ).not.toHaveBeenCalled();
+		} );
+
+		it( 'keeps a summary row tinted unread after it is clicked', async () => {
+			const source = sourceWithSummary();
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			await inTab( wrapper, 'all' )[ 0 ].trigger( 'click' );
+			await wrapper.vm.$nextTick();
+
+			expect( wrapper.findAll( '[data-tab="all"] .citizen-notifications__item--unread' ).length )
+				.toBe( 1 );
+		} );
+
+		it( 'leaves mark-all disabled when only a summary row is unread', async () => {
+			const source = sourceWithSummary();
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			expect( wrapper.find( '.citizen-notifications__mark-all' ).attributes( 'disabled' ) )
+				.toBeDefined();
+		} );
+
+		it( 'keeps the summary count in the badge after a local mark-read', async () => {
+			const onCountsChange = vi.fn();
+			const local = makeItem( 12, 'alert', false, 1700000400 );
+			const source = sourceWithSummary( [ local ] );
+			const wrapper = mountApp( source, { onCountsChange } );
+			await flushPromises();
+			onCountsChange.mockClear();
+
+			// Click the real notification, not the pinned summary.
+			await inTab( wrapper, 'all' )[ 1 ].trigger( 'click' );
+
+			expect( source.markRead ).toHaveBeenCalledWith( [ 12 ] );
+			// 3 cross-wiki alerts survive; only the local one is cleared.
+			expect( onCountsChange ).toHaveBeenLastCalledWith( { alert: 3, message: 0, total: 3 } );
+		} );
+
+		it( 'keeps the summary count after mark-all clears the local rows', async () => {
+			const onCountsChange = vi.fn();
+			const local = makeItem( 12, 'alert', false, 1700000400 );
+			const source = sourceWithSummary( [ local ] );
+			const wrapper = mountApp( source, { onCountsChange } );
+			await flushPromises();
+			onCountsChange.mockClear();
+
+			await wrapper.find( '.citizen-notifications__mark-all' ).trigger( 'click' );
+
+			expect( onCountsChange ).toHaveBeenLastCalledWith( { alert: 3, message: 0, total: 3 } );
+		} );
+	} );
 } );

--- a/tests/vitest/skins.citizen.notifications/echoSource.test.js
+++ b/tests/vitest/skins.citizen.notifications/echoSource.test.js
@@ -93,6 +93,57 @@ const GROUPED_RESPONSE = {
 	}
 };
 
+/**
+ * Echo's synthetic cross-wiki roll-up, as it arrives with
+ * notcrosswikisummary=1: type 'foreign', id -1, unshifted onto the front of
+ * EVERY requested section's list, with no `read` key and no primary link.
+ *
+ * @param {string} section 'alert' | 'message'
+ * @param {Object} sources `sources` map keyed by wiki id
+ * @param {number} count unread count on the other wikis
+ * @return {Object}
+ */
+function summaryEntry( section, sources, count ) {
+	return {
+		id: -1,
+		type: 'foreign',
+		// Echo files it under a pseudo-category that resolves to 'other'.
+		category: 'other',
+		section: section,
+		count: count,
+		sources: sources,
+		timestamp: { utcunix: '1700000500' },
+		'*': {
+			header: `More ${ section === 'alert' ? 'alerts' : 'notices' } from another wiki`,
+			body: 'Example Wiki',
+			iconUrl: '/icons/global.svg',
+			links: { primary: [], secondary: [] }
+		}
+	};
+}
+
+const ONE_WIKI = {
+	examplewiki: {
+		title: 'Example Wiki',
+		url: 'https://example.org/w/api.php',
+		base: 'https://example.org/wiki/$1',
+		ts: '2023-11-14T00:00:00Z'
+	}
+};
+
+/**
+ * The grouped response with a cross-wiki summary unshifted into both sections.
+ *
+ * @param {Object} [sources] `sources` map to attach to each summary
+ * @return {Object}
+ */
+function responseWithSummary( sources = ONE_WIKI ) {
+	const base = structuredClone( GROUPED_RESPONSE );
+	base.query.notifications.alert.list.unshift( summaryEntry( 'alert', sources, 3 ) );
+	base.query.notifications.message.list.unshift( summaryEntry( 'message', sources, 2 ) );
+	return base;
+}
+
 describe( 'createEchoSource', () => {
 	describe( 'fetch', () => {
 		it( 'requests both sections as grouped model data (no deprecated format/filter)', async () => {
@@ -109,7 +160,10 @@ describe( 'createEchoSource', () => {
 				notsections: 'alert|message',
 				notformat: 'model',
 				notgroupbysection: 1,
-				notlimit: 25
+				notlimit: 25,
+				// Asks for the cross-wiki roll-up row and cross-wiki-inclusive
+				// counts; ignored where the wiki has cross-wiki turned off.
+				notcrosswikisummary: 1
 			} );
 			// `notfilter` only accepts read/!read; rely on its default (both).
 			expect( params.notfilter ).toBeUndefined();
@@ -247,6 +301,103 @@ describe( 'createEchoSource', () => {
 
 			expect( items ).toEqual( [] );
 			expect( counts ).toEqual( { alert: 0, message: 0, total: 0 } );
+		} );
+	} );
+
+	describe( 'cross-wiki summaries', () => {
+		it( 'never exposes Echo\'s placeholder id', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary() );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items.some( ( item ) => item.id === -1 ) ).toBe( false );
+			expect( items.map( ( item ) => item.id ) )
+				.toEqual( [ 'summary-alert', 'summary-message', 12, 21, 11 ] );
+		} );
+
+		it( 'pins summaries above the sorted list', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary() );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items.slice( 0, 2 ).map( ( item ) => item.isSummary ) )
+				.toEqual( [ true, true ] );
+			// The remaining items keep the order they have without a summary.
+			expect( items.slice( 2 ).map( ( item ) => item.id ) ).toEqual( [ 12, 21, 11 ] );
+		} );
+
+		it( 'carries the section and the count it stands for', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary() );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items[ 0 ] ).toMatchObject( { section: 'alert', count: 3, read: false } );
+			expect( items[ 1 ] ).toMatchObject( { section: 'message', count: 2, read: false } );
+		} );
+
+		it( 'leaves the category label off rather than showing "Other"', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary() );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items[ 0 ].categoryLabel ).toBe( '' );
+			expect( items[ 0 ].category ).toBe( '' );
+		} );
+
+		it( 'keeps Echo\'s own wording for the header and body', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary() );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items[ 0 ].header ).toBe( 'More alerts from another wiki' );
+			expect( items[ 0 ].body ).toBe( 'Example Wiki' );
+		} );
+
+		it( 'links a single-wiki summary to that wiki\'s notifications', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary() );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items[ 0 ].primaryUrl )
+				.toBe( 'https://example.org/wiki/Special:Notifications' );
+		} );
+
+		it( 'links a multi-wiki summary to the local special page', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary( Object.assign(
+				{}, ONE_WIKI, { otherwiki: { title: 'Other', base: 'https://other.org/wiki/$1' } }
+			) ) );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items[ 0 ].primaryUrl ).toBe( '/wiki/Special:Notifications' );
+		} );
+
+		it( 'falls back to the local special page for an unusable base', async () => {
+			const { ApiConstructor } = makeApi( responseWithSummary( {
+				examplewiki: { title: 'Example Wiki', base: 'https://example.org/wiki/Foo' }
+			} ) );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items[ 0 ].primaryUrl ).toBe( '/wiki/Special:Notifications' );
+		} );
+
+		it( 'leaves ordinary items untouched when no summary arrives', async () => {
+			const { ApiConstructor } = makeApi( GROUPED_RESPONSE );
+			const source = createEchoSource( ApiConstructor );
+
+			const { items } = await source.fetch();
+
+			expect( items.some( ( item ) => item.isSummary ) ).toBe( false );
+			expect( items[ 0 ].isSummary ).toBeUndefined();
 		} );
 	} );
 


### PR DESCRIPTION
Closes #1751

## Problem

On a wiki farm, a user with notifications on other wikis saw nothing about them in the panel. Citizen replaced Echo's badges with its own, and the panel never asked Echo for its cross-wiki roll-up — so the notifications existed, and the bell's own count knew about them, but the panel did not.

## Behaviour

The panel now asks for the roll-up and pins it above the list, reusing Echo's own wording — "More alerts from another wiki", with the wiki names underneath — so it reads the same here as it does in any other skin. One other wiki links straight to its notifications; several link to Special:Notifications, the only page that shows them together. The badge now counts other wikis too, matching what the bell already showed before the panel was opened.

Wikis without cross-wiki notifications are unaffected: Echo only registers the parameter where the feature is on, and ignores it with a harmless warning elsewhere — which is what Echo's own client does.

## Contract

A roll-up stands for notifications this panel cannot reach, so it is never marked read, never cleared by "mark all read", and never leaves that button enabled on its own. Echo files it under a category that resolves to "Other", which says nothing useful here, so the label is left off. Echo gives every roll-up the same placeholder id, so each is given a stable per-section one instead — otherwise two of them collide in the list and one can stand in for the other when marked.

The roll-up is pinned rather than sorted: Echo appends it after the result limit has been applied, so left to the sort it would sink out of view on a busy wiki.

## Testing

Verified against a wiki configured as a farm member — shared tracking DB, a second wiki with unread notifications — so Echo's real cross-wiki path runs rather than a stubbed one. Roll-ups appear with the right counts, clicking one sends nothing to the server, and clearing a local notification leaves the cross-wiki count intact.

Note for reviewers testing this: cross-wiki notifications are gated on the per-user "Show notifications from other wikis" preference, which is off unless the user has turned it on. Without it, Echo returns no roll-up and the panel correctly shows nothing new.

## Follow-ups

The panel is due a wider redesign — dropping the alert/notice split and giving other wikis their own tab with previews fetched per wiki. This change is the contract that work builds on, not the final shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cross-wiki notification summary rows with item counts and links to relevant notifications.
  - Summary rows remain pinned above regular notifications and preserve cross-wiki totals.
  - Added support for single-wiki, multi-wiki, and fallback links when cross-wiki details are unavailable.

- **Bug Fixes**
  - Summary rows are no longer incorrectly marked as read when selected.
  - “Mark all as read” now affects only individual unread notifications.
  - Notification counts remain accurate after marking notifications as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->