### PR TITLE
refactor(sections): remove an unreachable heading check in the section builder

### DIFF
--- a/includes/Components/CitizenComponentBodyContent.php
+++ b/includes/Components/CitizenComponentBodyContent.php
@@ -140,39 +140,7 @@ class CitizenComponentBodyContent implements CitizenComponent {
 			return null;
 		}
 
-		if ( !$this->isValidSectionHeading( $node ) ) {
-			return null;
-		}
-
 		return (int)$tagName[1];
-	}
-
-	/**
-	 * Checks if a node is a valid heading for creating a section.
-	 * This is used to filter out headings that shouldn't create sections,
-	 * e.g., headings inside the Table of Contents.
-	 */
-	private function isValidSectionHeading( Element $element ): bool {
-		// A heading element can be the element itself (h1-h6) or a wrapper div.
-		$headingElement = $element;
-		if ( !in_array( strtolower( $element->tagName ), $this->topHeadingTags ) ) {
-			// If the element is not a heading tag, it might be a wrapper.
-			$found = DOMCompat::querySelector( $element, implode( ',', $this->topHeadingTags ) );
-			if ( !$found ) {
-				// Not a valid heading wrapper.
-				return false;
-			}
-		}
-
-		$parent = $headingElement->parentNode;
-		if ( !( $parent instanceof Element ) ) {
-			// Should not happen in a valid document.
-			return false;
-		}
-
-		$classList = DOMCompat::getClassList( $parent );
-		// Ignore headings inside the Table of Contents.
-		return !$classList->contains( 'toctitle' );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
@@ -30,7 +30,6 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::createSectionBodyElement
 	 * @covers ::getSectionHeadingLevel
 	 * @covers ::getTemplateData
-	 * @covers ::isValidSectionHeading
 	 * @covers ::makeSections
 	 * @covers ::prepareHeading
 	 */


### PR DESCRIPTION
## Problem

`CitizenComponentBodyContent::isValidSectionHeading()` looked like a safety guard excluding table-of-contents headings from being turned into sections. It could never fire.

The section walk only ever examines direct children of `div.mw-parser-output` — it captures the next sibling *before* reparenting the current node, so every node reaching the check has the container as its parent. The check tested the parent's class list for `toctitle`, which the container never carries.

The method was also internally broken: for wrapped headings it located the inner heading element but never assigned it, so it inspected the original node's parent regardless.

## Behaviour

Byte-identical HTML for every input. The guard always returned `true` on the only reachable path, so removing it changes nothing that ships.

Table-of-contents markup continues to be excluded, as it always actually was — legacy `<div id="toc">` wrappers fail the heading-tag check earlier in `getSectionHeadingLevel()`, before the removed guard was ever consulted.

## Contract

The `Ignores TOC title headings` test case is retained unchanged, and still passes. It is the behavioural proof that TOC exclusion survives this deletion.

## Follow-ups

None. Note for future readers: TOC exclusion rests on the *walk visiting only direct children*, not on the tag check alone — worth knowing before anyone "simplifies" that area further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnWqmgRUvoSDMgbiGjichr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heading recognition for page structure and accessibility.
  * Headings are now consistently assigned their level without being incorrectly excluded based on surrounding content.

* **Tests**
  * Updated heading-related test coverage to reflect the improved behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->