### PR TITLE
docs(showcase): add Pleasant Goat Wiki

### DIFF
--- a/docs/src/community/showcase.md
+++ b/docs/src/community/showcase.md
@@ -29,4 +29,5 @@ Check out these amazing wikis powering their content with Citizen:
  <LinkCard title="Stella Sora Wiki" href="https://stellasora.miraheze.org" />
  <LinkCard title="CapoeiiraWiki" href="https://capoeirawiki.org" />
  <LinkCard title="The Petit Planet Wiki" href="https://petitplanet.wiki" />
+ <LinkCard title="Pleasant Goat Wiki" href="https://xyy.miraheze.org" />
 </LinkGrid>


### PR DESCRIPTION
## Summary

Adds [Pleasant Goat Wiki](https://xyy.miraheze.org) to the community showcase page, joining the list of wikis powered by Citizen.

## Changes

- Add a `<LinkCard>` for Pleasant Goat Wiki to `docs/src/community/showcase.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011P5bmYP49yvpNDA365fivS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Pleasant Goat Wiki to the community showcase links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->