### PR TITLE
feat(preferences): set defaults and hide entries from the preferences JSON

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -34,6 +34,10 @@ $wgCitizenHeaderPositionMobile = 'bottom';
 
 ### `$wgCitizenThemeDefault`
 
+::: warning Deprecated
+Set the default with the `skin-theme` preference's [`default` field](../features/preferences.md#setting-defaults) in `MediaWiki:Citizen-preferences.json` instead. This config keeps working until Citizen 4 as a fallback — the JSON value wins when both are set.
+:::
+
 Sets the default color theme for new visitors.
 
 ```php [LocalSettings.php]

--- a/docs/src/customization/recipes.md
+++ b/docs/src/customization/recipes.md
@@ -95,23 +95,20 @@ To hide a preference from the panel entirely, set it to `null`:
 
 ## Force a theme site-wide
 
-To lock everyone into a single theme, combine two changes — set the default theme, then remove the picker so users can't switch.
-
-First, set the default in `LocalSettings.php` using a valid value for [`$wgCitizenThemeDefault`](../config/#wgcitizenthemedefault):
-
-```php
-$wgCitizenThemeDefault = 'dark';
-```
-
-Then remove the theme picker by editing `MediaWiki:Citizen-preferences.json`:
+To lock everyone into a single theme, give `skin-theme` a default and hide the picker by editing `MediaWiki:Citizen-preferences.json`:
 
 ```json
 {
   "preferences": {
-    "skin-theme": null
+    "skin-theme": {
+      "default": "night",
+      "hidden": true
+    }
   }
 }
 ```
+
+`default` makes the theme apply to everyone who hasn't chosen one, and `hidden` removes the picker so nobody can.
 
 ::: warning
 Users who picked a different theme before you applied this change have it stored in their browser's local storage. They'll keep seeing their old choice until they clear site data — local storage doesn't expire on its own. New visitors get the forced theme immediately.

--- a/docs/src/customization/theming.md
+++ b/docs/src/customization/theming.md
@@ -200,7 +200,7 @@ Every property you don't override falls through to the default palette's [`light
 One limitation to know about: a few dark-mode extras are keyed to the built-in themes by name — the image dimming preference, and dark-mode fixes for some extensions — so they don't fire for custom themes. If your theme needs one of them, replicate it in your theme's CSS block.
 
 ::: tip
-Set `$wgCitizenThemeDefault = 'ocean';` to make your theme the default for new visitors.
+Make your theme the default for new visitors by adding `"default": "ocean"` to the `skin-theme` block you set up above — alongside `options`, not instead of it, so the theme stays registered in the picker.
 :::
 
 ## Performance considerations

--- a/docs/src/features/preferences.md
+++ b/docs/src/features/preferences.md
@@ -92,6 +92,8 @@ Each preference is keyed by its feature name.
 | `descriptionMsg` / `description` | string | i18n message key or literal text for the description. |
 | `columns` | number | For radio type, number of columns (default: 2). |
 | `visibilityCondition` | string | Optional gate on when the preference appears: `"always"` (default), `"dark-theme"` (visible only in dark theme), `"tablet-viewport"` (visible only at tablet width or above). |
+| `default` | string | The value that applies when the user hasn't made a choice. Must be one of the `options` values, letters and numbers only. For preferences defined on-wiki this is applied to every page by the server; for preferences registered through the JavaScript API it sets the panel's initial selection. See [Setting defaults](#setting-defaults). |
+| `hidden` | boolean | Set `true` to remove the preference from the panel while keeping it active — for preferences defined on-wiki, its `default` still applies site-wide. Use together with `default` to force a value. Sections whose preferences are all hidden disappear automatically. |
 
 ### `label` vs `labelMsg`
 
@@ -111,7 +113,7 @@ The simplest way to manage preferences — create a JSON page on your wiki at `M
 Your configuration is merged with the built-in defaults:
 
 - **Omitting** a built-in preference or section keeps its default.
-- Setting a preference to **`null`** removes it from the panel. Sections with no remaining preferences are dropped automatically.
+- Setting a preference to **`null`** removes it from the panel. Sections with no remaining preferences are dropped automatically. Unlike [`hidden`](#preference-entries), a `null` preference is gone entirely — it can't carry a `default`, and a `null` `skin-theme` stops informing theme-dependent visibility. Prefer `hidden: true` when the feature should stay active.
 - **Overriding** specific fields of a built-in preference merges them — unspecified fields keep their default values.
 - **Options arrays** are replaced wholesale, not merged element-by-element. If you override `options`, provide the full list.
 
@@ -165,6 +167,58 @@ This removes the "auto" option from the theme preference, leaving only day and n
   }
 }
 ```
+
+### Setting defaults
+
+Every preference can declare a `default` — the value that applies when a visitor hasn't made a choice. For preferences managed on-wiki (built-in or added in the JSON), Citizen applies the default on the server: the `<feature>-clientpref-<value>` class is on the `<html>` element from the first paint, so CSS keyed to it always works. The server read relies on database messages, so on a wiki running `$wgUseDatabaseMessages = false` a `default` only affects the panel's selection, not the served page.
+
+Changing a built-in default:
+
+```json
+{
+  "preferences": {
+    "citizen-feature-custom-width": { "default": "wide" }
+  }
+}
+```
+
+An added preference with a default:
+
+```json
+{
+  "preferences": {
+    "my-extension-dark-reader": {
+      "section": "extensions",
+      "type": "switch",
+      "options": ["0", "1"],
+      "default": "1",
+      "label": "Dark Reader"
+    }
+  }
+}
+```
+
+The theme works the same way — `"skin-theme": { "default": "night" }` — and supersedes the deprecated [`$wgCitizenThemeDefault`](../config/index.md#wgcitizenthemedefault) config (the JSON value wins when both are set).
+
+The built-in defaults, when you don't override them:
+
+| Preference | Default |
+| :--- | :--- |
+| `skin-theme` | `os` |
+| `citizen-feature-custom-font-size` | `standard` |
+| `citizen-feature-custom-width` | `standard` |
+| `citizen-feature-pure-black` <!-- citizen-v4-remove — the pure-black preference is deleted at the 4.0 flip; drop this row with it. --> | `0` |
+| `citizen-feature-image-dimming` | `0` |
+| `citizen-feature-autohide-navigation` | `1` |
+| `citizen-feature-performance-mode` | `1` |
+
+::: warning Performance mode detects the device
+`citizen-feature-performance-mode` is the one preference where your default doesn't stick. On a visitor's first page load, Citizen checks whether their device has GPU acceleration and stores the answer for them — so your `default` only holds until that check runs, and the detected value applies from their next page load on.
+:::
+
+::: info Preferences registered from JavaScript
+The server never sees preferences registered through the JavaScript API, so it can't apply their class ahead of time. Their `default` sets the panel's initial selection, and your CSS should treat "no class on `<html>`" and "class equals the default value" as the same state — a user who explicitly picks the default does get the class.
+:::
 
 ### JavaScript API
 
@@ -250,6 +304,8 @@ html.my-extension-dark-reader-clientpref-1 {
   /* styles when dark reader is enabled */
 }
 ```
+
+For preferences with a `default`, remember the contract above: style the default state as the base, and key your overrides to the non-default classes.
 
 ### Listening for changes
 

--- a/includes/Hooks/ResourceLoaderHooks.php
+++ b/includes/Hooks/ResourceLoaderHooks.php
@@ -38,6 +38,11 @@ class ResourceLoaderHooks {
 
 	/**
 	 * Passes config variables to skins.citizen.preferences ResourceLoader module.
+	 *
+	 * citizen-v4-remove — this callback only ships the deprecated
+	 * $wgCitizenThemeDefault; delete it and skin.json's config.json
+	 * virtual file entry at the 4.0 flip.
+	 *
 	 * @param RL\Context $context
 	 * @param Config $config
 	 * @return array

--- a/includes/PreferencesConfigProvider.php
+++ b/includes/PreferencesConfigProvider.php
@@ -12,7 +12,11 @@ use MessageLocalizer;
  */
 class PreferencesConfigProvider {
 
-	private const PAGE_NAME = 'Citizen-preferences.json';
+	/**
+	 * Page under the MediaWiki namespace holding admin overrides.
+	 * Shared with SkinCitizen's per-request defaults read.
+	 */
+	public const PAGE_NAME = 'Citizen-preferences.json';
 
 	private OnWikiJsonReader $reader;
 	private MessageLocalizer $messageLocalizer;
@@ -84,5 +88,41 @@ class PreferencesConfigProvider {
 		}
 
 		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * Extract per-preference default values from a preferences config.
+	 *
+	 * Validation is charset-only — option membership lives in JS
+	 * (defaultConfig.js), so it cannot be checked here. The charsets
+	 * mirror the clientPrefs validation in MediaWiki core
+	 * (isValidFeatureName/isValidFeatureValue in mediawiki.user.js);
+	 * keep the two in sync.
+	 *
+	 * @param array $config Parsed MediaWiki:Citizen-preferences.json
+	 * @return array<string, string> feature name => default value
+	 */
+	public static function extractDefaults( array $config ): array {
+		$prefs = $config['preferences'] ?? [];
+		if ( !is_array( $prefs ) ) {
+			// Valid JSON, wrong shape — e.g. `"preferences": "oops"`.
+			return [];
+		}
+
+		$defaults = [];
+		foreach ( $prefs as $feature => $pref ) {
+			// json_decode turns numeric JSON keys into ints
+			$feature = (string)$feature;
+			if (
+				!is_array( $pref ) ||
+				!is_string( $pref['default'] ?? null ) ||
+				preg_match( '/^[a-zA-Z0-9-]+$/', $feature ) !== 1 ||
+				preg_match( '/^[a-zA-Z0-9]+$/', $pref['default'] ) !== 1
+			) {
+				continue;
+			}
+			$defaults[$feature] = $pref['default'];
+		}
+		return $defaults;
 	}
 }

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -10,6 +10,7 @@ use MediaWiki\Config\Config;
 use MediaWiki\Languages\LanguageConverterFactory;
 use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\MainConfigNames;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent;
@@ -46,6 +47,7 @@ class SkinCitizen extends SkinMustache {
 	];
 
 	private const DEFAULT_CLIENT_PREFS = [
+		'skin-theme' => 'os',
 		'citizen-feature-autohide-navigation' => '1',
 		'citizen-feature-image-dimming' => '0',
 		'citizen-feature-pure-black' => '0',
@@ -131,21 +133,36 @@ class SkinCitizen extends SkinMustache {
 		$config = $this->getConfig();
 		$classes = [];
 
-		// Theme
+		// Default client preferences: on-wiki JSON defaults override the
+		// built-in values; the deprecated $wgCitizenThemeDefault sits
+		// between them for skin-theme only.
+		$defaults = self::DEFAULT_CLIENT_PREFS;
+
+		// citizen-v4-remove — $wgCitizenThemeDefault is deprecated in
+		// favor of the skin-theme `default` in
+		// MediaWiki:Citizen-preferences.json. At the 4.0 flip delete this
+		// block, CLIENTPREFS_THEME_MAP, the ThemeDefault entry in
+		// skin.json and its section in docs/src/config/index.md. Nothing
+		// else needs adding: the `skin-theme` entry in
+		// DEFAULT_CLIENT_PREFS keeps serving the terminal fallback once
+		// this block is gone, matching init.js's `|| 'os'`.
 		$theme = $config->get( 'CitizenThemeDefault' );
 		if ( isset( self::CLIENTPREFS_THEME_MAP[$theme] ) ) {
-			$classes[] = 'skin-theme-clientpref-' . self::CLIENTPREFS_THEME_MAP[$theme];
+			$defaults['skin-theme'] = self::CLIENTPREFS_THEME_MAP[$theme];
 		} elseif ( is_string( $theme ) && preg_match( '/^[a-zA-Z0-9]+$/', $theme ) === 1 ) {
 			// Theme values outside the legacy vocabulary — 'black' or a
 			// wiki-defined theme — map straight to their clientpref class.
 			// The charset mirrors the clientprefs value validation in
 			// MediaWiki core (isValidFeatureValue in mediawiki.user.js);
 			// keep the two in sync.
-			$classes[] = 'skin-theme-clientpref-' . $theme;
+			$defaults['skin-theme'] = $theme;
 		}
 
-		// Default client preferences
-		foreach ( self::DEFAULT_CLIENT_PREFS as $feature => $value ) {
+		foreach ( $this->getOnWikiDefaults() as $feature => $value ) {
+			$defaults[$feature] = $value;
+		}
+
+		foreach ( $defaults as $feature => $value ) {
 			$classes[] = $feature . '-clientpref-' . $value;
 		}
 
@@ -384,6 +401,49 @@ class SkinCitizen extends SkinMustache {
 		// If MF is installed, check if page is in mobile view and let MF do the formatting
 		// @phan-suppress-next-line PhanUndeclaredClassMethod MobileFrontend is an optional dependency
 		return $this->mfContext === null || !$this->mfContext->shouldDisplayMobileView();
+	}
+
+	/**
+	 * Per-preference defaults from MediaWiki:Citizen-preferences.json.
+	 *
+	 * Read through MessageCache: this runs on every page view, and
+	 * MessageCache serves NS_MEDIAWIKI pages from its individual-page
+	 * cache (APCu → WAN → DB), so the steady-state cost is a
+	 * local-server-cache (APCu) lookup — measured ~44µs per request, and
+	 * ~1ms on a wiki with no local server cache configured, where every
+	 * view falls through to the WAN cache. Web edits invalidate promptly;
+	 * an edit made from the CLI reaches php-fpm workers on the next local
+	 * server cache cycle (or a restart). The service is resolved
+	 * from the container and the class is never named because it cannot
+	 * be type-hinted portably: MW 1.43 has a global MessageCache class,
+	 * later versions namespace it.
+	 *
+	 * @return array<string, string> feature name => default value
+	 */
+	private function getOnWikiDefaults(): array {
+		$services = MediaWikiServices::getInstance();
+		$messageCache = $services->getMessageCache();
+		// A disabled cache means the wiki is not serving MediaWiki-namespace
+		// content at all ($wgUseDatabaseMessages off, or a load failure), so
+		// there are no on-wiki defaults to honour. Asking anyway would also
+		// trip a deprecation inside core: the individual-page cache key is
+		// built from the main cache's hash, which a disabled cache never has.
+		if ( $messageCache->isDisabled() ) {
+			return [];
+		}
+
+		$text = $messageCache->getMsgFromNamespace(
+			PreferencesConfigProvider::PAGE_NAME,
+			$services->getContentLanguage()->getCode()
+		);
+		if ( !is_string( $text ) || $text === '' ) {
+			return [];
+		}
+		$data = json_decode( $text, true );
+		if ( !is_array( $data ) ) {
+			return [];
+		}
+		return PreferencesConfigProvider::extractDefaults( $data );
 	}
 
 	/**

--- a/resources/skins.citizen.preferences/App.vue
+++ b/resources/skins.citizen.preferences/App.vue
@@ -170,6 +170,9 @@ module.exports = exports = defineComponent( {
 		 * Resolve the stored (or default) value for a preference and
 		 * store it in the reactive `values` map.
 		 *
+		 * Fallback chain: stored clientpref value → the preference's
+		 * declared `default` → the first option.
+		 *
 		 * @param {string} featureName
 		 * @param {Object} prefConfig
 		 */
@@ -189,9 +192,14 @@ module.exports = exports = defineComponent( {
 				values[ featureName ] = storedValue;
 				return;
 			}
+			if ( typeof storedValue === 'string' && allowedValues.has( storedValue ) ) {
+				values[ featureName ] = storedValue;
+				return;
+			}
 			values[ featureName ] = (
-				typeof storedValue === 'string' && allowedValues.has( storedValue )
-			) ? storedValue : prefConfig.options[ 0 ].value;
+				typeof prefConfig.default === 'string' &&
+				allowedValues.has( prefConfig.default )
+			) ? prefConfig.default : prefConfig.options[ 0 ].value;
 		}
 
 		// Initialize all preferences that exist at mount time.
@@ -232,7 +240,7 @@ module.exports = exports = defineComponent( {
 			return Object.entries( config.sections )
 				.map( ( [ key, sectionDef ] ) => {
 					const sectionPrefs = Object.entries( config.preferences )
-						.filter( ( [ , pref ] ) => pref.section === key )
+						.filter( ( [ , pref ] ) => pref.section === key && pref.hidden !== true )
 						.map( ( [ featureName, prefConfig ] ) => {
 							const options = prefConfig.options.map( ( opt ) => {
 								const option = {

--- a/resources/skins.citizen.preferences/init.js
+++ b/resources/skins.citizen.preferences/init.js
@@ -8,6 +8,8 @@ const {
 	mergeConfigs, normalizeConfig
 } = require( './configRegistry.js' );
 
+// citizen-v4-remove — legacy $wgCitizenThemeDefault vocabulary; dies with
+// the config at the 4.0 flip.
 const THEME_CONFIG_MAP = { auto: 'os', light: 'day', dark: 'night' };
 
 /**
@@ -57,13 +59,27 @@ function initApp() {
 		Object.assign( config.preferences, updated.preferences );
 	}
 
-	// Legacy config vocabulary maps to clientpref values; anything else
-	// ('black', wiki-defined themes) passes through. No charset check
-	// here, unlike the PHP side: the value never reaches the DOM raw —
-	// App.vue validates it against the registered options list, so an
-	// unregistered value safely falls back to the first option.
-	const themeDefault = THEME_CONFIG_MAP[ serverConfig.wgCitizenThemeDefault ] ||
-		serverConfig.wgCitizenThemeDefault || 'os';
+	// The panel's fallback theme when no clientpref class is present:
+	// the on-wiki JSON default wins, then the deprecated
+	// $wgCitizenThemeDefault. Belt-and-braces: skin-theme normally always
+	// resolves from the class or its options, so this seed only decides
+	// theme-dependent visibility in degenerate configs (e.g. skin-theme
+	// with an empty options list). No charset check here, unlike the PHP side:
+	// the value never reaches the DOM raw — App.vue validates it against
+	// the registered options list, so an unregistered value safely falls
+	// back to the first option.
+	const overrides = overrideData.overrides;
+	const jsonThemeDefault = overrides && overrides.preferences &&
+		overrides.preferences[ 'skin-theme' ] &&
+		overrides.preferences[ 'skin-theme' ].default;
+	// citizen-v4-remove — the config fallback dies with
+	// $wgCitizenThemeDefault at the 4.0 flip (along with THEME_CONFIG_MAP
+	// above, the config.json require, and the RL callback in
+	// ResourceLoaderHooks).
+	const configThemeDefault = THEME_CONFIG_MAP[ serverConfig.wgCitizenThemeDefault ] ||
+		serverConfig.wgCitizenThemeDefault;
+	const themeDefault = ( typeof jsonThemeDefault === 'string' && jsonThemeDefault ) ||
+		configThemeDefault || 'os';
 
 	const app = Vue.createMwApp( App );
 	app.provide( 'preferencesConfig', config );

--- a/resources/skins.citizen.preferences/types.js
+++ b/resources/skins.citizen.preferences/types.js
@@ -32,6 +32,10 @@
  * @property {'always'|'dark-theme'|'tablet-viewport'} [visibilityCondition]
  *   When the preference is visible. Defaults to 'always'.
  * @property {number} [columns] Grid columns for radio type (default: 2).
+ * @property {string} [default] Value applied when the user has not chosen one.
+ *   Must match one of the options values.
+ * @property {boolean} [hidden] When true, the preference stays active but is
+ *   not rendered in the panel.
  */
 
 /**
@@ -71,6 +75,10 @@
  * @property {'always'|'dark-theme'|'tablet-viewport'} [visibilityCondition]
  *   When the preference is visible. Defaults to 'always'.
  * @property {number} [columns] Grid columns for radio type (default: 2).
+ * @property {string} [default] Value applied when the user has not chosen one.
+ *   Must match one of the options values.
+ * @property {boolean} [hidden] When true, the preference stays active but is
+ *   not rendered in the panel.
  */
 
 /**

--- a/skin.json
+++ b/skin.json
@@ -1021,7 +1021,7 @@
 	"config": {
 		"ThemeDefault": {
 			"value": "auto",
-			"description": "Default theme of the skin. Accepts 'auto', 'light', 'dark', or any theme value such as 'black' or a wiki-defined theme.",
+			"description": "Deprecated: set the skin-theme `default` in MediaWiki:Citizen-preferences.json instead; the JSON value wins when both are set. Default theme of the skin. Accepts 'auto', 'light', 'dark', or any theme value such as 'black' or a wiki-defined theme.",
 			"descriptionmsg": "citizen-config-themedefault",
 			"public": true
 		},

--- a/tests/phpunit/Unit/PreferencesConfigProviderTest.php
+++ b/tests/phpunit/Unit/PreferencesConfigProviderTest.php
@@ -125,4 +125,91 @@ class PreferencesConfigProviderTest extends MediaWikiUnitTestCase {
 
 		$this->assertSame( [], $keys );
 	}
+
+	public function testExtractDefaultsReturnsValidEntries(): void {
+		$config = [
+			'preferences' => [
+				'citizen-feature-custom-width' => [ 'default' => 'wide' ],
+				'my-gadget-feature' => [ 'default' => '1' ]
+			]
+		];
+
+		$defaults = PreferencesConfigProvider::extractDefaults( $config );
+
+		$this->assertSame(
+			[
+				'citizen-feature-custom-width' => 'wide',
+				'my-gadget-feature' => '1'
+			],
+			$defaults
+		);
+	}
+
+	public function testExtractDefaultsSkipsInvalidValueCharset(): void {
+		$config = [
+			'preferences' => [
+				// Values are alphanumeric only — hyphens, spaces and
+				// punctuation are all rejected.
+				'pref-a' => [ 'default' => 'very wide' ],
+				'pref-b' => [ 'default' => 'wi-de' ],
+				'pref-c' => [ 'default' => '' ]
+			]
+		];
+
+		$this->assertSame( [], PreferencesConfigProvider::extractDefaults( $config ) );
+	}
+
+	public function testExtractDefaultsSkipsInvalidFeatureName(): void {
+		$config = [
+			'preferences' => [
+				'bad name!' => [ 'default' => '1' ],
+				'ok-name' => [ 'default' => '1' ]
+			]
+		];
+
+		$this->assertSame(
+			[ 'ok-name' => '1' ],
+			PreferencesConfigProvider::extractDefaults( $config )
+		);
+	}
+
+	public function testExtractDefaultsSkipsNonStringDefaults(): void {
+		$config = [
+			'preferences' => [
+				'pref-int' => [ 'default' => 1 ],
+				'pref-bool' => [ 'default' => true ],
+				'pref-array' => [ 'default' => [ '1' ] ],
+				'pref-missing' => [ 'section' => 'appearance' ],
+				'pref-removed' => null
+			]
+		];
+
+		$this->assertSame( [], PreferencesConfigProvider::extractDefaults( $config ) );
+	}
+
+	public function testExtractDefaultsHandlesNumericFeatureKeys(): void {
+		// json_decode turns the JSON key "123" into PHP int 123 — the cast
+		// inside extractDefaults must keep this from fataling.
+		$config = [
+			'preferences' => [
+				123 => [ 'default' => 'a' ]
+			]
+		];
+
+		$this->assertSame(
+			[ '123' => 'a' ],
+			PreferencesConfigProvider::extractDefaults( $config )
+		);
+	}
+
+	public function testExtractDefaultsReturnsEmptyForEmptyConfig(): void {
+		$this->assertSame( [], PreferencesConfigProvider::extractDefaults( [] ) );
+	}
+
+	public function testExtractDefaultsReturnsEmptyForNonArrayPreferences(): void {
+		// Valid JSON, wrong shape — foreach over a string would warn.
+		$config = [ 'preferences' => 'oops' ];
+
+		$this->assertSame( [], PreferencesConfigProvider::extractDefaults( $config ) );
+	}
 }

--- a/tests/phpunit/integration/SkinCitizenPreferenceDefaultsTest.php
+++ b/tests/phpunit/integration/SkinCitizenPreferenceDefaultsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Integration;
+
+use MediaWiki\MainConfigNames;
+use MediaWiki\Skins\Citizen\SkinCitizen;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * Client preference default classes stamped onto <html>, including
+ * defaults read from MediaWiki:Citizen-preferences.json through
+ * MessageCache. Editing the page with real JsonContent also proves the
+ * MessageCache path serves JSON content-model pages.
+ *
+ * @group Citizen
+ * @group Database
+ * @covers \MediaWiki\Skins\Citizen\SkinCitizen
+ */
+class SkinCitizenPreferenceDefaultsTest extends MediaWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// The test runner turns database messages off wiki-wide, which
+		// disables MessageCache; production defaults them on. Restore the
+		// production shape so these tests exercise the real read path.
+		$this->overrideConfigValue( MainConfigNames::UseDatabaseMessages, true );
+	}
+
+	private function createSkinInstance(): SkinCitizen {
+		return new SkinCitizen(
+			$this->getServiceContainer()->getUserFactory(),
+			$this->getServiceContainer()->getGenderCache(),
+			$this->getServiceContainer()->getUserIdentityLookup(),
+			$this->getServiceContainer()->getLanguageConverterFactory(),
+			$this->getServiceContainer()->getLanguageNameUtils(),
+			$this->getServiceContainer()->getPermissionManager(),
+			$this->getServiceContainer()->getUserGroupManager(),
+			$this->getServiceContainer()->getUrlUtils(),
+			$this->getServiceContainer()->getTempUserConfig(),
+			null,
+			[
+				'name' => 'Citizen',
+			]
+		);
+	}
+
+	private function setPreferencesJson( string $json ): void {
+		$this->editPage( 'MediaWiki:Citizen-preferences.json', $json );
+	}
+
+	public function testBuiltInDefaultsStampedWithoutJson(): void {
+		$attrs = $this->createSkinInstance()->getHtmlElementAttributes();
+
+		$this->assertStringContainsString(
+			'citizen-feature-custom-width-clientpref-standard', $attrs['class'] );
+		// Config default 'auto' maps to the os clientpref class.
+		$this->assertStringContainsString(
+			'skin-theme-clientpref-os', $attrs['class'] );
+	}
+
+	public function testJsonDefaultOverridesBuiltIn(): void {
+		$this->setPreferencesJson(
+			'{ "preferences": { "citizen-feature-custom-width": { "default": "wide" } } }'
+		);
+
+		$attrs = $this->createSkinInstance()->getHtmlElementAttributes();
+
+		$this->assertStringContainsString(
+			'citizen-feature-custom-width-clientpref-wide', $attrs['class'] );
+		$this->assertStringNotContainsString(
+			'citizen-feature-custom-width-clientpref-standard', $attrs['class'] );
+	}
+
+	public function testJsonThemeDefaultOverridesConfig(): void {
+		$this->overrideConfigValues( [ 'CitizenThemeDefault' => 'light' ] );
+		$this->setPreferencesJson(
+			'{ "preferences": { "skin-theme": { "default": "night" } } }'
+		);
+
+		$attrs = $this->createSkinInstance()->getHtmlElementAttributes();
+
+		$this->assertStringContainsString(
+			'skin-theme-clientpref-night', $attrs['class'] );
+		$this->assertStringNotContainsString(
+			'skin-theme-clientpref-day', $attrs['class'] );
+	}
+
+	public function testJsonAddedPreferenceIsStamped(): void {
+		$this->setPreferencesJson(
+			'{ "preferences": { "my-gadget-feature": { "default": "1" } } }'
+		);
+
+		$attrs = $this->createSkinInstance()->getHtmlElementAttributes();
+
+		$this->assertStringContainsString(
+			'my-gadget-feature-clientpref-1', $attrs['class'] );
+	}
+
+	public function testInvalidDefaultValueIsIgnored(): void {
+		$this->setPreferencesJson(
+			'{ "preferences": { "citizen-feature-custom-width": { "default": "very wide" } } }'
+		);
+
+		$attrs = $this->createSkinInstance()->getHtmlElementAttributes();
+
+		$this->assertStringContainsString(
+			'citizen-feature-custom-width-clientpref-standard', $attrs['class'] );
+	}
+
+	/**
+	 * With MessageCache disabled the wiki serves no MediaWiki-namespace
+	 * content, so the read is skipped entirely rather than asking a cache
+	 * that has no page hash to key its individual-page lookup with.
+	 */
+	public function testOnWikiDefaultsSkippedWhenDatabaseMessagesDisabled(): void {
+		$this->setPreferencesJson(
+			'{ "preferences": { "citizen-feature-custom-width": { "default": "wide" } } }'
+		);
+		$this->overrideConfigValue( MainConfigNames::UseDatabaseMessages, false );
+
+		$attrs = $this->createSkinInstance()->getHtmlElementAttributes();
+
+		$this->assertStringContainsString(
+			'citizen-feature-custom-width-clientpref-standard', $attrs['class'] );
+	}
+
+	public function testThemeConfigStillMapsLegacyVocabulary(): void {
+		$this->overrideConfigValues( [ 'CitizenThemeDefault' => 'dark' ] );
+
+		$attrs = $this->createSkinInstance()->getHtmlElementAttributes();
+
+		$this->assertStringContainsString(
+			'skin-theme-clientpref-night', $attrs['class'] );
+	}
+}

--- a/tests/phpunit/integration/SkinCitizenTest.php
+++ b/tests/phpunit/integration/SkinCitizenTest.php
@@ -143,15 +143,16 @@ class SkinCitizenTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
-	public function testSetSkinThemeWithInvalidValue(): void {
+	public function testSetSkinThemeWithInvalidValueFallsBackToOs(): void {
 		$this->overrideConfigValues( [
 			'CitizenThemeDefault' => 'invalid-value',
 		] );
 
-		// Should not throw an undefined array key error
+		// A config value outside the clientpref charset falls back to the
+		// built-in os default instead of leaving the page with no theme class.
 		$skin = $this->createSkinInstance();
 		$attrs = $skin->getHtmlElementAttributes();
-		$this->assertStringNotContainsString( 'skin-theme-clientpref-', $attrs['class'] );
+		$this->assertStringContainsString( 'skin-theme-clientpref-os', $attrs['class'] );
 	}
 
 	public function testSetSkinThemeWithCustomValue(): void {

--- a/tests/vitest/skins.citizen.preferences/App.test.js
+++ b/tests/vitest/skins.citizen.preferences/App.test.js
@@ -563,4 +563,130 @@ describe( 'App', () => {
 			expect( groups ).toHaveLength( 8 );
 		} );
 	} );
+
+	describe( 'default values', () => {
+		/**
+		 * Build a config containing an extra switch pref carrying a default.
+		 *
+		 * @param {string|undefined} defaultValue
+		 * @return {Object}
+		 */
+		function configWithDefault( defaultValue ) {
+			const config = getTestConfig();
+			config.preferences[ 'gadget-toggle' ] = {
+				section: 'behavior',
+				options: [ { value: '0' }, { value: '1' } ],
+				type: 'switch',
+				default: defaultValue,
+				label: 'My Gadget',
+				visibilityCondition: 'always'
+			};
+			return config;
+		}
+
+		/**
+		 * @param {import('@vue/test-utils').VueWrapper} wrapper
+		 * @return {import('@vue/test-utils').VueWrapper|undefined}
+		 */
+		function findGadgetToggle( wrapper ) {
+			return wrapper
+				.findAllComponents( { name: 'CdxToggleSwitch' } )
+				.find( ( c ) => c.props( 'id' ) === 'skin-client-prefs-gadget-toggle' );
+		}
+
+		it( 'should fall back to the declared default when no value is stored', () => {
+			const wrapper = mountApp( ALL_PREF_CLASSES, configWithDefault( '1' ) );
+
+			expect( findGadgetToggle( wrapper ).props( 'modelValue' ) ).toBe( true );
+		} );
+
+		it( 'should prefer the stored value over the declared default', () => {
+			const wrapper = mountApp(
+				[ ...ALL_PREF_CLASSES, 'gadget-toggle-clientpref-0' ],
+				configWithDefault( '1' )
+			);
+
+			expect( findGadgetToggle( wrapper ).props( 'modelValue' ) ).toBe( false );
+		} );
+
+		it( 'should ignore a default that is not among the options', () => {
+			const wrapper = mountApp( ALL_PREF_CLASSES, configWithDefault( '2' ) );
+
+			expect( findGadgetToggle( wrapper ).props( 'modelValue' ) ).toBe( false );
+		} );
+
+		it( 'should apply the default to dynamically registered preferences', async () => {
+			const config = reactive( getTestConfig() );
+			const wrapper = mountApp( ALL_PREF_CLASSES, config );
+
+			config.sections[ 'gadget' ] = { label: 'Gadgets' };
+			config.preferences[ 'gadget-toggle' ] = {
+				section: 'gadget',
+				options: [ { value: '0' }, { value: '1' } ],
+				type: 'switch',
+				default: '1',
+				label: 'My Gadget'
+			};
+			await wrapper.vm.$nextTick();
+
+			expect( findGadgetToggle( wrapper ).props( 'modelValue' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'hidden preferences', () => {
+		it( 'should not render a control for a hidden preference', () => {
+			const config = getTestConfig();
+			config.preferences[ 'skin-theme' ].hidden = true;
+
+			const wrapper = shallowMountApp( ALL_PREF_CLASSES, config );
+
+			expect(
+				wrapper.find( '#skin-client-prefs-skin-theme' ).exists()
+			).toBe( false );
+			// The other appearance prefs still render.
+			expect( wrapper.findAll( '.citizen-preferences-group' ) ).toHaveLength( 6 );
+		} );
+
+		it( 'should hide a section whose preferences are all hidden', () => {
+			const config = getTestConfig();
+			for ( const pref of Object.values( config.preferences ) ) {
+				if ( pref.section === 'behavior' ) {
+					pref.hidden = true;
+				}
+			}
+
+			const wrapper = shallowMountApp( ALL_PREF_CLASSES, config );
+
+			const headings = wrapper.findAll( '.citizen-preferences-section__heading' );
+			expect( headings ).toHaveLength( 1 );
+			expect( headings[ 0 ].text() ).toBe( 'citizen-preferences-section-appearance' );
+		} );
+
+		it( 'should keep dark-theme visibility working when skin-theme is hidden', () => {
+			// Hiding only filters the rendered list — the theme value still
+			// seeds the model that dark-theme visibility conditions read.
+			const config = getTestConfig();
+			config.preferences[ 'skin-theme' ].hidden = true;
+			const classes = ALL_PREF_CLASSES.map( ( cls ) =>
+				cls.replace( 'skin-theme-clientpref-os', 'skin-theme-clientpref-night' )
+			);
+			mockColorScheme = 'dark';
+
+			const wrapper = shallowMountApp( classes, config );
+
+			// The theme control itself is gone...
+			expect(
+				wrapper.find( '#skin-client-prefs-skin-theme' ).exists()
+			).toBe( false );
+			// ...but a dark-theme-conditioned pref stays rendered and visible.
+			// v-show omits the style attribute entirely while shown, so
+			// normalize before asserting.
+			const imageDimming = wrapper.find(
+				'#skin-client-prefs-citizen-feature-image-dimming'
+			);
+			expect( imageDimming.exists() ).toBe( true );
+			expect( imageDimming.attributes( 'style' ) || '' )
+				.not.toContain( 'display: none' );
+		} );
+	} );
 } );

--- a/tests/vitest/skins.citizen.preferences/init.test.js
+++ b/tests/vitest/skins.citizen.preferences/init.test.js
@@ -140,6 +140,41 @@ describe( 'initApp', () => {
 		expect( mockProvide ).toHaveBeenCalledWith( 'themeDefault', 'night' );
 	} );
 
+	it( 'should prefer the JSON skin-theme default over server config', () => {
+		document.body.innerHTML = '<div id="citizen-preferences-content"></div>';
+		overridesMock.overrides = {
+			preferences: { 'skin-theme': { default: 'night' } }
+		};
+		configMock.wgCitizenThemeDefault = 'light';
+
+		initApp();
+
+		expect( mockProvide ).toHaveBeenCalledWith( 'themeDefault', 'night' );
+	} );
+
+	it( 'should pass wiki-defined JSON theme defaults through unmapped', () => {
+		document.body.innerHTML = '<div id="citizen-preferences-content"></div>';
+		overridesMock.overrides = {
+			preferences: { 'skin-theme': { default: 'ocean' } }
+		};
+
+		initApp();
+
+		expect( mockProvide ).toHaveBeenCalledWith( 'themeDefault', 'ocean' );
+	} );
+
+	it( 'should fall back to server config when JSON declares no default', () => {
+		document.body.innerHTML = '<div id="citizen-preferences-content"></div>';
+		overridesMock.overrides = {
+			preferences: { 'skin-theme': { columns: 2 } }
+		};
+		configMock.wgCitizenThemeDefault = 'dark';
+
+		initApp();
+
+		expect( mockProvide ).toHaveBeenCalledWith( 'themeDefault', 'night' );
+	} );
+
 	it( 'should fire citizen.preferences.register hook', () => {
 		document.body.innerHTML = '<div id="citizen-preferences-content"></div>';
 


### PR DESCRIPTION
## Problem

Defaults for client preferences were scattered and partly unreachable: built-in defaults were hardcoded, the theme alone had a LocalSettings escape hatch (`$wgCitizenThemeDefault`), and preferences added through `MediaWiki:Citizen-preferences.json` or `citizen.preferences.register` could not declare a default at all — the server never stamped their class, and the panel silently showed the first option as the selection.

## What this changes

- Every preference in `MediaWiki:Citizen-preferences.json` (and hook registrations) can declare a `"default"`. The server applies it on every page view, so `<feature>-clientpref-<value>` classes are present from first paint and the panel always agrees with actual behavior.
- Precedence: JSON `default` → `$wgCitizenThemeDefault` (deprecated, theme only) → built-in defaults.
- New `"hidden": true` keeps a preference active but out of the panel. Combined with `default`, it is the supported way to force a value site-wide — the force-a-theme recipe is now a single JSON page, no LocalSettings.
- The panel resolves each control's initial value as stored choice → declared default → first option, so hook-registered preferences finally show their intended default.
- `$wgCitizenThemeDefault` is deprecated: the JSON wins when both are set, and the config keeps working as a fallback until Citizen 4 (all fallback branches carry `citizen-v4-remove` markers).

## Contract

- `default` must be one of the preference's `options` values, letters and numbers only. Server validation is charset-only; an unknown value degrades exactly like an invalid `$wgCitizenThemeDefault` does today.
- For preferences registered from JavaScript the server cannot stamp a class ahead of time; CSS should treat "no class" and "class = default value" as the same state (now documented).
- Removing a preference with `null` still stamps its built-in default — removal hides UI, it does not disable the feature.
- `citizen-feature-performance-mode` is the one preference whose `default` doesn't stick: first-load device detection stores the real value and wins from then on. This is by design — performance mode isn't meant to be admin-forced — and the docs note it.
- Upgrade note: a `$wgCitizenThemeDefault` containing characters outside letters/numbers (e.g. a hyphenated name) previously produced no theme class at all; it now falls back to `os`, so those wikis start following the visitor's OS color scheme.
- JSON edits take effect on fresh renders without purges; CDN-cached pages keep the old default until they expire, same as the config today. No compat slice needed — no selectors are renamed or removed.

## Performance

The per-view read of `MediaWiki:Citizen-preferences.json` goes through MessageCache's individual-page cache (APCu → WAN → DB), benchmarked before/after on the dev wiki:

- ~44µs added per request (web SAPI), ~0.12% of a 40ms render; e2e p50 delta +0.66ms against a 0.44ms same-code noise floor.
- Zero added DB queries at steady state — the normalized query set is byte-identical before and after.
- Installs with no local server cache (no APCu) pay ~1ms/request from the WAN tier instead.
- CLI edits to the page can serve stale values until the php-fpm cache cycles; web edits propagate promptly. The panel's config payload (ResourceLoader) and the server-stamped classes also refresh on different clocks after an edit and can briefly disagree — the stored class wins in the panel, so there is no user-visible effect.

## Follow-ups

- `composer preflight` currently exits 1 on `main` itself (two pre-existing Phan `UnusedPluginSuppression` findings in `CitizenComponentBodyContent.php` abort the chain before PHPUnit runs) — deserves a standalone cleanup.
- At the 4.0 flip: delete the `citizen-v4-remove`-marked fallback branches plus the `ThemeDefault` entry in `skin.json` and its docs section.

Cache status: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3f6XHrsLjLxhErsiTwN6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure preference defaults and visibility through `MediaWiki:Citizen-preferences.json`.
  * Hidden preferences no longer appear in preference sections.
  * Stored preference values take precedence over declared defaults, with safe fallbacks for invalid values.
  * The default theme now supports on-wiki configuration, defaulting to the operating system theme when unspecified.

* **Documentation**
  * Added guidance for preference defaults, hidden settings, precedence, and theme configuration.
  * Marked the legacy theme configuration as deprecated ahead of Citizen 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->