### PR TITLE
perf(core): stop sticky header toggles from recalculating the whole page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,11 @@ To add a new skill, create `.agents/skills/<name>/SKILL.md` with frontmatter (`n
 
 ## Coding conventions
 
+### Code comments
+
+- Add a comment only when the behavior is not obvious from the code itself
+- Write comments to be durable: state the constraint or invariant a future reader needs, not the change being made, its justification to a reviewer, or what the next line does
+
 ### PHP
 
 - All files start with `declare( strict_types=1 );`

--- a/resources/mixins.less
+++ b/resources/mixins.less
@@ -70,7 +70,24 @@
 	}
 }
 
+// Dynamic states of --header-offset-block-start, applied per consumer:
+// flipping an inherited custom property at the root or body recalcs the
+// whole document on every toggle. The default state inherits the root token.
+.mixin-citizen-header-offset-block-start() {
+	.citizen-sticky-header-visible & {
+		--header-offset-block-start: ~'calc( var( --header-size-block-start ) + var( --height-sticky-header ) )';
+	}
+
+	@media ( max-width: @max-width-breakpoint-tablet ) {
+		.citizen-feature-autohide-navigation-clientpref-1 .citizen-scroll--down & {
+			// Escaped zero keeps the unit calc() consumers need (#1058)
+			--header-offset-block-start: ~'0px';
+		}
+	}
+}
+
 .mixin-citizen-sticky-header-element() {
+	.mixin-citizen-header-offset-block-start();
 	top: var( --header-offset-block-start ) !important;
 	transition-timing-function: var( --transition-timing-function-ease );
 	transition-duration: var( --transition-duration-medium );

--- a/resources/skins.citizen.scripts/stickyHeader.js
+++ b/resources/skins.citizen.scripts/stickyHeader.js
@@ -87,15 +87,22 @@ class StickyHeader {
 		this.cloneDropdowns = [];
 		this.dropdownsBuilt = false;
 		this.dropdownsDirty = false;
+		this.lastHeight = null;
 		this.handleClick = this.handleClick.bind( this );
 	}
 
 	/**
-	 * Update sticky header CSS variable, used by other sticky elements.
+	 * Update the sticky header height CSS variable, used by other sticky
+	 * elements. Root-scoped writes recalc the whole document, so skip
+	 * writes when the measured height is unchanged.
 	 *
 	 * @param {number} value
 	 */
 	setCSSVariable( value ) {
+		if ( value === this.lastHeight ) {
+			return;
+		}
+		this.lastHeight = value;
 		this.document.documentElement.style.setProperty( '--height-sticky-header', `${ value }px` );
 	}
 
@@ -153,13 +160,13 @@ class StickyHeader {
 	}
 
 	/**
-	 * Hide the sticky header.
+	 * Hide the sticky header. The height variable stays — visibility is
+	 * gated by the body class.
 	 */
 	hide() {
 		// Scrolling away dismisses the cloned menus; closing the <details>
 		// unbinds their window listeners via the toggle handler.
 		this.cloneDropdowns.forEach( ( dropdown ) => dropdown.dismiss() );
-		this.setCSSVariable( 0 );
 		this.document.body.classList.remove( STICKY_HEADER_VISIBLE_CLASS );
 		this.unbind();
 	}
@@ -299,6 +306,12 @@ class StickyHeader {
 		this.initFakeButtons();
 		this.updateEditIcon();
 		this.initDropdowns();
+		// Pre-measure at idle: the hidden bar is laid out and measurable,
+		// and the tree-wide recalc of the first variable write happens off
+		// the scroll path.
+		this.requestIdleCallback( () => {
+			this.setCSSVariable( this.stickyHeaderElement.getBoundingClientRect().height );
+		} );
 	}
 }
 

--- a/resources/skins.citizen.styles/common/common.less
+++ b/resources/skins.citizen.styles/common/common.less
@@ -5,7 +5,10 @@
 html {
 	box-sizing: border-box;
 	font-size: 100%;
-	scroll-padding-top: ~'calc( var( --header-offset-block-start ) + var( --space-xl ) )';
+	// Always reserves sticky header space: any anchor jump below the page
+	// title reveals the bar, and a root property that tracked visibility
+	// would recalc styles at subtree scale on every toggle.
+	scroll-padding-top: ~'calc( var( --header-offset-block-start ) + var( --height-sticky-header ) + var( --space-xl ) )';
 	scroll-padding-bottom: ~'calc( var( --header-offset-block-end ) + var( --space-xl ) )';
 }
 

--- a/resources/skins.citizen.styles/common/features.less
+++ b/resources/skins.citizen.styles/common/features.less
@@ -147,14 +147,6 @@
 		}
 
 		.citizen-scroll--down {
-			// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
-			--height-sticky-header: 0px !important;
-			// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
-			--header-offset-block-start: 0px;
-			// Just do not modify --header-size-block-end
-			// Because we have already used `transform` to hide the header
-			// If we use bottom in the meantime, the transition will not work.
-
 			// header should use the same timing function
 			.citizen-sticky-header-container,
 			.citizen-header,

--- a/resources/skins.citizen.styles/components/JumpLink.less
+++ b/resources/skins.citizen.styles/components/JumpLink.less
@@ -28,8 +28,8 @@
 		position: fixed;
 		// Pinned to the raw viewport corner rather than the header tokens: the
 		// header can sit on any edge, --header-inset-block-start is `auto` in
-		// the bottom placements, and --header-offset-block-start is rewritten at
-		// runtime by stickyHeader.js, so a token-pinned link would drift while
+		// the bottom placements, and --header-offset-block-start changes with
+		// sticky header visibility, so a token-pinned link would drift while
 		// scrolling.
 		inset-block-start: var( --space-xs );
 		inset-inline-start: var( --space-xs );

--- a/resources/skins.citizen.styles/components/OverflowElements.less
+++ b/resources/skins.citizen.styles/components/OverflowElements.less
@@ -251,6 +251,7 @@
 // CSS so the live --header-offset-block-start var chain resolves here.
 // The 9999px default keeps the band parked until the first write.
 .citizen-overflow-wrapper--sticky-js .citizen-overflow-sticky-row {
+	.mixin-citizen-header-offset-block-start();
 	transform: ~'translateY( clamp( 0px, calc( var( --header-offset-block-start ) - var( --citizen-overflow-sticky-top, 9999px ) ), var( --citizen-overflow-sticky-travel, 0px ) ) )';
 }
 
@@ -259,6 +260,7 @@
 // the table, which sits inside the horizontal scroller.
 @supports ( animation-timeline: view() ) and ( animation-range: exit-crossing 0% ) {
 	.citizen-overflow-wrapper--sticky-css {
+		.mixin-citizen-header-offset-block-start();
 		// Not yet baseline, but the enclosing feature check gates it and
 		// browsers that fail the probe take the JS drive instead.
 		// stylelint-disable-next-line plugin/use-baseline

--- a/resources/skins.citizen.styles/components/TableOfContents.less
+++ b/resources/skins.citizen.styles/components/TableOfContents.less
@@ -194,6 +194,7 @@
 
 @media ( min-width: @min-width-breakpoint-desktop ) {
 	.citizen-toc {
+		.mixin-citizen-header-offset-block-start();
 		position: -webkit-sticky;
 		position: sticky;
 		top: var( --header-offset-block-start );

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -35,8 +35,9 @@
 	--size-icon: @size-icon;
 	// Height of the bottom toolbar used by page tools and ToC toggle
 	--toolbar-size: 2.5rem;
-	// Used to offset sticky elements with sticky header
-	// This is overriden by inline styles in the html element when sticky header is active
+	// Measured sticky header bar height, written by stickyHeader.js. Not
+	// zeroed while the bar is hidden — visibility is gated per consumer by
+	// .mixin-citizen-header-offset-block-start.
 	// stylelint-disable-next-line length-zero-no-unit -- Need the unit for calc() (#1058)
 	--height-sticky-header: 0px;
 	// Width or height of citizen-header, depending on the orientation
@@ -239,9 +240,9 @@
 	}
 	/* stylelint-enable length-zero-no-unit */
 
-	// Derived header offset tokens
-	// These combine the static header size with the dynamic sticky header height
-	--header-offset-block-start: calc( var( --header-size-block-start ) + var( --height-sticky-header ) );
+	// Derived header offset tokens. Deliberately static at the root — the
+	// dynamic states live in .mixin-citizen-header-offset-block-start.
+	--header-offset-block-start: var( --header-size-block-start );
 	--header-offset-block-end: var( --header-size-block-end );
 
 	// Deprecated aliases — drop alongside the legacy pipeline.

--- a/skinStyles/extensions/ArticleFeedbackv5/ext.articleFeedbackv5.dashboard.less
+++ b/skinStyles/extensions/ArticleFeedbackv5/ext.articleFeedbackv5.dashboard.less
@@ -84,8 +84,14 @@
 
 #articleFeedbackv5-sort-filter-controls {
 	position: sticky;
-	top: calc( var( --height-sticky-header ) * 2 );
+	top: 0;
 	z-index: 5;
 	padding-top: var( --space-md );
 	.mixin-citizen-frosted-glass;
+
+	// --height-sticky-header keeps its measured value while the bar is
+	// hidden; consumers gate on the visibility class.
+	.citizen-sticky-header-visible & {
+		top: calc( var( --height-sticky-header ) * 2 );
+	}
 }

--- a/skinStyles/extensions/SearchDigest/ext.searchdigest.styles.less
+++ b/skinStyles/extensions/SearchDigest/ext.searchdigest.styles.less
@@ -31,6 +31,7 @@
 }
 
 .searchdigest-stats-table thead {
+	.mixin-citizen-header-offset-block-start();
 	position: sticky;
 	top: var( --header-offset-block-start );
 }

--- a/skinStyles/extensions/SemanticResultFormats/datatables/ext.srf.datatables.v2.format.less
+++ b/skinStyles/extensions/SemanticResultFormats/datatables/ext.srf.datatables.v2.format.less
@@ -34,6 +34,7 @@ div.dtsp-panesContainer div.dtsp-titleRow div.dtsp-title {
 }
 
 .dtfh-floatingparent-head {
+	.mixin-citizen-header-offset-block-start();
 	background: transparent;
 	transform: translateY( var( --header-offset-block-start ) );
 	.mixin-citizen-sticky-header-background;

--- a/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
+++ b/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
@@ -9,7 +9,9 @@
 @import '../../../resources/variables.less';
 
 .ve-activated {
-	--header-offset-block-start: calc( var( --header-size-block-start ) + var( --height-sticky-header ) + 48px );
+	// No --height-sticky-header term: the sticky header is disabled under
+	// VE and the token keeps its measured value while hidden.
+	--header-offset-block-start: calc( var( --header-size-block-start ) + 48px );
 
 	#citizen-page-header-sticky-sentinel {
 		display: none;

--- a/tests/vitest/skins.citizen.scripts/stickyHeader.test.js
+++ b/tests/vitest/skins.citizen.scripts/stickyHeader.test.js
@@ -156,6 +156,21 @@ describe( 'StickyHeader', () => {
 			expect( document.documentElement.style.getPropertyValue( '--height-sticky-header' ) ).toBe( '64px' );
 		} );
 
+		it( 'should not rewrite the CSS variable when the height is unchanged', () => {
+			const { stickyHeader } = buildStickyHeaderDom();
+			const header = createStickyHeader( stickyHeader );
+			stickyHeader.getBoundingClientRect = vi.fn( () => ( {
+				height: 64, top: 0, bottom: 64, left: 0, right: 100, width: 100, x: 0, y: 0
+			} ) );
+			const setPropertySpy = vi.spyOn( document.documentElement.style, 'setProperty' );
+
+			header.show();
+			header.hide();
+			header.show();
+
+			expect( setPropertySpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		it( 'should bind click listener on show', () => {
 			const { stickyHeader } = buildStickyHeaderDom();
 			const header = createStickyHeader( stickyHeader );
@@ -175,7 +190,7 @@ describe( 'StickyHeader', () => {
 	} );
 
 	describe( 'hide', () => {
-		it( 'should remove visible class and set CSS variable to 0', () => {
+		it( 'should remove visible class and keep the height variable in place', () => {
 			const { stickyHeader } = buildStickyHeaderDom();
 			const header = createStickyHeader( stickyHeader );
 			stickyHeader.getBoundingClientRect = vi.fn( () => ( {
@@ -186,7 +201,7 @@ describe( 'StickyHeader', () => {
 			header.hide();
 
 			expect( document.body.classList.contains( 'citizen-sticky-header-visible' ) ).toBe( false );
-			expect( document.documentElement.style.getPropertyValue( '--height-sticky-header' ) ).toBe( '0px' );
+			expect( document.documentElement.style.getPropertyValue( '--height-sticky-header' ) ).toBe( '64px' );
 		} );
 
 		it( 'should unbind click listener on hide', () => {
@@ -386,6 +401,50 @@ describe( 'StickyHeader', () => {
 			expect( document.getElementById( 'citizen-sticky-header-more' ).children ).toHaveLength( 1 );
 			expect( document.getElementById( 'citizen-sticky-header-languages' ).children ).toHaveLength( 1 );
 			expect( header.cloneDropdowns ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'init', () => {
+		it( 'should pre-measure the bar height into the CSS variable at idle', () => {
+			const { stickyHeader } = buildStickyHeaderDom();
+			stickyHeader.getBoundingClientRect = vi.fn( () => ( {
+				height: 64, top: 0, bottom: 64, left: 0, right: 100, width: 100, x: 0, y: 0
+			} ) );
+			const header = createStickyHeader( stickyHeader );
+
+			header.init();
+
+			expect( document.documentElement.style.getPropertyValue( '--height-sticky-header' ) ).toBe( '64px' );
+		} );
+
+		it( 'should make the first show() skip the variable write', () => {
+			const { stickyHeader } = buildStickyHeaderDom();
+			stickyHeader.getBoundingClientRect = vi.fn( () => ( {
+				height: 64, top: 0, bottom: 64, left: 0, right: 100, width: 100, x: 0, y: 0
+			} ) );
+			const header = createStickyHeader( stickyHeader );
+			const setPropertySpy = vi.spyOn( document.documentElement.style, 'setProperty' );
+
+			header.init();
+			header.show();
+
+			expect( setPropertySpy ).toHaveBeenCalledTimes( 1 );
+			expect( document.body.classList.contains( 'citizen-sticky-header-visible' ) ).toBe( true );
+		} );
+
+		it( 'should write a changed height on the next show()', () => {
+			const { stickyHeader } = buildStickyHeaderDom();
+			let height = 64;
+			stickyHeader.getBoundingClientRect = vi.fn( () => ( {
+				height, top: 0, bottom: height, left: 0, right: 100, width: 100, x: 0, y: 0
+			} ) );
+			const header = createStickyHeader( stickyHeader );
+			header.init();
+
+			height = 72;
+			header.show();
+
+			expect( document.documentElement.style.getPropertyValue( '--height-sticky-header' ) ).toBe( '72px' );
 		} );
 	} );
 


### PR DESCRIPTION
## Problem

`--header-offset-block-start` was derived at the root from a live `--height-sticky-header`, and an inherited custom property that changes at root or body scope recalculates styles for every element in the document. That cost fired on every sticky header show/hide (JS rewrote the variable on `<html>` each time) and on every scroll direction change on mobile (the autohide feature flipped both variables through a body class). Measured at 9–11 ms per toggle on a small test page and 30–40 ms on a production article — it scales with page length and multiplies on phone CPUs, landing exactly on scroll gestures.

## Behaviour

The root token is now static, and the dynamic states live only on the elements that consume the offset (sticky TOC, `.mw-sticky-header-element` and the skinStyles built on it, overflow sticky bands, SearchDigest, SRF datatables, ArticleFeedbackv5), applied through one shared mixin: visible adds the measured bar height, mobile autohide zeroes the offset. JS writes the height variable only when the measured value changes and pre-measures it at idle, so steady-state toggles are pure class flips.

Benchmarked on the same page, main vs branch (medians, forced style+layout flush):

| User event | main | branch |
| --- | --- | --- |
| Sticky bar show/hide, mobile | ~9.0 ms | 0.3 ms |
| Sticky bar show/hide, desktop | ~11.1 ms | 2.6 ms |
| Scroll direction change with autohide (mobile) | 7.1 ms | 1.1 ms |

The residual costs no longer scale with article length (the desktop remainder is the TOC subtree that consumes the offset).

Behaviour change: anchor scroll padding now always reserves the bar height instead of tracking visibility. Any jump below the page title reveals the bar, so this also fixes jumps from the top of the page landing with the target heading covered by the bar. Jumps to targets above the title land with extra headroom, which is benign.

Alternatives measured and rejected: `@property` registration (inherited propagation costs a full recalc regardless), and tracking visibility on the root via `:has()` or a mirrored class (any property change on `<html>` recalcs at subtree scale).

## Contract

- The root `--header-offset-block-start` is static and equals the hidden-state offset. Third-party CSS reading it keeps a correct value while the bar is hidden and no longer sees the bar height while it is shown.
- `--height-sticky-header` keeps its measured value while the bar is hidden. Anything reading it raw must gate on `citizen-sticky-header-visible` — all in-repo readers now do.
- The VisualEditor override keeps working through the same variable; its always-zero sticky-header term is dropped.
- CSS+JS only, no markup or class changes. Cache status: clean.

## Verification

Reviewed (specificity ordering verified via standalone LESS compiles; consumer sweep re-checked repo-wide) and browser-tested against the dev wiki: desktop and mobile real-scroll paths, autohide direction flips, anchor jumps, VisualEditor activation, overflow sticky bands (identical to main; the timeline inset resolves to the same values). 1340 Vitest tests and all lints pass.

## Follow-ups

- Remaining item from the same scrolling audit: frosted glass saturates the GPU while translucent chrome overlaps scrolling content (separate design decision).
- The PR also carries a small AGENTS.md addition documenting the code-comment convention used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBcu2ERwQJWp1MRXz8fck6