### PR TITLE
fix(header): close the gap above sticky table headers when the navigation auto-hides

### DIFF
--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -149,6 +149,8 @@
 		.citizen-scroll--down {
 			// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
 			--height-sticky-header: 0px !important;
+			// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
+			--header-offset-block-start: 0px;
 			// Just do not modify --header-size-block-end
 			// Because we have already used `transform` to hide the header
 			// If we use bottom in the meantime, the transition will not work.


### PR DESCRIPTION
## Problem

With **automatically hide navigation** enabled, scrolling down hides the header and the sticky title bar, but sticky elements kept the offset that reserved space for them — leaving an empty gap above sticky table headers (#1716). Affected everything that pins below the site chrome: table sticky bands, the `.mw-sticky-header-element` template API, and the sticky headers in skinStyles (Preferences, WikiEditor, etc.).

## Behaviour

While the navigation is hidden (scrolling down on mobile/tablet with auto-hide on), sticky elements now pin flush to the viewport top. Scrolling back up restores the normal offset below the returning chrome. Nothing changes with auto-hide off, and desktop widths are untouched — the rule lives inside the existing mobile-only auto-hide scope.

The band snaps rather than animates on direction flips: its transform *is* the scroll drive, so it cannot transition. `top`-based sticky elements keep their existing `top` transition.

## Verification

Browser-tested against the dev wiki (mobile viewport, auto-hide on):

- Sticky band, CSS scroll-drive: scroll-down → band at viewport top (was a 53px gap); scroll-up → flush under the returning title bar
- Sticky band, JS drive (view-timeline probe spoofed off): identical results
- `.mw-sticky-header-element`: computed `top` `0` on scroll-down, restored on scroll-up
- Top mobile header placement: gap closed on scroll-down; header + title bar + band stack restores on scroll-up
- Auto-hide off: behaviour unchanged in both scroll directions
- No console errors; pure CSS change, so no cache-compat slice is needed

Closes #1716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJbCktsdwR3m2mq9q1bToY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sticky header behavior when scrolling by resetting its top offset along with its height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->