### PR TITLE
docs(commandPalette): sync type definitions with the shipped contract

### DIFF
--- a/resources/skins.citizen.commandPalette/components/CommandPaletteGalleryItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteGalleryItem.vue
@@ -38,7 +38,6 @@
 <script>
 const { defineComponent, computed, ref } = require( 'vue' );
 const CommandPaletteImage = require( './CommandPaletteImage.vue' );
-const { CommandPaletteItem } = require( '../types.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
@@ -126,7 +125,7 @@ module.exports = exports = defineComponent( {
 				event.shiftKey
 			) );
 			emit( 'select',
-				/** @type {CommandPaletteItem} */ ( {
+				/** @type {import('../types.js').CommandPaletteItem} */ ( {
 					id: props.id,
 					label: props.label,
 					url: props.url,

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItem.vue
@@ -44,7 +44,6 @@ const { defineComponent, computed, ref } = require( 'vue' );
 // Import the new sub-components
 const CommandPaletteListItemContent = require( './CommandPaletteListItemContent.vue' );
 const CommandPaletteListItemActions = require( './CommandPaletteListItemActions.vue' );
-const { CommandPaletteItem } = require( '../types.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
@@ -157,7 +156,7 @@ module.exports = exports = defineComponent( {
 				event.shiftKey
 			) );
 			emit( 'select',
-				/** @type {CommandPaletteItem} */ ( {
+				/** @type {import('../types.js').CommandPaletteItem} */ ( {
 					id: props.id,
 					label: props.label,
 					url: props.url,

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
@@ -25,7 +25,6 @@
 <script>
 const { defineComponent, ref, onBeforeUpdate, nextTick } = require( 'vue' );
 const { CdxIcon, CdxButton } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
-const { CommandPaletteActionEvent } = require( '../types.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {
@@ -120,7 +119,7 @@ module.exports = exports = defineComponent( {
 				actionType = 'navigate';
 			}
 
-			/** @type {CommandPaletteActionEvent} */
+			/** @type {import('../types.js').CommandPaletteActionEvent} */
 			const payload = {
 				type: actionType,
 				itemId: props.itemId, // Include parent item ID

--- a/resources/skins.citizen.commandPalette/modes/namespace.js
+++ b/resources/skins.citizen.commandPalette/modes/namespace.js
@@ -1,7 +1,7 @@
 /**
  * Command handler for retrieving namespace suggestions.
  */
-const { CommandPaletteItem, PaletteMode, CommandPaletteExitWithQueryAction, CommandPaletteNoneAction } = require( '../types.js' );
+
 const { cdxIconArticles } = require( '../icons.json' );
 const { defineMode } = require( '../services/defineMode.js' );
 
@@ -82,7 +82,7 @@ function getNamespaceIndex() {
 
 /**
  * @param {NamespaceResult} nsResult
- * @return {CommandPaletteItem}
+ * @return {import('../types.js').CommandPaletteItem}
  */
 function adaptNamespaceResult( nsResult ) {
 	return {
@@ -104,7 +104,7 @@ function adaptNamespaceResult( nsResult ) {
  * Gets namespace suggestions based on the sub-query by filtering local config.
  *
  * @param {string} subQuery The part of the query after "/ns" or "/ns ", or the ID part (e.g., "1").
- * @return {Promise<Array<CommandPaletteItem>>} A promise resolving to an array of adapted namespace items.
+ * @return {Promise<Array<import('../types.js').CommandPaletteItem>>} A promise resolving to an array of adapted namespace items.
  */
 function getNamespaceResults( subQuery ) {
 	const allNamespaces = getNamespaceEntries().map( ( entry ) => ( {
@@ -187,7 +187,7 @@ function matchNamespacePrefix( text ) {
 	return { label: name ? `${ name }:` : raw, raw };
 }
 
-/** @type {PaletteMode} */
+/** @type {import('../types.js').PaletteMode} */
 module.exports = defineMode( {
 	id: 'namespace',
 	triggers: [ '/ns:', ':' ],
@@ -209,8 +209,8 @@ module.exports = defineMode( {
 	/**
 	 * Handles selection of a namespace result item.
 	 *
-	 * @param {CommandPaletteItem} item The selected namespace result item.
-	 * @return {CommandPaletteExitWithQueryAction | CommandPaletteNoneAction}
+	 * @param {import('../types.js').CommandPaletteItem} item The selected namespace result item.
+	 * @return {import('../types.js').CommandPaletteExitWithQueryAction | import('../types.js').CommandPaletteNoneAction}
 	 */
 	onResultSelect( item ) {
 		// Default behavior: update query with the namespace trigger (e.g., "Talk:")

--- a/resources/skins.citizen.commandPalette/services/recentItems.js
+++ b/resources/skins.citizen.commandPalette/services/recentItems.js
@@ -1,4 +1,3 @@
-const { CommandPaletteItem } = require( '../types.js' );
 const { cdxIconArticleSearch, cdxIconTrash } = require( '../icons.json' );
 const RECENT_ITEMS_KEY = 'skin-citizen-command-palette-recent-items';
 const MAX_RECENT_ITEMS = 5;
@@ -47,7 +46,7 @@ function createRecentItems() {
 	/**
 	 * Gets recent items from history
 	 *
-	 * @return {Array<CommandPaletteItem>} Recent items in the format expected by the command palette
+	 * @return {Array<import('../types.js').CommandPaletteItem>} Recent items in the format expected by the command palette
 	 */
 	function getRecentItems() {
 		const items = mw.storage.getObject( RECENT_ITEMS_KEY ) ?? [];

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -16,6 +16,7 @@
  * @property {string} [icon] Optional SVG icon string or object.
  * @property {string} label Metadata label (e.g., matched title for redirect).
  * @property {boolean} [highlightQuery] Whether to highlight the query in the label.
+ * @property {'success'|'error'} [status] Optional status tint for the badge (e.g. the size-delta direction in the history mode).
  */
 
 /**
@@ -54,11 +55,22 @@
  */
 
 /**
+ * Media block rendered at the top of the detail panel.
+ *
+ * @typedef {Object} CommandPaletteItemDetailMedia
+ * @property {string} src Image URL; empty string when the item has no renderable thumbnail.
+ * @property {?number} width Intrinsic width, when known.
+ * @property {?number} height Intrinsic height, when known.
+ * @property {Object|null} [placeholderIcon] Codex icon shown while loading, on load error, or when `src` is empty.
+ */
+
+/**
  * Detail data shown in the side panel when an item is focused.
  *
  * @typedef {Object} CommandPaletteItemDetail
  * @property {Array<CommandPaletteDetailPair>} [pairs] Key-value pairs to display.
  * @property {CommandPaletteItemDetailHeader} [header] Optional header rendered above the pairs.
+ * @property {CommandPaletteItemDetailMedia} [media] Optional media block rendered above the header and pairs.
  */
 
 /**
@@ -77,6 +89,7 @@
  * @property {Array<CommandPaletteItemAction>} [actions] Optional list of actions available for the item.
  * @property {string} [value] Optional mode-specific payload associated with the item (e.g. the namespace trigger '/ns:', or the SMW property name for value suggestions).
  * @property {boolean} [highlightQuery] Whether to highlight the query in the label.
+ * @property {string} [highlightTerm] Overrides the term highlighted in the label — set by providers whose sub-query differs from the full input. Falls back to the current search query.
  * @property {CommandPaletteItemDetail} [detail] Optional detail data shown in the side panel when focused.
  * @property {string} [source] Identifier of the provider that generated this item (e.g., 'recent', 'command', 'search').
  * @property {boolean} [isMouseClick] True if the selection was triggered by a mouse click.
@@ -214,6 +227,15 @@
  */
 
 /**
+ * Action to append a token chip to the input and clear the free text,
+ * without leaving the current mode.
+ *
+ * @typedef {Object} CommandPaletteAddTokenAction
+ * @property {'addToken'} action
+ * @property {{label: string, raw: string, modeId: string, position: string, variant: (string|undefined)}} payload The token to append — the shape TokenPattern matchers produce, plus its owning mode.
+ */
+
+/**
  * Action to toggle the in-palette help overlay.
  *
  * @typedef {Object} CommandPaletteToggleHelpAction
@@ -233,7 +255,7 @@
  * Describes the action the UI should take after an item selection is handled.
  * This is a discriminated union based on the 'action' property.
  *
- * @typedef {CommandPaletteNavigateAction | CommandPaletteExitWithQueryAction | CommandPaletteUpdateQueryAction | CommandPalettePushModeContextAction | CommandPaletteToggleHelpAction | CommandPaletteNoneAction} CommandPaletteActionResult
+ * @typedef {CommandPaletteNavigateAction | CommandPaletteExitWithQueryAction | CommandPaletteUpdateQueryAction | CommandPalettePushModeContextAction | CommandPaletteAddTokenAction | CommandPaletteToggleHelpAction | CommandPaletteNoneAction} CommandPaletteActionResult
  */
 
 /**
@@ -250,7 +272,6 @@
 /**
  * @typedef {Object} CitizenCommandPaletteSearchClient
  * @property {function(string): Promise<CommandPaletteSearchResponse>} fetchByQuery
- * @property {function(): Promise<CommandPaletteSearchResponse>} [loadMore]
  */
 
 /**
@@ -264,9 +285,8 @@
  *
  * @interface CommandPaletteProvider
  * @property {string} id - Unique identifier for the provider.
- * @property {boolean} isAsync - Whether the provider fetches results asynchronously.
- * @property {?number} debounceMs - Debounce time in milliseconds for async providers.
- * @property {boolean} keepStaleResultsOnQueryChange - Whether to keep stale results when the query changes.
+ * @property {number} debounceMs - Debounce in milliseconds; 0 fetches immediately on every keystroke.
+ * @property {boolean} keepStaleResults - Whether the previous results stay on screen while fresh ones load.
  * @property {function(string): boolean} canProvide - Method to check if the provider can handle the query.
  * @property {function(string): Array<CommandPaletteItem>|Promise<Array<CommandPaletteItem>>} getResults - Method to fetch results.
  * @property {?function(CommandPaletteItem): CommandPaletteActionResult|Promise<CommandPaletteActionResult>} onResultSelect - Optional method to handle result selection.

--- a/resources/skins.citizen.commandPalette/utils/providerActions.js
+++ b/resources/skins.citizen.commandPalette/utils/providerActions.js
@@ -1,13 +1,11 @@
-const { CommandPaletteItem, CommandPaletteNavigateAction, CommandPaletteNoneAction } = require( '../types.js' );
-
 /**
  * Returns a navigation action result based on the item's URL.
  *
  * This is primarily used for keyboard-driven selections (e.g., Enter key),
  * as clicks on items with URLs are handled by standard browser behavior on `<a>` tags.
  *
- * @param {CommandPaletteItem} item The selected item.
- * @return {CommandPaletteNavigateAction | CommandPaletteNoneAction} Action result for the UI.
+ * @param {import('../types.js').CommandPaletteItem} item The selected item.
+ * @return {import('../types.js').CommandPaletteNavigateAction | import('../types.js').CommandPaletteNoneAction} Action result for the UI.
  */
 function getNavigationAction( item ) {
 	if ( !item?.url ) {


### PR DESCRIPTION
## Problem

`resources/skins.citizen.commandPalette/types.js` is what a third-party mode or provider author reads to learn the palette's contract, and it had drifted from the code in both directions.

Shipped but undocumented:

- the `addToken` action result
- `detail.media` on the detail panel
- `highlightTerm` on list items
- `status` on item metadata

Documented but fictional:

- `isAsync` and `keepStaleResultsOnQueryChange` on the provider interface — the real fields are `debounceMs` and `keepStaleResults`
- `loadMore` on the search client — no implementation anywhere

Separately, six files pulled type names out of `types.js` with a runtime `require()`. That module exports an empty object, so every one of those bindings was `undefined` at runtime — harmless only because they were referenced from JSDoc alone, but it reads like a real import while doing nothing.

## Behaviour

None. Comments and annotations only; no runtime line changes.

## Contract

Where the code and the types disagreed, the code was treated as correct and the types were corrected to match — no behaviour was changed to fit a stale annotation. Each documented producer and consumer was checked against the source before its typedef was written.

The six no-op requires are replaced by inline `import('../types.js').X` references at the use sites, which is the idiom the module already uses in `paletteRegistry.js`, `defineMode.js`, `searchClient.js` and `modes/help.js`. No new type-reference style is introduced.

## Follow-ups

`CommandPaletteProvider.onResultSelect` is still typed nullable although `createProvider` always defaults it. That remains accurate for hand-built providers, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnWqmgRUvoSDMgbiGjichr