### PR TITLE
perf(notifications): stop paying twice to open the notification panel

### DIFF
--- a/resources/skins.citizen.notifications/components/App.vue
+++ b/resources/skins.citizen.notifications/components/App.vue
@@ -212,6 +212,19 @@ module.exports = exports = defineComponent( {
 		// second one.
 		let fetching = false;
 
+		// How far Echo's "seen" marker reaches, and the newest thing waiting
+		// behind it, both unix seconds from the last fetch. Marking seen is
+		// only worth a request when the second is past the first.
+		let seenTime = 0;
+		// Null until a fetch answers, and that is not the same as nothing
+		// waiting: the trigger marks seen as soon as the panel mounts, which is
+		// before the panel's own first fetch can possibly have landed. Reading
+		// that as "nothing waiting" would drop the marker for the whole visit.
+		// A server-confirmed zero is the one case we can answer up front.
+		let newestWaiting = seededEmpty ? 0 : null;
+		// True while a mark-seen request is outstanding.
+		let markingSeen = false;
+
 		function applyResult( result ) {
 			// Server truth supersedes a clear-all sweep still in flight (the
 			// panel was reopened mid-sweep): cancel the pending swap so it
@@ -230,6 +243,12 @@ module.exports = exports = defineComponent( {
 			if ( !wikis.value.length ) {
 				activeSource.value = 'local';
 			}
+			// Never backwards. A refresh issued before the marker was set comes
+			// back carrying the older value, and adopting it would cost a
+			// redundant mark on the next open. Echo has no way to move the
+			// marker back, so the later of the two is always the truth.
+			seenTime = Math.max( seenTime, result.seenTime || 0 );
+			newestWaiting = result.newestWaiting || 0;
 			hasLoaded.value = true;
 			reportCounts();
 		}
@@ -245,7 +264,46 @@ module.exports = exports = defineComponent( {
 		 * cosmetic to Echo alone.
 		 */
 		function markSeen() {
-			source.markSeen( 'all' ).catch( () => {} );
+			// Nothing waiting, or the marker already reaches past it: the
+			// request would set the marker to a later time that no notification
+			// is behind, which changes nothing anyone can observe. Reopening a
+			// panel therefore costs one request, not two.
+			//
+			// The figures come from the last completed fetch, not the refresh
+			// the same open just started, so a notification arriving in that
+			// window is not counted until the following open. It can only
+			// delay the decision, never the effect: Echo marks seen up to the
+			// server's clock rather than up to a notification, so a call made
+			// here covers whatever the refresh is about to bring anyway. The
+			// worst case is Echo's highlight surviving one extra open, which
+			// the next one clears.
+			// One in flight is enough: Echo marks up to its own clock, so the
+			// call already on its way covers anything a second would. Without
+			// this a close-and-reopen before the first lands pays twice, which
+			// is the cost this whole guard exists to avoid.
+			if ( markingSeen ) {
+				return;
+			}
+			if ( newestWaiting !== null && ( !newestWaiting || seenTime >= newestWaiting ) ) {
+				return;
+			}
+			markingSeen = true;
+			source.markSeen( 'all' ).then( ( marked ) => {
+				markingSeen = false;
+				// Carry Echo's own marker forward rather than a local clock, so
+				// a skewed client cannot leave this permanently re-marking or
+				// permanently skipping. Forward only for the same reason as
+				// applyResult, though the guard above is what actually rules
+				// out the reordering — nothing can reach this with two answers
+				// in flight, so treat it as holding the invariant rather than
+				// as a live defence.
+				if ( marked ) {
+					seenTime = Math.max( seenTime, marked );
+				}
+			} ).catch( () => {
+				// Let the next open try again rather than wedging the guard.
+				markingSeen = false;
+			} );
 		}
 
 		// Fetch, showing the skeleton only when there is nothing legitimate on

--- a/resources/skins.citizen.notifications/sources/echo.js
+++ b/resources/skins.citizen.notifications/sources/echo.js
@@ -14,8 +14,13 @@
  *   FetchResult {
  *     items: NotificationItem[],
  *     counts: { total, local, foreign },
- *     wikis: Wiki[]
+ *     wikis: Wiki[],
+ *     seenTime: number,      — how far the "seen" marker reaches, unix seconds
+ *     newestWaiting: number  — newest thing waiting, unix seconds; 0 if nothing
  *   }
+ *
+ * `seenTime` and `newestWaiting` exist so the panel can tell whether marking
+ * seen would change anything, and skip the request when it would not.
  *
  * Only unread notifications are fetched — the panel shows what is waiting,
  * and Special:Notifications is where the history lives.
@@ -90,6 +95,18 @@ function normalizeEntry( entry, labels ) {
 }
 
 /**
+ * Parse an ISO 8601 instant into unix seconds, so seen times and notification
+ * timestamps can be compared as plain numbers.
+ *
+ * @param {string} iso
+ * @return {number} 0 when absent or unparseable
+ */
+function toUnixSeconds( iso ) {
+	const ms = Date.parse( iso );
+	return isNaN( ms ) ? 0 : Math.floor( ms / 1000 );
+}
+
+/**
  * Link target for a cross-wiki summary. Echo hands back each wiki's article
  * path with a `$1` placeholder; anything not shaped like that falls back to the
  * local special page, which is the only surface with a cross-wiki view.
@@ -122,14 +139,13 @@ function normalizeWikis( entry ) {
 	return Object.keys( sources )
 		.map( ( id ) => {
 			const source = sources[ id ];
-			const ts = Date.parse( source.ts );
 			return {
 				id: id,
 				name: source.title || id,
 				url: foreignNotificationsUrl( source ),
 				// That wiki's api.php, for previewing what is waiting there.
 				apiUrl: source.url || '',
-				timestamp: isNaN( ts ) ? 0 : Math.floor( ts / 1000 )
+				timestamp: toUnixSeconds( source.ts )
 			};
 		} )
 		.sort( ( a, b ) => b.timestamp - a.timestamp );
@@ -173,7 +189,9 @@ function createEchoSource( ApiConstructor, ForeignApiConstructor ) {
 			// typical user, whose unread are a handful among a long history.
 			notfilter: '!read',
 			notlimit: FETCH_LIMIT,
-			notprop: 'list|count',
+			// seenTime rides this request, so the panel can tell whether Echo's
+			// marker already covers everything waiting and skip re-marking it.
+			notprop: 'list|count|seenTime',
 			// Ask Echo for its "N unread on other wikis" row, and for
 			// cross-wiki-inclusive counts — the same figure the server already
 			// renders on the bell. Echo only registers this parameter where
@@ -221,7 +239,28 @@ function createEchoSource( ApiConstructor, ForeignApiConstructor ) {
 			// state left to sort on.
 			items.sort( ( a, b ) => b.timestamp - a.timestamp );
 
-			return { items, counts, wikis: rollup ? normalizeWikis( rollup ) : [] };
+			const wikis = rollup ? normalizeWikis( rollup ) : [];
+
+			// Echo keeps a seen time per section and treats the older of the
+			// two as the marker for 'all', so that is what has to cover the
+			// newest thing waiting.
+			const seen = notifications.seenTime || {};
+			const seenTime = Math.min(
+				toUnixSeconds( seen.alert ),
+				toUnixSeconds( seen.message )
+			);
+
+			// What the marker has to reach past to be worth re-setting. Only
+			// unread notifications count: Echo's own badge gates its unseen
+			// state on the unread count and the last unread timestamp, so a
+			// read one can never leave the badge flagged. Other wikis are
+			// included because their rollup rides the same badge.
+			const newestWaiting = Math.max(
+				items.length ? items[ 0 ].timestamp : 0,
+				wikis.reduce( ( max, wiki ) => Math.max( max, wiki.timestamp ), 0 )
+			);
+
+			return { items, counts, wikis, seenTime, newestWaiting };
 		} );
 	}
 
@@ -268,14 +307,31 @@ function createEchoSource( ApiConstructor, ForeignApiConstructor ) {
 	 * Reset the "seen" marker so the badge highlight clears. Items remain
 	 * unread until explicitly read.
 	 *
+	 * A GET, not a POST: the module takes no token, is not write mode, and
+	 * touches the seen-time cache rather than the database. It was made a GET
+	 * deliberately so multi-datacenter wikis can serve it locally instead of
+	 * routing it to the primary — POSTing it gives that up. Echo's own client
+	 * issues a GET here too.
+	 *
+	 * Echo additionally builds its API instance with `cache: false`; this one
+	 * does not, because the option would apply to every request the source
+	 * makes, and the response is already unreusable without it — MediaWiki
+	 * answers with `private, must-revalidate, max-age=0` and no validator, so
+	 * there is nothing a browser could serve from cache.
+	 *
 	 * @param {string} type 'alert' | 'message' | 'all'
-	 * @return {Promise<void>}
+	 * @return {Promise<number>} The marker Echo recorded, unix seconds; 0 when
+	 *   it did not say.
 	 */
 	function markSeen( type ) {
-		return api.postWithToken( 'csrf', {
+		return api.get( {
 			action: 'echomarkseen',
-			type: type
-		} ).then( () => undefined );
+			type: type,
+			timestampFormat: 'ISO_8601'
+		} ).then( ( data ) => {
+			const marked = ( ( ( data || {} ).query || {} ).echomarkseen || {} ).timestamp;
+			return toUnixSeconds( marked );
+		} );
 	}
 
 	/**

--- a/tests/vitest/skins.citizen.notifications/App.test.js
+++ b/tests/vitest/skins.citizen.notifications/App.test.js
@@ -65,11 +65,23 @@ function cloneItems() {
 	return ITEMS.map( ( item ) => Object.assign( {}, item ) );
 }
 
+// The seen marker sits behind the newest notification, so the panel has
+// something to mark; the tests that care override these.
+const SEEN_TIME = 1700000000;
+const NEWEST_WAITING = 1700000400;
+
 function makeSource( overrides ) {
 	return Object.assign( {
-		fetch: vi.fn().mockResolvedValue( { items: cloneItems(), counts: Object.assign( {}, COUNTS ), wikis: [] } ),
+		fetch: vi.fn().mockResolvedValue( {
+			items: cloneItems(),
+			counts: Object.assign( {}, COUNTS ),
+			wikis: [],
+			seenTime: SEEN_TIME,
+			newestWaiting: NEWEST_WAITING
+		} ),
 		fetchWiki: vi.fn().mockResolvedValue( { items: [] } ),
-		markSeen: vi.fn().mockResolvedValue(),
+		// Echo answers with the marker it recorded.
+		markSeen: vi.fn().mockResolvedValue( NEWEST_WAITING + 10 ),
 		markRead: vi.fn().mockResolvedValue(),
 		markAllRead: vi.fn().mockResolvedValue()
 	}, overrides );
@@ -111,6 +123,195 @@ describe( 'notifications App', () => {
 		wrapper.vm.markSeen();
 
 		expect( source.markSeen ).toHaveBeenCalledWith( 'all' );
+	} );
+
+	describe( 'marking seen', () => {
+		it( 'marks seen on a cold open, before its own first fetch has landed', () => {
+			// The trigger marks seen straight after mounting, so this runs with
+			// no fetch result yet. Treating that as "nothing waiting" would
+			// drop the marker for the whole visit.
+			const source = makeSource();
+			const wrapper = mountApp( source );
+
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).toHaveBeenCalledWith( 'all' );
+		} );
+
+		it( 'trusts a server-confirmed zero without waiting for the fetch', () => {
+			// The one thing we can answer before fetching: the server rendered
+			// a count of zero, so there is nothing for a marker to cover.
+			const source = makeSource();
+			const wrapper = mountApp( source, { initialCount: 0 } );
+
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).not.toHaveBeenCalled();
+		} );
+
+		it( 'skips the request when the marker sits exactly on the newest item', async () => {
+			const source = makeSource( {
+				fetch: vi.fn().mockResolvedValue( {
+					items: cloneItems(), counts: Object.assign( {}, COUNTS ), wikis: [],
+					seenTime: NEWEST_WAITING, newestWaiting: NEWEST_WAITING
+				} )
+			} );
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).not.toHaveBeenCalled();
+		} );
+
+		it( 'keeps its own marker when a refresh answers with an older one', async () => {
+			const source = makeSource();
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+			await flushPromises();
+			expect( source.markSeen ).toHaveBeenCalledTimes( 1 );
+
+			// A refresh already in flight when the marker was set comes back
+			// carrying the older value; adopting it would cost a second mark.
+			wrapper.vm.refresh();
+			await flushPromises();
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'asks once while a mark is still in flight', async () => {
+			// Echo marks up to its own clock, so the call already on its way
+			// covers anything a second would.
+			let settle;
+			const source = makeSource( {
+				markSeen: vi.fn( () => new Promise( ( resolve ) => {
+					settle = resolve;
+				} ) )
+			} );
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+			wrapper.vm.markSeen();
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).toHaveBeenCalledTimes( 1 );
+
+			// Once it lands the guard lifts again, though the marker it carried
+			// forward now covers everything waiting.
+			settle( NEWEST_WAITING + 10 );
+			await flushPromises();
+			expect( source.markSeen ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'keeps its previous marker when Echo answers without one', async () => {
+			const source = makeSource( { markSeen: vi.fn().mockResolvedValue( 0 ) } );
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+			await flushPromises();
+
+			// Nothing to carry forward, so the next open asks again rather than
+			// recording a marker of zero and skipping forever.
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'skips the request when the marker already covers everything waiting', async () => {
+			const source = makeSource( {
+				fetch: vi.fn().mockResolvedValue( {
+					items: cloneItems(),
+					counts: Object.assign( {}, COUNTS ),
+					wikis: [],
+					// Already past the newest notification.
+					seenTime: NEWEST_WAITING + 1,
+					newestWaiting: NEWEST_WAITING
+				} )
+			} );
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).not.toHaveBeenCalled();
+		} );
+
+		it( 'skips the request when nothing is waiting at all', async () => {
+			const source = makeSource( {
+				fetch: vi.fn().mockResolvedValue( {
+					items: [], counts: { total: 0, local: 0, foreign: 0 }, wikis: [],
+					seenTime: 0, newestWaiting: 0
+				} )
+			} );
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).not.toHaveBeenCalled();
+		} );
+
+		it( 'marks once, then stops asking until something newer arrives', async () => {
+			const source = makeSource();
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			// First open: the marker is behind, so Echo is told.
+			wrapper.vm.markSeen();
+			await flushPromises();
+			expect( source.markSeen ).toHaveBeenCalledTimes( 1 );
+
+			// Reopening with nothing new must not ask again — this is the
+			// second request per open that the guard exists to remove.
+			wrapper.vm.markSeen();
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'marks again once a newer notification lands', async () => {
+			const source = makeSource();
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+			await flushPromises();
+			expect( source.markSeen ).toHaveBeenCalledTimes( 1 );
+
+			// A refresh brings something newer than the marker Echo returned.
+			source.fetch.mockResolvedValueOnce( {
+				items: cloneItems(),
+				counts: Object.assign( {}, COUNTS ),
+				wikis: [],
+				seenTime: NEWEST_WAITING + 10,
+				newestWaiting: NEWEST_WAITING + 500
+			} );
+			wrapper.vm.refresh();
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'keeps asking when the request fails, rather than assuming it landed', async () => {
+			const source = makeSource( {
+				markSeen: vi.fn().mockRejectedValue( new Error( 'network' ) )
+			} );
+			const wrapper = mountApp( source );
+			await flushPromises();
+
+			wrapper.vm.markSeen();
+			await flushPromises();
+			wrapper.vm.markSeen();
+
+			expect( source.markSeen ).toHaveBeenCalledTimes( 2 );
+		} );
 	} );
 
 	it( 'renders one list, in the order the source gave', async () => {

--- a/tests/vitest/skins.citizen.notifications/echoSource.test.js
+++ b/tests/vitest/skins.citizen.notifications/echoSource.test.js
@@ -91,7 +91,13 @@ const RESPONSE = {
 			],
 			continue: null,
 			rawcount: 3,
-			count: '3'
+			count: '3',
+			// Echo keeps one marker per section; 'all' is the older of the two.
+			// Second precision, no milliseconds, as Echo's TS_ISO_8601 emits.
+			seenTime: {
+				alert: '2023-11-14T22:19:10Z',
+				message: '2023-11-14T22:15:00Z'
+			}
 		},
 		// Parsed echo-category-title-* messages, including one from an
 		// extension (edit-thank, Extension:Thanks).
@@ -477,17 +483,134 @@ describe( 'createEchoSource', () => {
 		} );
 	} );
 
-	describe( 'mutations', () => {
-		it( 'markSeen posts the given type with a csrf token', async () => {
-			const { ApiConstructor, postWithToken } = makeApi( RESPONSE );
+	describe( 'seen marker', () => {
+		it( 'asks for the seen time on the request it already makes', async () => {
+			const { ApiConstructor, get } = makeApi( RESPONSE );
 			const source = createEchoSource( ApiConstructor );
 
-			await source.markSeen( 'all' );
+			await source.fetch();
 
-			expect( postWithToken ).toHaveBeenCalledWith( 'csrf', {
-				action: 'echomarkseen',
-				type: 'all'
+			expect( get ).toHaveBeenCalledTimes( 1 );
+			expect( get.mock.calls[ 0 ][ 0 ].notprop ).toContain( 'seenTime' );
+		} );
+
+		it( 'takes the older of the two section markers, as Echo does for "all"', async () => {
+			const { ApiConstructor } = makeApi( RESPONSE );
+			const source = createEchoSource( ApiConstructor );
+
+			const result = await source.fetch();
+
+			// message (22:15:00) is older than alert (22:19:10).
+			expect( result.seenTime ).toBe( 1700000100 );
+		} );
+
+		it( 'reports the newest unread notification as what the marker must cover', async () => {
+			const { ApiConstructor } = makeApi( RESPONSE );
+			const source = createEchoSource( ApiConstructor );
+
+			const result = await source.fetch();
+
+			expect( result.newestWaiting ).toBe( 1700000400 );
+		} );
+
+		it( 'counts another wiki as something waiting, since it rides the same badge', async () => {
+			const recentWiki = {
+				examplewiki: {
+					title: 'Example Wiki',
+					url: 'https://example.org/w/api.php',
+					base: 'https://example.org/wiki/$1',
+					// Later than any local notification (22:20:00).
+					ts: '2023-11-14T23:00:00Z'
+				}
+			};
+			const { ApiConstructor } = makeApi( responseWithSummary( recentWiki ) );
+			const source = createEchoSource( ApiConstructor );
+
+			const result = await source.fetch();
+
+			expect( result.newestWaiting ).toBe( 1700002800 );
+		} );
+
+		it( 'ignores another wiki that is older than what is waiting here', async () => {
+			// The bundled fixture's wiki last saw activity well before the
+			// local notifications, so it must not drag the figure backwards.
+			const { ApiConstructor } = makeApi( responseWithSummary() );
+			const source = createEchoSource( ApiConstructor );
+
+			const result = await source.fetch();
+
+			expect( result.newestWaiting ).toBe( 1700000400 );
+		} );
+
+		it( 'reads Echo\'s never-seen sentinel as older than anything waiting', async () => {
+			// Echo has no "absent" marker: with nothing stored it reports
+			// unix 1, so this is what a user who has never opened the panel
+			// actually gets back.
+			const neverSeen = structuredClone( RESPONSE );
+			neverSeen.query.notifications.seenTime = {
+				alert: '1970-01-01T00:00:01Z',
+				message: '1970-01-01T00:00:01Z'
+			};
+			const { ApiConstructor } = makeApi( neverSeen );
+			const source = createEchoSource( ApiConstructor );
+
+			const result = await source.fetch();
+
+			expect( result.seenTime ).toBe( 1 );
+			expect( result.seenTime ).toBeLessThan( result.newestWaiting );
+		} );
+
+		it( 'treats a marker Echo did not send as unseen rather than as now', async () => {
+			const bare = structuredClone( RESPONSE );
+			delete bare.query.notifications.seenTime;
+			const { ApiConstructor } = makeApi( bare );
+			const source = createEchoSource( ApiConstructor );
+
+			const result = await source.fetch();
+
+			// Zero is older than anything waiting, so the panel marks seen.
+			expect( result.seenTime ).toBe( 0 );
+		} );
+
+		it( 'reports nothing waiting when the list and the wikis are both empty', async () => {
+			const { ApiConstructor } = makeApi( {
+				query: { notifications: { list: [], rawcount: 0 }, allmessages: [] }
 			} );
+			const source = createEchoSource( ApiConstructor );
+
+			const result = await source.fetch();
+
+			expect( result.newestWaiting ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'mutations', () => {
+		it( 'marks seen with a plain GET, which multi-DC wikis can serve locally', async () => {
+			const { ApiConstructor, get, postWithToken } = makeApi( {
+				query: { echomarkseen: { result: 'success', timestamp: '2026-08-07T21:27:42Z' } }
+			} );
+			const source = createEchoSource( ApiConstructor );
+
+			const marked = await source.markSeen( 'all' );
+
+			// The module takes no token and is not write mode; POSTing it would
+			// pin the request to the primary datacentre for nothing.
+			expect( postWithToken ).not.toHaveBeenCalled();
+			expect( get ).toHaveBeenCalledWith( {
+				action: 'echomarkseen',
+				type: 'all',
+				timestampFormat: 'ISO_8601'
+			} );
+			// Echo's own marker comes back, so the panel can carry it forward
+			// instead of trusting the client clock.
+			expect( marked ).toBe( 1786138062 );
+		} );
+
+		it( 'reports an unparseable seen marker as zero rather than NaN', async () => {
+			const { ApiConstructor } = makeApi( { query: { echomarkseen: { result: 'success' } } } );
+			const source = createEchoSource( ApiConstructor );
+
+			await expect( source.markSeen( 'all' ) ).resolves.toBe( 0 );
 		} );
 
 		it( 'markRead posts the id list', async () => {


### PR DESCRIPTION
## Problem

Opening the notification dropdown cost two API requests: the notifications
fetch, and a call telling Echo the streams had been seen. Two things were wrong
with the second one.

**It was a POST carrying a CSRF token.** `ApiEchoMarkSeen` overrides none of
`needsToken` / `mustBePosted` / `isWriteMode`, so on `ApiBase` defaults it needs
neither a token nor a POST, and it writes to the seen-time cache rather than the
database — its own header comment says so. Echo made it a GET module on purpose
so multi-datacentre wikis can serve it locally instead of routing it to the
primary (T222851), and calls it that way from its own client. Citizen was giving
that up for nothing.

**It fired on every open regardless of whether anything had changed.** Echo
marks seen up to the current time, so re-marking when the existing marker
already sits past everything waiting cannot change what anyone sees. Opening the
panel five times with nothing arriving spent five of those calls on nothing.

## Behaviour

| | before | after |
| --- | --- | --- |
| Open, marker behind | 1 GET + 1 **POST** | 1 GET + 1 **GET** |
| Open, nothing new | 1 GET + 1 POST | **1 GET** |
| Five reopens, nothing new | 10 requests | **5 requests** |

Measured against the dev wiki: no POST is issued on any path, a cold open with
the marker behind still marks, and consecutive reopens with nothing new issue
one request each.

## Contract

**What counts as "waiting"** is the newest unread notification, plus any other
wiki in the cross-wiki roll-up, since that rides the same badge. Read
notifications are deliberately excluded: Echo's own badge gates its unseen state
on the unread count and `getLastUnreadMessageTime()` /
`getLastUnreadAlertTime()`, so a read notification can never leave the badge
flagged.

**Not knowing is distinct from nothing waiting.** The trigger marks seen as soon
as the panel mounts, which is before the panel's own first fetch can have
landed. An unanswered fetch therefore marks rather than skips — otherwise a cold
open, which is every keyboard activation and every first click that beats the
hover prefetch, would drop the marker for the whole visit. A count of zero from
the server is the one case answerable up front, and it skips.

**The marker only moves forward.** What is carried between opens is the marker
Echo returns, not a local clock, so a skewed client can neither re-mark forever
nor skip forever; and a refresh issued before the mark comes back carrying the
older value, which is ignored rather than adopted.

**`seenTime` rides the existing request.** `notprop=seenTime` is added to the
fetch the panel already makes, so the dedupe costs no extra round trip.

**Only one mark is ever in flight.** Echo marks up to its own clock, so the call
already on its way covers anything a second would; without that guard a
close-and-reopen before it lands would pay the very cost this change removes.

## Known limit

`markSeen()` decides using the last completed fetch, not the refresh the same
open just started. It can only delay the decision, never the effect, because
Echo marks seen up to the server's clock rather than up to a particular
notification — so a call made here covers whatever the refresh is about to
bring. Worst case is Echo's highlight surviving one extra open, which the next
one clears. Documented in a comment in `App.vue`.

## Verified

Cold open, warm hover-then-click, repeated reopens, and a server-confirmed count
of zero, all against the dev wiki with request logging. Vitest suite green;
ESLint, stylelint and compat lint clean. No PHP touched.

The tests were checked by mutation rather than merely run — each of these fails
when the behaviour it names is removed:

| mutation | fails |
| --- | --- |
| reinstate the `0` sentinel for "unknown" | marks seen on a cold open |
| drop `Math.max` on the marker | keeps its own marker when a refresh answers with an older one |
| remove the skip guard | three dedupe tests |
| revert the GET to `postWithToken` | marks seen with a plain GET |
| remove the in-flight guard | asks once while a mark is still in flight |

## Follow-ups

- None outstanding. The one-open lag above is accepted rather than deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Notification read-status tracking is now more accurate and remains synchronized with the server.
  * The interface avoids repeated “mark as seen” requests when no new notifications are waiting.
  * Notification updates are protected against overlapping requests and stale responses.
  * Newly arrived notifications correctly advance the waiting status.
  * Failed read-status updates can be retried automatically.
  * Notification timestamps are handled consistently across local and cross-wiki activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->