### PR TITLE
chore: remove two static analysis suppressions that no longer apply

### DIFF
--- a/includes/Components/CitizenComponentBodyContent.php
+++ b/includes/Components/CitizenComponentBodyContent.php
@@ -76,7 +76,6 @@ class CitizenComponentBodyContent implements CitizenComponent {
 		while ( $currentNode ) {
 			$nextNode = $currentNode->nextSibling;
 
-			// @phan-suppress-next-line PhanTypeMismatchArgument DOMNode is a Parsoid DOM\Node alias
 			$level = $this->getSectionHeadingLevel( $currentNode );
 			if ( $level === null ) {
 				$currentSection->appendChild( $currentNode );
@@ -192,7 +191,6 @@ class CitizenComponentBodyContent implements CitizenComponent {
 		$sectionBody->setAttribute( 'id', 'citizen-section-' . $sectionNumber );
 		$sectionBody->setAttribute( 'class', self::SECTION_CLASS );
 
-		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType DOMElement is a Parsoid DOM\Element alias
 		return $sectionBody;
 	}
 


### PR DESCRIPTION
## Problem

`composer phan` fails on `main`. Both reported issues are `UnusedPluginSuppression` in `CitizenComponentBodyContent.php`: two `@phan-suppress-next-line` annotations silencing type mismatches that no longer occur.

Because Phan treats a stale suppression as an issue in its own right, the two annotations were the only thing failing the analysis job — they were suppressing nothing and failing the run that checks for exactly that.

## Behaviour

None. Comment-only change.

## Contract

`composer phan` exits 0 on this branch. Verified that the underlying type mismatches do not resurface once the annotations are gone — Phan reports no issues at all, rather than trading two suppression warnings for two type warnings.

Both annotations pre-date any recent work on this file; this is not fallout from another change.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnWqmgRUvoSDMgbiGjichr