### PR TITLE
fix(toc): keep the table of contents from vanishing while scrolling in Firefox

### DIFF
--- a/resources/skins.citizen.styles/components/PageSidebar.less
+++ b/resources/skins.citizen.styles/components/PageSidebar.less
@@ -7,7 +7,10 @@
 		grid-area: sidebar;
 		gap: var( --space-sm );
 		margin-top: var( --space-sm ); // align with first paragraph
-		contain: strict;
+		// Not `strict`: pairing `layout` with `size` makes this a reflow root
+		// in Firefox, which strands the sticky ToC at its static position
+		// mid-scroll (#1175). Do not add `layout` back.
+		contain: size paint style;
 	}
 
 	.citizen-menu__heading,


### PR DESCRIPTION
Closes #1175.

## Problem

On desktop, the sticky table of contents blanks out for a few frames at a time while scrolling in Firefox, repeatedly, then reappears in place. Chromium is unaffected. The reporter confirmed it on Citizen v3.x and could not reproduce on v2.37.0.

The trigger is `contain: strict` on `.citizen-page-sidebar`, added four days after the v2.37.0 tag.

`strict` is `size layout paint style`. Gecko treats a box that has `layout` containment together with size containment on both axes as a *dynamic reflow root*, and a reflow rooted inside such a box never reaches the scroll container that applies sticky offsets. Any reflow inside the sidebar during a scroll — the scroll spy toggling section classes, the sticky header rewriting `--height-sticky-header` — therefore leaves the table of contents at its static position, far above the viewport, until the next scroll-frame reflow puts it back.

This is a layout failure, not a compositing one. `getBoundingClientRect()` itself returns the static position, and disabling retained display lists, APZ and hardware WebRender changes nothing.

## Behaviour

The table of contents stays stuck to its offset throughout a scroll, in every browser.

Nothing else changes. Grid geometry is byte-identical to the previous behaviour on both normal-length and short pages, at every viewport, and the sidebar keeps the containment win the original change was after.

## Contract

`.citizen-page-sidebar` keeps `size`, `paint` and `style` containment and gives up `layout`. That is safe to rely on here because the sidebar is a flex container, so it already establishes an independent formatting context, and `paint` already makes it a stacking context and a containing block for absolutely and fixed positioned descendants.

The general rule this establishes, worth remembering when adding containment elsewhere: **no ancestor of a `position: sticky` element may carry both `layout` and `size` containment** — which includes `contain: strict`, and also `content-visibility: auto` and `content-visibility: hidden`, since those apply the same pair implicitly and leave nothing for a `contain:` search to find.

Not cache-breaking: a property value changes on an existing selector, no class or ID is renamed or removed, and no server-rendered markup changes. No compat slice is needed.

## Verification

Measured in Firefox against a page with a long table of contents, sampling the element's rect every animation frame during a scroll:

| `contain` on `.citizen-page-sidebar` | frames with the sticky offset lost, out of 285 |
| --- | --- |
| `strict` (before) | 8 |
| `size paint style` (this PR) | 0, across three runs |

Chromium was clean before and after. A full sweep of all sixteen `contain` keyword combinations showed that exactly the four containing both `size` and `layout` fail and the other twelve are clean, which matches the Gecko condition above.

`npm run lint:styles` and `npm run lint:compat` pass.

## Follow-ups, not in this PR

- Firefox 146 shipped a cluster of fixes for sticky invalidation. Worth asking the reporter whether unpatched Citizen still misbehaves there, to learn whether anything upstream also contributed.
- The desktop table of contents override resets the card's background, border, shadow, clip path and transform but not its `backdrop-filter`, so a blur that has nothing left to blur is still evaluated on every frame. It is not the cause of this bug, but it is free to remove.
- `.citizen-dropdown .citizen-menu__card` has `content-visibility: hidden` and contains a sticky search form. Harmless today only because a closed card renders nothing, but it is the same hazard as above and worth a look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar rendering and containment behavior.
  * Fixed compatibility issues affecting sticky table-of-contents behavior in Firefox.
  * Preserved sidebar sizing, painting, and styling while improving layout reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->