### PR TITLE
fix(ArticleFeedbackv5): make the panel's icon buttons work where they look like they do

### DIFF
--- a/skinStyles/extensions/ArticleFeedbackv5/ext.articleFeedbackv5.less
+++ b/skinStyles/extensions/ArticleFeedbackv5/ext.articleFeedbackv5.less
@@ -87,6 +87,10 @@
 					display: flex;
 					gap: var( --space-xs );
 					align-items: center;
+					// The extension clips this box to contain the floats it lays the
+					// header out with. Flex contains them anyway, and the clip would
+					// swallow the back link's focus ring, which hugs the box's edge.
+					overflow: visible;
 				}
 			}
 		}
@@ -205,15 +209,30 @@
 		}
 
 		&-arrow-back {
-			.cdx-mixin-css-icon( @cdx-icon-previous );
+			.mixin-citizen-button-quiet();
+			position: relative;
 			min-width: @min-size-interactive-pointer;
 			min-height: @min-size-interactive-pointer;
 			padding: 0;
 			margin: 0;
-			background: var( --color-neutral );
+			background-image: none; // The extension paints a legacy arrow bitmap here
+			border-radius: var( --border-radius-base );
 
-			&:hover {
-				background: var( --color-emphasized );
+			// As above, the icon sits on a pseudo-element so the mask cannot clip the
+			// link's focus outline. It is taken out of flow because the element still
+			// relies on the extension's `text-indent` to hide its label.
+			&::before {
+				.cdx-mixin-css-icon( @cdx-icon-previous, currentColor );
+				position: absolute;
+				inset: 0;
+				margin: auto;
+				content: '';
+			}
+
+			// The mixin's own flip targets the element it is applied to, which is not
+			// expressible for a pseudo-element, so this chevron is flipped by hand.
+			html[ dir='rtl' ] &::before {
+				transform: scaleX( -1 );
 			}
 		}
 

--- a/skinStyles/extensions/ArticleFeedbackv5/ext.articleFeedbackv5.less
+++ b/skinStyles/extensions/ArticleFeedbackv5/ext.articleFeedbackv5.less
@@ -8,28 +8,65 @@
 
 	#articleFeedbackv5 {
 		&-bucket6-toggle-wrapper {
-			&-yes {
-				.cdx-mixin-css-icon( @cdx-icon-check );
-
-				&:hover {
-					background-color: var( --color-success );
-				}
-			}
-
-			&-no {
-				.cdx-mixin-css-icon( @cdx-icon-close );
-
-				&:hover {
-					background-color: var( --color-destructive );
-				}
-			}
-
 			&-yes,
 			&-no {
+				.mixin-citizen-button-quiet();
+				position: relative;
+				display: flex;
+				align-items: center;
+				justify-content: center;
 				min-width: @min-size-interactive-touch;
 				min-height: @min-size-interactive-touch;
-				background-color: var( --color-neutral );
 				border-radius: var( --border-radius-base );
+
+				// The icon has to sit on a pseudo-element: a mask clips everything the
+				// element paints, including its descendants and its focus outline.
+				&::before {
+					content: '';
+				}
+
+				// The extension binds the click handler to this link alone, so it has to
+				// cover the whole target instead of just its own label text.
+				.articleFeedbackv5-button-placeholder {
+					position: absolute;
+					inset: 0;
+					height: auto !important; // The extension hardcodes a 22px height
+					// A margin would shrink the box back out of the corners: jQuery UI
+					// gives `.ui-button` one, and only the extension currently zeroes it.
+					margin: 0;
+					opacity: 0; // The icon above stands in for the label
+				}
+
+				// The link is invisible, so the focus ring goes on the target it covers.
+				// An inset ring keeps the whole target clickable, unlike a border.
+				&:has( .articleFeedbackv5-button-placeholder:focus-visible ) {
+					outline: @outline-base--focus;
+					box-shadow: @box-shadow-inset-small var( --color-progressive );
+				}
+			}
+
+			// Declared after the shared rule so the answer colour outranks the quiet
+			// button's own neutral hover colour.
+			&-yes {
+				&::before {
+					.cdx-mixin-css-icon( @cdx-icon-check, currentColor );
+				}
+
+				&:hover,
+				&:active {
+					color: var( --color-success );
+				}
+			}
+
+			&-no {
+				&::before {
+					.cdx-mixin-css-icon( @cdx-icon-close, currentColor );
+				}
+
+				&:hover,
+				&:active {
+					color: var( --color-destructive );
+				}
 			}
 		}
 	}
@@ -147,10 +184,6 @@
 					+ .form-item::before {
 						content: '';
 					}
-				}
-
-				.articleFeedbackv5-button-placeholder {
-					opacity: 0; // Needed to color the Codex icon
 				}
 			}
 


### PR DESCRIPTION
Closes #1777

## Problem

The Yes/No buttons on the ArticleFeedbackv5 panel only responded to presses in a small region that did not include the icon a reader can see.

Citizen paints the 44px target on the wrapper element, but the extension binds its click handler to a link inside it, and that link keeps its own intrinsic size at the start of the wrapper while the icon renders in the centre. Measured on a 500px-wide viewport, **16.5% of the painted button was live**, in the top-left corner. Below the mobile breakpoint the wrapper stretches to half the row, so the miss is wide and obvious — which is why the report singles out mobile.

The step-2 back button had a related fault: it carries its icon as a CSS mask, and a mask clips everything its element paints, including the element's own focus outline. The focus ring the skin already gave that link was cut away before it reached the screen, so keyboard readers got no indication of where they were.

## Behaviour

- The whole painted Yes/No target is pressable, at every width.
- Both controls take the quiet button's hover and active backgrounds, so the target is now something a reader can see rather than infer. The answer colours (green check, red cross) still apply on hover and hold through the press.
- Both controls show a keyboard focus ring. Neither could before.
- The back button's resting colour is the one the stylesheet asked for; it was silently losing to a Codex default.

Resting appearance is otherwise unchanged: same icons, same size, same position.

## Contract

- Styles only, in `skinStyles/`. No markup, config, message or module changes, and nothing here depends on a change to the extension.
- No compat slice: this panel is client-rendered by `mw.template`, which the cache-compat rules exempt.
- Browsers without `:has()` get no focus ring on the Yes/No pair. That matches today's behaviour, so it is not a regression.

## Verification

Verified against the extension running on a dev wiki, at 480px and 1200px, in light and dark, and in RTL (`uselang=he`): hit-testing across the full target, a real press advancing the form and checking the radio, hover/active/focus states, and no new console errors.

## Follow-ups, not in this PR

- The back button stays at pointer size (32px) rather than touch size (44px), unlike the Yes/No pair beside it. It passes WCAG 2.5.8, so this is a house-convention gap and a deliberate call to make separately.
- Display bucket 1 ships markup byte-identical to bucket 6 but with `bucket1` IDs, so Citizen styles none of it and it renders raw upstream CSS. It is weighted 0 by default and needs an explicit override to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated article feedback controls with quieter button styling and clearer success or destructive interaction states.
  * Improved keyboard focus visibility and expanded clickable areas.
  * Updated the back arrow with improved styling and right-to-left layout support.
  * Removed outdated visual behavior and prevented title content from being clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->