### PR TITLE
fix(docs): repair the copy button hover and harden the docs build

### DIFF
--- a/docs/.vitepress/theme/components/ChangelogByTag.vue
+++ b/docs/.vitepress/theme/components/ChangelogByTag.vue
@@ -23,7 +23,7 @@
 <script setup lang="ts">
 import MarkdownIt from "markdown-it";
 import { computed } from "vue";
-import { data as changelogs } from "../data/changelogs.data";
+import { data as changelogs } from "../data/changelogs.data.ts";
 import { formatChangelog } from "../utils/formatChangelog.ts";
 import ContributorList from "./ContributorList.vue";
 

--- a/docs/.vitepress/theme/components/ChangelogsList.vue
+++ b/docs/.vitepress/theme/components/ChangelogsList.vue
@@ -22,10 +22,10 @@
 <script setup lang="ts">
 import { withBase } from "vitepress";
 import MarkdownIt from "markdown-it";
-import { data as changelogs } from "../data/changelogs.data";
+import { data as changelogs } from "../data/changelogs.data.ts";
 import { formatChangelog } from "../utils/formatChangelog.ts";
 import ContributorList from "./ContributorList.vue";
-import { GITHUB_OWNER, GITHUB_REPO } from "../../constants";
+import { GITHUB_OWNER, GITHUB_REPO } from "../../constants.ts";
 
 const md = new MarkdownIt({ html: true });
 

--- a/docs/.vitepress/theme/components/ContributorList.vue
+++ b/docs/.vitepress/theme/components/ContributorList.vue
@@ -27,7 +27,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { extractContributors } from "../utils/contributors";
+import { extractContributors } from "../utils/contributors.ts";
 
 const { body } = defineProps<{ body: string }>();
 

--- a/docs/.vitepress/theme/components/CopyCode.vue
+++ b/docs/.vitepress/theme/components/CopyCode.vue
@@ -82,8 +82,8 @@ async function copy() {
 
 .copy-btn:hover {
 	color: var(--vp-c-text-1);
-	background-color: var(--vp-c-bg-mute);
-	border-color: var(--vp-c-brand);
+	background-color: var(--vp-c-default-soft);
+	border-color: var(--vp-c-brand-1);
 }
 
 .icon-copy,

--- a/docs/.vitepress/theme/data/changelogs.data.ts
+++ b/docs/.vitepress/theme/data/changelogs.data.ts
@@ -1,7 +1,7 @@
 import type { GetResponseDataTypeFromEndpointMethod } from "@octokit/types";
 import { Octokit } from "@octokit/rest";
 import { defineLoader } from "vitepress";
-import { GITHUB_OWNER, GITHUB_REPO } from "../../constants";
+import { GITHUB_OWNER, GITHUB_REPO } from "../../constants.ts";
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 

--- a/docs/.vitepress/theme/data/release.data.ts
+++ b/docs/.vitepress/theme/data/release.data.ts
@@ -1,7 +1,7 @@
 import type { GetResponseDataTypeFromEndpointMethod } from "@octokit/types";
 import { Octokit } from "@octokit/rest";
 import { defineLoader } from "vitepress";
-import { GITHUB_OWNER, GITHUB_REPO } from "../../constants";
+import { GITHUB_OWNER, GITHUB_REPO } from "../../constants.ts";
 
 const octokit = new Octokit();
 

--- a/docs/.vitepress/theme/utils/formatChangelog.ts
+++ b/docs/.vitepress/theme/utils/formatChangelog.ts
@@ -1,6 +1,6 @@
 import type MarkdownIt from "markdown-it";
-import { GITHUB_OWNER, GITHUB_REPO } from "../../constants";
-import { linkContributors } from "./contributors";
+import { GITHUB_OWNER, GITHUB_REPO } from "../../constants.ts";
+import { linkContributors } from "./contributors.ts";
 
 function removeVersionHeader(input: string): string {
 	return input.replace(/^\s*##\s+\[.*?\]\(.*?\)(?:\s+\(.*\))?\s*(\r?\n)+/, "");

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -44,9 +44,9 @@
 			}
 		},
 		"node_modules/@11ty/gray-matter/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3616,9 +3616,9 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-			"integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+			"integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
 			"dev": true,
 			"funding": [
 				{

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"docs:dev": "vitepress dev",
-		"docs:build": "vitepress build",
+		"docs:build": "node scripts/build.js",
 		"docs:preview": "vitepress preview",
 		"format": "oxfmt \"**/*.{ts,js,vue}\"",
 		"format:check": "oxfmt --check \"**/*.{ts,js,vue}\"",

--- a/docs/scripts/build.js
+++ b/docs/scripts/build.js
@@ -1,0 +1,62 @@
+/**
+ * Runs `vitepress build` and fails when a page threw during server-side
+ * rendering. VitePress logs those errors but still exits 0, so without this
+ * wrapper a broken docs site deploys behind a green CI run.
+ */
+
+import { spawn } from "node:child_process";
+import { findSsrErrors } from "./ssr-errors.js";
+
+const child = spawn("vitepress", ["build", ...process.argv.slice(2)], {
+	shell: process.platform === "win32",
+	stdio: ["inherit", "pipe", "pipe"],
+});
+
+let log = "";
+
+/**
+ * Forwards a stream to the terminal unchanged while buffering it for analysis.
+ *
+ * @param {import("node:stream").Readable} source
+ * @param {NodeJS.WriteStream} target
+ */
+function tee(source, target) {
+	source.setEncoding("utf8");
+	source.on("data", (chunk) => {
+		log += chunk;
+		target.write(chunk);
+	});
+}
+
+tee(child.stdout, process.stdout);
+tee(child.stderr, process.stderr);
+
+child.on("error", (error) => {
+	console.error(`Failed to start vitepress build: ${error.message}`);
+	process.exit(1);
+});
+
+child.on("close", (code, signal) => {
+	if (signal) {
+		process.exit(1);
+	}
+
+	if (code !== 0) {
+		process.exit(code ?? 1);
+	}
+
+	const hits = findSsrErrors(log);
+
+	if (hits.length > 0) {
+		console.error(
+			`\nvitepress build reported success, but ${hits.length} line(s) show a server-side render failure.\n` +
+				"The affected pages ship with missing content, so this is treated as a build failure:\n",
+		);
+
+		for (const hit of hits) {
+			console.error(`  line ${hit.line}: ${hit.text.trim()}`);
+		}
+
+		process.exit(1);
+	}
+});

--- a/docs/scripts/ssr-errors.js
+++ b/docs/scripts/ssr-errors.js
@@ -1,0 +1,37 @@
+/**
+ * `vitepress build` exits 0 even when a page throws during server-side
+ * rendering: it logs the error, emits the page without the failed component and
+ * reports success. A broken docs site therefore ships behind a green CI run.
+ * These matchers let the build wrapper turn such a log into a non-zero exit.
+ */
+
+/** Uncaught error header, e.g. `TypeError: Cannot read properties of undefined`. */
+const ERROR_HEADER = /^(?:[A-Za-z_$][\w$]*\.)*[A-Za-z_$][\w$]*(?:Error|Exception):\s+\S/;
+
+/** Stack frame from Vue's SSR renderer, present even when the header is unusual. */
+const SSR_FRAME =
+	/^\s+at\s+.*(?:server-renderer|ssrRenderComponent|renderComponentVNode|_sfc_ssrRender)/;
+
+/** ANSI SGR sequences, stripped so coloured output still matches the patterns above. */
+const ANSI = /\u001B\[[0-9;]*m/g;
+
+/**
+ * Finds log lines that indicate a server-side render failure.
+ *
+ * @param {string} log Combined stdout and stderr of a `vitepress build` run.
+ * @returns {{ line: number, text: string }[]} One entry per offending line, with its 1-based line number.
+ */
+export function findSsrErrors(log) {
+	/** @type {{ line: number, text: string }[]} */
+	const hits = [];
+
+	log.split(/\r?\n/).forEach((text, index) => {
+		const plain = text.replace(ANSI, "");
+
+		if (ERROR_HEADER.test(plain) || SSR_FRAME.test(plain)) {
+			hits.push({ line: index + 1, text: plain });
+		}
+	});
+
+	return hits;
+}

--- a/docs/tests/ssrErrors.spec.ts
+++ b/docs/tests/ssrErrors.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { findSsrErrors } from "../scripts/ssr-errors.js";
+
+const SUCCESSFUL_BUILD = [
+	"vitepress v2.0.0-alpha.19",
+	"- building client + server bundles...",
+	"✓ building client + server bundles...",
+	"- rendering pages...",
+	"✓ rendering pages...",
+	"build complete in 7.15s.",
+].join("\n");
+
+const THROWN_IN_SETUP = [
+	"- rendering pages...",
+	"TypeError: Cannot read properties of undefined (reading 'location')",
+	"    at setup (file:///docs/.vitepress/.temp/app.js:4286:34)",
+	"build complete in 7.20s.",
+].join("\n");
+
+const UNUSUAL_HEADER = [
+	"- rendering pages...",
+	"something went wrong",
+	"    at renderComponentVNode (/docs/node_modules/@vue/server-renderer/dist/server-renderer.cjs.prod.js:407:15)",
+].join("\n");
+
+const COLOURED_HEADER = "\u001B[31mReferenceError: window is not defined\u001B[39m";
+
+const PROSE_MENTIONING_ERRORS = [
+	"llmstxt » ✓ Processed guide/error-handling.md",
+	"(!) Some chunks are larger than 500 kB after minification.",
+	"Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.",
+	"  - Error handling is described in the troubleshooting guide.",
+].join("\n");
+
+describe("findSsrErrors", () => {
+	it("reports nothing for a successful build", () => {
+		const hits = findSsrErrors(SUCCESSFUL_BUILD);
+
+		expect(hits).toEqual([]);
+	});
+
+	it("reports an uncaught error thrown while rendering pages", () => {
+		const hits = findSsrErrors(THROWN_IN_SETUP);
+
+		expect(hits).toHaveLength(1);
+		expect(hits[0]).toEqual({
+			line: 2,
+			text: "TypeError: Cannot read properties of undefined (reading 'location')",
+		});
+	});
+
+	it("reports a Vue SSR stack frame even when the error header is unusual", () => {
+		const hits = findSsrErrors(UNUSUAL_HEADER);
+
+		expect(hits).toHaveLength(1);
+		expect(hits[0].line).toBe(3);
+	});
+
+	it("matches error headers that are wrapped in ANSI colour codes", () => {
+		const hits = findSsrErrors(COLOURED_HEADER);
+
+		expect(hits).toHaveLength(1);
+		expect(hits[0].text).toBe("ReferenceError: window is not defined");
+	});
+
+	it("ignores prose that merely mentions an error", () => {
+		const hits = findSsrErrors(PROSE_MENTIONING_ERRORS);
+
+		expect(hits).toEqual([]);
+	});
+});


### PR DESCRIPTION
Follow-ups from reviewing #1753. Each is independent of that bump and stands on its own.

## Copy button hover was inert

`CopyCode`'s hover rule set `background-color: var(--vp-c-bg-mute)`, and VitePress defines no such property. An invalid `var()` reference computes to the property's initial value, so hovering made the button **fully transparent** rather than tinting it — it lost its background instead of darkening.

Measured computed styles on `/reference/classes`:

| | resting | hover before | hover after |
| --- | --- | --- | --- |
| light | `rgb(246,246,247)` | `rgba(0,0,0,0)` | `rgba(142,150,170,0.14)` |
| dark | `rgb(32,33,39)` | `rgba(0,0,0,0)` | `rgba(101,117,133,0.16)` |

`--vp-c-bg-alt` would have looked like the obvious fix but is identical to `--vp-c-bg-soft` in light mode, so it would have been a no-op in exactly one theme. `--vp-c-default-soft` is what VitePress uses for its own hovered interactive surfaces.

The border moves off the deprecated `--vp-c-brand` alias onto `--vp-c-brand-1`, which it already resolves to; the computed border colour is unchanged before and after.

## Extensionless relative imports

Vite warns that `configLoader: 'native'`, planned to become the default in a future major, cannot resolve them. The theme already mixed both conventions. All relative imports now carry an explicit extension.

## js-yaml advisories

Both copies sat on versions covered by GHSA-pm4m-ph32-ghv5 and GHSA-5p4m-2wfm-xmqj. The patched releases satisfy the ranges their parents already declare, so this is lockfile-only — no manifest change, no transitive majors. `npm audit` now reports 0 vulnerabilities.

## The docs build no longer passes while broken

`vitepress build` exits 0 even when a page throws during server-side rendering: it logs the error, emits the page without the failed component, and reports success. A broken docs site therefore deploys behind a green CI run, and merging to `main` publishes immediately.

This is not hypothetical — the alpha.18 upgrade shipped 166 pages whose copy buttons had thrown at SSR, and nothing caught it.

`docs:build` now scans its own output and exits non-zero on an uncaught error header or a Vue SSR stack frame.

**Contract:** a clean build is unaffected; a build that logs an SSR failure now fails and names the offending lines.

The matchers were validated against five real build logs — alpha.18, alpha.19, the Algolia/DocSearch configuration and the versioned non-root-base configuration — reporting nothing for all of them, and against a deliberately broken page, turning exit 0 into exit 1. Five unit tests cover the matchers directly.

## Deliberately not included

Uploading the preview dist artifact for Dependabot PRs. Most Dependabot `/docs` bumps are lint and type tooling that cannot change rendered output, so the artifact would be noise on nearly every one — and the SSR gate above already covers the failure mode that motivated it. A real Cloudflare preview would need `pull_request_target`, which would run freshly bumped dependency code with repository credentials; the existing exclusion is correct.

## Verification

`npm run lint`, `npm test` (14 passing) and `npm run docs:build` all exit 0. Lint findings are identical to `main`. The built output was diffed page by page against `main` with asset hashes normalised: 0 pages differ apart from the intended CSS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation build validation by detecting server-rendering errors that could otherwise go unnoticed.
  * Refined copy-button hover colors for better consistency with the documentation theme.

* **Tests**
  * Added coverage for successful builds, server-rendering failures, colored logs, unusual stack traces, and harmless error mentions.

* **Chores**
  * Updated documentation build handling to provide clearer failure reporting and more reliable module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->