### PR TITLE
perf(core): lighten the frosted glass blur to keep scrolling smooth

### DIFF
--- a/resources/skins.citizen.tokens.new/misc.less
+++ b/resources/skins.citizen.tokens.new/misc.less
@@ -37,7 +37,7 @@
 	--filter-invert: none;
 	--filter-invert-primary: invert( 1 ) hue-rotate( 180deg );
 	--backdrop-filter-blur: blur( 2px );
-	--backdrop-filter-frosted-glass: ~'blur( 16px ) saturate( 140% )';
+	--backdrop-filter-frosted-glass: ~'blur( 8px ) saturate( 140% )';
 
 	// Citizen extensions — legacy back-compat aliases, dropped alongside
 	// the legacy pipeline. The HSL trio feeds tokens-citizen.less's

--- a/resources/skins.citizen.tokens/tokens-theme-base.less
+++ b/resources/skins.citizen.tokens/tokens-theme-base.less
@@ -94,7 +94,7 @@
 
 	// Backdrop
 	--backdrop-filter-blur: blur( 2px );
-	--backdrop-filter-frosted-glass: ~'blur( 16px ) saturate( 140% )';
+	--backdrop-filter-frosted-glass: ~'blur( 8px ) saturate( 140% )';
 	--backdrop-opacity: 0.65;
 
 	// Filter


### PR DESCRIPTION
## Problem

`backdrop-filter` re-filters every frame the content beneath it moves, so the sticky header bar and the mobile header bar pay for the frosted glass blur during the entire scroll. Chromium's blur cost jumps sharply between 8px and 16px: on identical scroll passes with the sticky bar visible, the current `blur(16px)` cost +14–27% frame time with the GPU process ~94% busy. This is the last of the three findings from the scrolling performance audit (after #1764 and #1766).

## Behaviour

The frosted glass token drops from `blur(16px)` to `blur(8px)` in both token pipelines. Every glass surface reads the same token, so the change is uniform. Benchmarked on identical scroll passes with the bar visible (medians, settled environment):

| | off | blur(8px) — new | blur(16px) — old |
| --- | --- | --- | --- |
| Frame time | 16.7 ms | 17.0 ms | 18.8 ms |
| GPU process busy | ~64% | ~89% | 94% |
| Frames over 17 ms (per 100) | ~30 | ~48 | 73 |

Across runs, 8px measured between free and half of 16px's cost, and was strictly cheaper in every round. Visually the two radii are near-identical over typical article content; the difference shows mainly over colorful imagery. Caveats: measured on one desktop-class machine — phone GPUs pay backdrop-filter primarily per surface area rather than radius, so the radius trim helps them less, but never hurts.

## Contract

- One token value change per pipeline; no selectors, markup, or classes touched. Cache status: clean.
- Performance mode and `prefers-reduced-transparency` continue to disable the effect entirely.
- Wikis overriding `--backdrop-filter-frosted-glass` in site CSS are unaffected.

## Follow-ups

None — this closes out the scrolling audit. `blur(4px)` measured a further ~12-point GPU reduction at equal frame time if a lighter frost is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBcu2ERwQJWp1MRXz8fck6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the frosted-glass blur effect for a sharper, less diffused appearance.
  * Kept the existing color saturation unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->