### PR TITLE
fix(menu): respect $wgUploadNavigationUrl and upload permissions

### DIFF
--- a/docs/src/customization/recipes.md
+++ b/docs/src/customization/recipes.md
@@ -113,3 +113,13 @@ To lock everyone into a single theme, give `skin-theme` a default and hide the p
 ::: warning
 Users who picked a different theme before you applied this change have it stored in their browser's local storage. They'll keep seeing their old choice until they clear site data — local storage doesn't expire on its own. New visitors get the forced theme immediately.
 :::
+
+## Point the upload link somewhere else
+
+The "Upload file" link in the site tools menu is the one MediaWiki builds, so [`$wgUploadNavigationUrl`](https://www.mediawiki.org/wiki/Manual:$wgUploadNavigationUrl) decides where it goes. Use it to send people to UploadWizard, a shared repository like Commons, or your own upload guide:
+
+```php [LocalSettings.php]
+$wgUploadNavigationUrl = '/wiki/Special:UploadWizard';
+```
+
+Leave it unset and the link points at `Special:Upload`, and only appears for people who are actually allowed to upload. Setting it shows the link to everyone, since MediaWiki can't know what permissions the destination needs.

--- a/includes/Hooks/SkinHooks.php
+++ b/includes/Hooks/SkinHooks.php
@@ -9,7 +9,6 @@ use MediaWiki\Html\Html;
 use MediaWiki\Output\Hook\BeforePageDisplayHook;
 use MediaWiki\Output\Hook\OutputPageAfterGetHeadLinksArrayHook;
 use MediaWiki\Output\OutputPage;
-use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\ResourceLoader as RL;
 use MediaWiki\Skin\SkinComponentUtils;
 use MediaWiki\Skins\Citizen\Menu\MenuItemDecorator;
@@ -27,6 +26,12 @@ class SkinHooks implements
 	SkinBuildSidebarHook,
 	SkinPageReadyConfigHook
 {
+	/**
+	 * Sidebar keys that name a skin-provided menu rather than one defined in
+	 * MediaWiki:Sidebar. They must never be picked as the site tools menu.
+	 */
+	private const MAGIC_PORTLETS = [ 'SEARCH', 'TOOLBOX', 'LANGUAGES' ];
+
 	private static ?string $inlineScript = null;
 
 	/**
@@ -116,7 +121,7 @@ class SkinHooks implements
 	}
 
 	/**
-	 * Modify toolbox links
+	 * Modify toolbox links and relocate the site-wide tools it holds
 	 * For some reason onSkinBuildSidebar was not able to get toolbox
 	 * So we need to use this hook instead
 	 *
@@ -130,9 +135,61 @@ class SkinHooks implements
 			return;
 		}
 
+		self::moveUploadToSiteTools( $skin, $sidebar );
+
 		if ( isset( $sidebar['TOOLBOX'] ) ) {
 			self::updateToolboxMenu( $sidebar );
 		}
+	}
+
+	/**
+	 * Move the "Upload file" link from the toolbox to the site tools menu.
+	 *
+	 * The item is taken from the toolbox rather than rebuilt: MediaWiki resolves
+	 * $wgUploadNavigationUrl and the viewer's upload permission when it builds
+	 * that entry, and this hook is the earliest one where the toolbox exists.
+	 * MediaWiki omits the entry when uploads are unavailable to the viewer, so
+	 * an absent entry means the menu must stay without an upload link.
+	 */
+	private static function moveUploadToSiteTools( Skin $skin, array &$sidebar ): void {
+		$item = $sidebar['TOOLBOX']['upload'] ?? null;
+
+		if ( $item === null ) {
+			return;
+		}
+
+		unset( $sidebar['TOOLBOX']['upload'] );
+
+		$item['msg'] = 'upload';
+		$item['icon'] = 'upload';
+		$item['link-html'] = MenuItemDecorator::getIconHtml( 'upload' );
+
+		$sidebar[self::getSiteToolsMenuId( $skin, $sidebar )][] = $item;
+	}
+
+	/**
+	 * Resolve the menu that site-wide tools are appended to.
+	 *
+	 * Called from both sidebar hooks, so the fallback skips the skin-provided
+	 * menus that only one of them sees.
+	 */
+	private static function getSiteToolsMenuId( Skin $skin, array $bar ): string {
+		$customSiteToolsMenuId = (string)$skin->getConfig()->get( 'CitizenGlobalToolsPortlet' );
+
+		if ( $customSiteToolsMenuId !== '' ) {
+			// remove initial p- for backward compatibility
+			return str_starts_with( $customSiteToolsMenuId, 'p-' )
+				? substr( $customSiteToolsMenuId, 2 )
+				: $customSiteToolsMenuId;
+		}
+
+		foreach ( array_keys( $bar ) as $key ) {
+			if ( !in_array( $key, self::MAGIC_PORTLETS, true ) ) {
+				return (string)$key;
+			}
+		}
+
+		return 'navigation';
 	}
 
 	/**
@@ -156,6 +213,8 @@ class SkinHooks implements
 			'n-specialpages' => 'specialPages',
 			// TODO: Remove when we drop MW 1.43 support
 			't-specialpages' => 'specialPages',
+			// Only reachable once upload moves into the sidebar upstream (T417298);
+			// until then the toolbox copy is decorated in moveUploadToSiteTools()
 			't-upload' => 'upload',
 		];
 
@@ -175,35 +234,14 @@ class SkinHooks implements
 	}
 
 	private function addSiteTools( Skin $skin, array &$bar ): void {
-		$out = $skin->getOutput();
-		$customSiteToolsMenuId = $out->getConfig()->get( 'CitizenGlobalToolsPortlet' );
-
-		$siteToolsMenuId = $customSiteToolsMenuId === ''
-			? array_key_first( $bar )
-			// remove initial p- for backward compatibility
-			: preg_replace( '/^p-/', '', $customSiteToolsMenuId );
-
 		// Do not override specialpages if it already exists (#1116)
 		// TODO: Revisit in next LTS release (T333211)
 		if ( version_compare( MW_VERSION, '1.44', '<' ) ) {
-			$bar[$siteToolsMenuId][] = [
+			$bar[self::getSiteToolsMenuId( $skin, $bar )][] = [
 				'text'  => $skin->msg( 'specialpages' ),
 				'href'  => SkinComponentUtils::makeSpecialUrl( 'Specialpages' ),
 				'title' => $skin->msg( 'tooltip-t-specialpages' ),
 				'id'    => 't-specialpages',
-			];
-		}
-
-		if ( !isset( $bar[$siteToolsMenuId]['upload'] ) && $out->getConfig()->get( 'EnableUploads' ) === true ) {
-			$isUploadWizardEnabled = ExtensionRegistry::getInstance()->isLoaded( 'Upload Wizard' );
-			$bar[$siteToolsMenuId][] = [
-				'text'  => $skin->msg( 'upload' ),
-				'href'  => SkinComponentUtils::makeSpecialUrl( $isUploadWizardEnabled ?
-					'UploadWizard' :
-					'Upload'
-				),
-				'title' => $skin->msg( 'tooltip-t-upload' ),
-				'id'    => 't-upload',
 			];
 		}
 	}
@@ -255,16 +293,9 @@ class SkinHooks implements
 			'wikibase' => 'logoWikidata'
 		];
 
-		// Remove upload and specialpages from toolbox as we moved them to drawer
+		// Remove specialpages from toolbox as we moved it to drawer
 		// TODO: Check again in the next LTS release, in case it's handled there
-		$siteTools = [
-			'upload',
-			'specialpages'
-		];
-
-		foreach ( $siteTools as $siteTool ) {
-			unset( $links['TOOLBOX'][$siteTool] );
-		}
+		unset( $links['TOOLBOX']['specialpages'] );
 
 		MenuItemDecorator::mapIconsToMenuItems( $links, 'TOOLBOX', $iconMap );
 		MenuItemDecorator::addIconsToMenuItems( $links, 'TOOLBOX' );

--- a/tests/phpunit/integration/Hooks/SkinHooksTest.php
+++ b/tests/phpunit/integration/Hooks/SkinHooksTest.php
@@ -94,10 +94,8 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testToolboxMenuRemovesSiteTools(): void {
-		$skinMock = $this->createMock( Skin::class );
-		$skinMock->method( 'getSkinName' )->willReturn( 'citizen' );
-
 		$sidebar = [
+			'navigation' => [],
 			'TOOLBOX' => [
 				'whatlinkshere' => [ 'id' => 't-whatlinkshere' ],
 				'upload' => [ 'id' => 't-upload' ],
@@ -106,7 +104,7 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 			],
 		];
 
-		$this->newSkinHooks()->onSidebarBeforeOutput( $skinMock, $sidebar );
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
 
 		$this->assertArrayNotHasKey( 'upload', $sidebar['TOOLBOX'] );
 		$this->assertArrayNotHasKey( 'specialpages', $sidebar['TOOLBOX'] );
@@ -115,9 +113,6 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testToolboxMenuMapsIcons(): void {
-		$skinMock = $this->createMock( Skin::class );
-		$skinMock->method( 'getSkinName' )->willReturn( 'citizen' );
-
 		$sidebar = [
 			'TOOLBOX' => [
 				'print' => [ 'id' => 't-print' ],
@@ -125,10 +120,114 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 			],
 		];
 
-		$this->newSkinHooks()->onSidebarBeforeOutput( $skinMock, $sidebar );
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
 
 		$this->assertSame( 'printer', $sidebar['TOOLBOX']['print']['icon'] );
 		$this->assertSame( 'recentChanges', $sidebar['TOOLBOX']['recentchangeslinked']['icon'] );
+	}
+
+	public function testUploadMovesToFirstSidebarMenuWithItsIcon(): void {
+		$sidebar = [
+			'navigation' => [ [ 'id' => 'n-mainpage' ] ],
+			'TOOLBOX' => [
+				'upload' => [ 'id' => 't-upload', 'href' => '/wiki/Special:Upload' ],
+			],
+			'LANGUAGES' => [],
+		];
+
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
+
+		$this->assertArrayNotHasKey( 'upload', $sidebar['TOOLBOX'] );
+		$moved = end( $sidebar['navigation'] );
+		$this->assertSame( 't-upload', $moved['id'] );
+		$this->assertSame( '/wiki/Special:Upload', $moved['href'] );
+		$this->assertSame( 'upload', $moved['icon'] );
+		$this->assertStringContainsString( 'mw-ui-icon-upload', $moved['link-html'] );
+	}
+
+	public function testUploadCarriesItsLabelMessageOutOfTheToolbox(): void {
+		$sidebar = [
+			'navigation' => [ [ 'id' => 'n-mainpage' ], [ 'id' => 'n-help' ] ],
+			'TOOLBOX' => [
+				'upload' => [ 'id' => 't-upload', 'href' => '/wiki/Special:Upload' ],
+			],
+		];
+
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
+
+		$this->assertSame( 'upload', end( $sidebar['navigation'] )['msg'] );
+	}
+
+	public function testUploadKeepsTheHrefMediaWikiResolved(): void {
+		$sidebar = [
+			'navigation' => [],
+			'TOOLBOX' => [
+				'upload' => [
+					'id' => 't-upload',
+					'href' => 'https://commons.example.org/wiki/Special:UploadWizard',
+				],
+			],
+		];
+
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
+
+		$this->assertSame(
+			'https://commons.example.org/wiki/Special:UploadWizard',
+			$sidebar['navigation'][0]['href']
+		);
+	}
+
+	public function testUploadMovesToTheConfiguredGlobalToolsPortlet(): void {
+		$sidebar = [
+			'navigation' => [],
+			'TOOLBOX' => [
+				'upload' => [ 'id' => 't-upload', 'href' => '/wiki/Special:Upload' ],
+			],
+		];
+
+		$this->newSkinHooks()->onSidebarBeforeOutput(
+			$this->createCitizenSkinMock( 'p-mytools' ),
+			$sidebar
+		);
+
+		$this->assertSame( [], $sidebar['navigation'] );
+		$this->assertSame( 't-upload', $sidebar['mytools'][0]['id'] );
+	}
+
+	public function testUploadSkipsSkinProvidedMenusWhenPickingTheDefault(): void {
+		$sidebar = [
+			'TOOLBOX' => [
+				'upload' => [ 'id' => 't-upload', 'href' => '/wiki/Special:Upload' ],
+			],
+			'navigation' => [],
+		];
+
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
+
+		$this->assertSame( 't-upload', $sidebar['navigation'][0]['id'] );
+	}
+
+	public function testUploadFallsBackToNavigationWhenTheSidebarHasNoMenus(): void {
+		$sidebar = [
+			'TOOLBOX' => [
+				'upload' => [ 'id' => 't-upload', 'href' => '/wiki/Special:Upload' ],
+			],
+		];
+
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
+
+		$this->assertSame( 't-upload', $sidebar['navigation'][0]['id'] );
+	}
+
+	public function testNoUploadLinkIsAddedWhenMediaWikiOmitsIt(): void {
+		$sidebar = [
+			'navigation' => [ [ 'id' => 'n-mainpage' ] ],
+			'TOOLBOX' => [ 'print' => [ 'id' => 't-print' ] ],
+		];
+
+		$this->newSkinHooks()->onSidebarBeforeOutput( $this->createCitizenSkinMock(), $sidebar );
+
+		$this->assertSame( [ [ 'id' => 'n-mainpage' ] ], $sidebar['navigation'] );
 	}
 
 	/**
@@ -151,9 +250,12 @@ class SkinHooksTest extends MediaWikiIntegrationTestCase {
 		return $out;
 	}
 
-	private function createCitizenSkinMock(): Skin {
+	private function createCitizenSkinMock( string $globalToolsPortlet = '' ): Skin {
 		$skin = $this->createMock( Skin::class );
 		$skin->method( 'getSkinName' )->willReturn( 'citizen' );
+		$skin->method( 'getConfig' )->willReturn( new HashConfig( [
+			'CitizenGlobalToolsPortlet' => $globalToolsPortlet,
+		] ) );
 
 		return $skin;
 	}


### PR DESCRIPTION
## Problem

Citizen hand-built the "Upload file" entry in the site tools menu instead of using the one MediaWiki already builds. Three things followed from that:

- **`$wgUploadNavigationUrl` was ignored.** The canonical core config for pointing this link elsewhere — a shared repository, a custom upload guide, UploadWizard — had no effect in Citizen.
- **The link showed to people who cannot upload.** It was gated on `$wgEnableUploads` alone, so anonymous readers and users without the `upload` right saw a link that leads only to a permission error. It also ignored PHP's `file_uploads` setting.
- **UploadWizard was special-cased.** Citizen detected the extension and rewrote the link, which is a decision the wiki operator should be making, not the skin.

## Behaviour

The link is now the entry MediaWiki builds, so it follows core's rules:

| Configuration | Result |
| --- | --- |
| `$wgUploadNavigationUrl` set | Link points there, and is shown to everyone — core cannot know what permissions the destination needs |
| Unset, viewer may upload | `Special:Upload`, as before |
| Unset, viewer may not upload, or uploads are off | No link |

Placement, ordering, icon and the `t-upload` id are unchanged. The label, tooltip and `[u]` accesskey now come from core, so the accesskey works where it previously did not.

## Upgrade note

**Wikis running UploadWizard need one config line.** Automatic detection is gone; point the link at the wizard explicitly:

```php
$wgUploadNavigationUrl = '/wiki/Special:UploadWizard';
```

Everyone else needs no action. Documented under [Recipes → Point the upload link somewhere else](docs/src/customization/recipes.md).

**Release cache status: `clean`.** No CSS or JS is touched, and no class or ID is renamed, so no compat slice is needed.

## Verification

- `composer test` exit 0, no PHPCS warnings; `composer phpunit` OK (244 tests, 497 assertions); `composer phan` shows only the two pre-existing `CitizenComponentBodyContent.php` failures that reproduce on a clean tree.
- On a MediaWiki 1.43.6 dev wiki: label renders in `en` / `fr` / `zh-hans`, fully escaped under `?uselang=x-xss`, anonymous visitors get no link, `$wgUploadNavigationUrl` is honoured, and `$wgCitizenGlobalToolsPortlet` still resolves with its `p-` prefix stripped.
- Browser check with the drawer open: link visible with its icon in its usual position, no console errors, no failed requests.

## Follow-ups

- Upstream [T417298](https://phabricator.wikimedia.org/T417298) proposes moving this link from page tools into the main menu in core. If it lands, the entry arrives already in the sidebar and Citizen's existing `t-upload` icon mapping picks it up — no change needed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for redirecting the MediaWiki upload link and explaining its default behavior and permission visibility.
  * Upload links now appear in the appropriate sidebar or global tools menu while retaining their configured label, icon, URL, and permissions.

* **Bug Fixes**
  * Improved menu placement and fallback behavior for upload and special-page links.
  * Prevented upload links from appearing when unavailable due to permissions or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->