### PR TITLE
feat(core): ✨ add upload file page styles

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -995,6 +995,7 @@
 			"+mediawiki.special.userlogin.common.styles": "skinStyles/mediawiki/special/mediawiki.special.userlogin.common.styles.less",
 			"+mediawiki.special.userlogin.login.styles": "skinStyles/mediawiki/special/mediawiki.special.userlogin.login.styles.less",
 			"+mediawiki.special.userlogin.signup.styles": "skinStyles/mediawiki/special/mediawiki.special.userlogin.signup.styles.less",
+			"+mediawiki.special.upload": "skinStyles/mediawiki/special/mediawiki.special.upload.styles.less",
 			"+mediawiki.ui": "skinStyles/mediawiki/ui/mediawiki.ui.less",
 			"+mediawiki.ui.checkbox": "skinStyles/mediawiki/ui/mediawiki.ui.checkbox.less",
 			"+mediawiki.ui.radio": "skinStyles/mediawiki/ui/mediawiki.ui.radio.less",

--- a/skinStyles/mediawiki/special/mediawiki.special.upload.styles.less
+++ b/skinStyles/mediawiki/special/mediawiki.special.upload.styles.less
@@ -1,0 +1,59 @@
+@import '../../../resources/variables.less';
+
+#mw-upload-form input[ name='wpUpload' ] {
+	width: 100%;
+	padding: var( --space-md );
+	font-weight: var( --font-weight-bold );
+	color: #fff;
+	cursor: pointer;
+	background-color: var( --background-color-progressive );
+	border-radius: var( --border-radius-medium );
+}
+
+#mw-upload-form input[ name='wpUpload' ]:not( :disabled ):hover {
+	background-color: var( --background-color-progressive--hover );
+}
+
+#mw-upload-form .mw-htmlform-field-HTMLCheckField .mw-input * {
+	cursor: pointer;
+}
+
+#mw-upload-form #wpUploadFile {
+	cursor: pointer;
+	border-radius: var( --border-radius-medium );
+}
+
+#mw-upload-form fieldset {
+	border-radius: var( --border-radius-medium );
+}
+
+#mw-upload-form input#wpDestFile {
+	padding: calc( var( --space-sm ) / 2 );
+	margin-bottom: 4px;
+	border-radius: var( --border-radius-medium );
+}
+
+#mw-upload-form textarea {
+	padding: calc( var( --space-sm ) / 2 );
+	border-radius: var( --border-radius-medium );
+}
+
+#mw-upload-form select#wpLicense {
+	padding: calc( var( --space-sm ) / 3 );
+	border-radius: var( --border-radius-medium );
+}
+
+#mw-upload-form #wpUploadFile::file-selector-button,
+#mw-upload-form #wpUploadFile::-webkit-file-upload-button {
+	padding: calc( var( --space-sm ) / 2 );
+	font-weight: var( --font-weight-medium );
+	color: #fff;
+	cursor: pointer;
+	background-color: var( --background-color-progressive );
+	border: 0;
+}
+
+#mw-upload-form #wpUploadFile::file-selector-button:hover,
+#mw-upload-form #wpUploadFile::-webkit-file-upload-button:hover {
+	background-color: var( --background-color-progressive--hover );
+}

--- a/skinStyles/mediawiki/special/mediawiki.special.upload.styles.less
+++ b/skinStyles/mediawiki/special/mediawiki.special.upload.styles.less
@@ -1,5 +1,3 @@
-@import '../../../resources/variables.less';
-
 #mw-upload-form input[ name='wpUpload' ] {
 	width: 100%;
 	padding: var( --space-md );

--- a/skinStyles/mediawiki/special/mediawiki.special.upload.styles.less
+++ b/skinStyles/mediawiki/special/mediawiki.special.upload.styles.less
@@ -1,57 +1,133 @@
-#mw-upload-form input[ name='wpUpload' ] {
-	width: 100%;
-	padding: var( --space-md );
-	font-weight: var( --font-weight-bold );
-	color: #fff;
-	cursor: pointer;
-	background-color: var( --background-color-progressive );
-	border-radius: var( --border-radius-medium );
-}
+@import '../../../resources/mixins.less';
+@import '../../../resources/variables.less';
 
-#mw-upload-form input[ name='wpUpload' ]:not( :disabled ):hover {
-	background-color: var( --background-color-progressive--hover );
-}
+#mw-upload-form {
+	fieldset {
+		border-radius: var( --border-radius-medium );
 
-#mw-upload-form .mw-htmlform-field-HTMLCheckField .mw-input * {
-	cursor: pointer;
-}
+		/* Source field */
+		&:first-of-type {
+			display: flex;
+			flex-wrap: wrap;
+			gap: var( --space-lg );
+			padding: var( --space-md );
+			margin: var( --space-xl ) 0;
+			color: var( --color-subtle );
+		}
+	}
 
-#mw-upload-form #wpUploadFile {
-	cursor: pointer;
-	border-radius: var( --border-radius-medium );
-}
+	#mw-htmlform-source {
+		flex-grow: 1;
+		order: -1;
+		.mixin-citizen-font-styles( 'small' );
 
-#mw-upload-form fieldset {
-	border-radius: var( --border-radius-medium );
-}
+		&,
+		tbody,
+		tr,
+		td {
+			display: block;
+		}
 
-#mw-upload-form input#wpDestFile {
-	padding: calc( var( --space-sm ) / 2 );
-	margin-bottom: 4px;
-	border-radius: var( --border-radius-medium );
-}
+		.mw-htmlform-field-UploadSourceField {
+			margin-bottom: var( --space-xs );
 
-#mw-upload-form textarea {
-	padding: calc( var( --space-sm ) / 2 );
-	border-radius: var( --border-radius-medium );
-}
+			.mw-label {
+				display: none;
+			}
+		}
+	}
 
-#mw-upload-form select#wpLicense {
-	padding: calc( var( --space-sm ) / 3 );
-	border-radius: var( --border-radius-medium );
-}
+	#wpUploadFile {
+		/* `align-content` and `text-align-last` are the only levers that reach the UA shadow content:
+		   flex and grid do not, and Blink and WebKit force `text-align: start !important` on file inputs. */
+		align-content: center;
+		width: 100%;
+		height: @size-1600;
+		color: inherit;
+		text-align-last: center;
+		cursor: pointer;
+		border-style: dashed;
+		border-radius: var( --border-radius-medium );
 
-#mw-upload-form #wpUploadFile::file-selector-button,
-#mw-upload-form #wpUploadFile::-webkit-file-upload-button {
-	padding: calc( var( --space-sm ) / 2 );
-	font-weight: var( --font-weight-medium );
-	color: #fff;
-	cursor: pointer;
-	background-color: var( --background-color-progressive );
-	border: 0;
-}
+		&:hover {
+			background-color: var( --background-color-button-quiet--hover );
+		}
 
-#mw-upload-form #wpUploadFile::file-selector-button:hover,
-#mw-upload-form #wpUploadFile::-webkit-file-upload-button:hover {
-	background-color: var( --background-color-progressive--hover );
+		&:active {
+			background-color: var( --background-color-button-quiet--active );
+		}
+
+		&::before {
+			width: @size-250 !important;
+			height: @size-250 !important;
+			margin-bottom: var( --space-sm );
+			content: '';
+			mask-size: @size-250 !important;
+			.cdx-mixin-css-icon( @cdx-icon-upload );
+		}
+
+		&::file-selector-button,
+		&::-webkit-file-upload-button {
+			display: block;
+			min-height: @min-size-interactive-pointer;
+			padding-inline: @spacing-horizontal-button;
+			margin-inline: auto;
+			margin-bottom: var( --space-sm );
+			font-family: inherit;
+			font-size: var( --font-size-medium );
+			font-weight: var( --font-weight-semi-bold );
+			appearance: none;
+			cursor: pointer;
+			background: transparent;
+			border: 1px solid var( --border-color-interactive );
+			border-radius: var( --border-radius-base );
+			.mixin-citizen-button-quiet();
+		}
+	}
+
+	#mw-upload-thumbnail {
+		margin: 0 auto;
+		text-align: center;
+		.mixin-citizen-font-styles( 'small' );
+
+		canvas {
+			border: var( --border-base );
+			border-radius: var( --border-radius-medium );
+		}
+	}
+
+	&:has( #mw-upload-thumbnail ) {
+		#wpUploadFile {
+			&::before {
+				.cdx-mixin-css-icon( @cdx-icon-success, @color-success );
+			}
+		}
+	}
+
+	#mw-upload-permitted > p {
+		margin: 0;
+	}
+
+	.mw-htmlform-field-HTMLCheckField .mw-input * {
+		cursor: pointer;
+	}
+
+	input#wpDestFile,
+	textarea,
+	select#wpLicense {
+		font-family: inherit;
+		.mixin-citizen-cdx-input();
+	}
+
+	input[ name='wpUpload' ] {
+		width: 100%;
+		min-height: @min-size-interactive-touch;
+		padding-inline: @spacing-horizontal-button;
+		font-size: var( --font-size-medium );
+		font-weight: var( --font-weight-semi-bold );
+		cursor: pointer;
+		border: 1px solid transparent;
+		border-radius: var( --border-radius-base );
+		.mixin-citizen-button-progressive();
+	}
 }


### PR DESCRIPTION
this pr adds styles to Special:Upload specifically

<img width="2545" height="1264" alt="image" src="https://github.com/user-attachments/assets/dc45dfab-2e31-4b1d-9dc8-355716dc85cf" />

<img width="578" height="811" alt="image" src="https://github.com/user-attachments/assets/583dafbb-7de8-4cda-a84c-fb1dbd49d168" />

---

there's still more to style but i've done this to start:

* distinguishable buttons, also easier to click
* proper pointer feedback on all interactable/clickable elements

before, for reference:

<img width="2541" height="1276" alt="image" src="https://github.com/user-attachments/assets/d7d920b6-d67b-4142-b983-a2ef774a9568" />

---

i haven't found any regressions when applying these styles to other wikis. styles only apply to the upload form so it can't cause issues elsewhere

related: #1205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the MediaWiki upload page with a more consistent visual design.
  * Added clearer spacing, borders, typography, and color treatment across upload controls.
  * Enhanced file selection, destination filename, license, and description fields for easier use.
  * Added responsive source-field layouts, thumbnail and preview styling, and clearer interactive check fields.
  * Added upload and success indicators, hover states, and pointer cues for interactive controls.
  * Updated the upload button with a full-width progressive layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->