### PR TITLE
fix(commandPalette): only activate results that match the typed query

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -24,8 +24,8 @@
 				:tokens="tokenInput.tokens.value"
 				:free-text="tokenInput.freeText.value"
 				:selected-token-index="tokenInput.selectedIndex.value"
-				:is-pending="isPending"
 				:show-pending="showPending"
+				:activation-queued="activationQueued"
 				:active-mode="activeMode"
 				:active-mode-context="activeModeContext"
 				:help-visible="helpVisible"
@@ -63,7 +63,7 @@
 					<template v-else>
 						<div class="citizen-command-palette__results">
 							<command-palette-empty-state
-								v-if="!isPending && flatItems.length === 0"
+								v-if="!isLoading && flatItems.length === 0"
 								:title="emptyStateContent.title"
 								:description="emptyStateContent.description"
 								:icon="emptyStateContent.icon"
@@ -115,6 +115,7 @@ const useGalleryColumnCount = require( '../composables/useGalleryColumnCount.js'
 const useListNavigation = require( '../composables/useListNavigation.js' );
 const useGridNavigation = require( '../composables/useGridNavigation.js' );
 const useKeyboard = require( '../composables/useKeyboard.js' );
+const usePendingActivation = require( '../composables/usePendingActivation.js' );
 const useProviderOrchestration = require( '../composables/useProviderOrchestration.js' );
 const useResultRouter = require( '../composables/useResultRouter.js' );
 const useTokenizedInput = require( '../composables/useTokenizedInput.js' );
@@ -321,10 +322,15 @@ module.exports = exports = defineComponent( {
 			itemRefs
 		} );
 
+		// Bound below: close() must exist before useResultRouter, which must
+		// exist before usePendingActivation can take its selectResult.
+		let cancelPendingActivation = () => {};
+
 		const close = () => {
 			if ( !isOpen.value ) {
 				return;
 			}
+			cancelPendingActivation();
 			isOpen.value = false;
 			if ( typeof paletteExternalClose === 'function' ) {
 				paletteExternalClose();
@@ -342,6 +348,21 @@ module.exports = exports = defineComponent( {
 			control: { focusInput, close, paletteRoot },
 			preview: previewService
 		} );
+
+		const pendingActivation = usePendingActivation( {
+			surfaceKey: orch.surfaceKey,
+			isLeadReady: orch.isLeadReady,
+			items: orch.flatItems,
+			defaultHighlightIndex: orch.defaultHighlightIndex,
+			onActivate: ( item ) => selectResult( item )
+		} );
+		cancelPendingActivation = pendingActivation.cancel;
+
+		// Only a surface the user drove with input may hold an Enter.
+		const canQueueActivation = computed(
+			() => !orch.isLeadReady.value &&
+				Boolean( orch.query.value || orch.activeMode.value )
+		);
 
 		const handleRemoveToken = ( index ) => {
 			const token = tokenInput.tokens.value[ index ];
@@ -371,9 +392,12 @@ module.exports = exports = defineComponent( {
 				items: orch.flatItems,
 				query: orch.query,
 				requestHeaderCopy,
+				canQueueActivation,
+				onQueueActivation: pendingActivation.arm,
 				onSelect: selectResult,
 				onClose: close,
 				onClearQuery: () => {
+					pendingActivation.cancel();
 					tokenInput.clear();
 					orch.updateQuery( '' );
 				}
@@ -457,15 +481,36 @@ module.exports = exports = defineComponent( {
 			orch.updateQuery( newQuery );
 		} );
 
-		// Watch for changes in displayed items to adjust highlighting
-		watch( orch.flatItems, ( newItems ) => {
+		// A surface change drops any selection the user made and returns the
+		// highlight to the default. A refresh within the same surface keeps
+		// their selection by item id, so a late-arriving group cannot re-point
+		// it at whatever inherits its index.
+		let appliedSurface = null;
+
+		watch( orch.flatItems, ( newItems, oldItems ) => {
 			itemRefs.value.clear();
 			actionNav.deactivate();
-			if ( newItems.length === 0 ) {
-				listNav.highlightedIndex.value = -1;
-			} else if ( listNav.highlightedIndex.value < 0 || listNav.highlightedIndex.value >= newItems.length ) {
-				listNav.highlightedIndex.value = 0;
+
+			const sameSurface = orch.surfaceKey.value === appliedSurface;
+			appliedSurface = orch.surfaceKey.value;
+
+			const previousIndex = listNav.highlightedIndex.value;
+			const previousItem = sameSurface && oldItems && previousIndex >= 0 ?
+				oldItems[ previousIndex ] :
+				null;
+
+			let nextIndex = orch.defaultHighlightIndex.value;
+			if ( previousItem ) {
+				// Match on id, not object identity: providers rebuild their
+				// item objects on every fetch.
+				const restored = newItems.findIndex(
+					( candidate ) => candidate.id === previousItem.id
+				);
+				if ( restored >= 0 ) {
+					nextIndex = restored;
+				}
 			}
+			listNav.highlightedIndex.value = nextIndex;
 
 			// Notify the preview handler (if any) so it can scan the
 			// freshly-rendered list for previewable anchors and attach
@@ -521,7 +566,9 @@ module.exports = exports = defineComponent( {
 			query: orch.query,
 			displayedItems: orch.displayedItems,
 			flatItems,
-			isPending: orch.isPending,
+			isLoading: orch.isLoading,
+			// Exposed at the top level so Vue unwraps the ref for the template.
+			activationQueued: pendingActivation.isActivationQueued,
 			showPending: orch.showPending,
 			helpVisible: orch.helpVisible,
 			orchCloseHelp: orch.closeHelp,

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteGallery.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteGallery.vue
@@ -71,7 +71,11 @@ module.exports = exports = defineComponent( {
 		function getGlobalIndex( sectionIndex, localIndex ) {
 			let offset = 0;
 			for ( let i = 0; i < sectionIndex; i++ ) {
-				offset += props.sections[ i ].items.length;
+				// Vue runs a row's `ref` callback during teardown against an
+				// already-shortened section list, so a preceding section can
+				// be gone while this index still refers to it.
+				const preceding = props.sections[ i ];
+				offset += preceding ? preceding.items.length : 0;
 			}
 			return offset + localIndex;
 		}

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteHeader.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteHeader.vue
@@ -60,7 +60,7 @@
 			></cdx-text-input>
 		</div>
 		<div
-			v-if="isPending && showPending"
+			v-if="showPending || activationQueued"
 			class="citizen-command-palette-header__progress-indicator citizen-loading"
 		></div>
 	</div>
@@ -93,11 +93,13 @@ module.exports = exports = defineComponent( {
 			type: Number,
 			default: -1
 		},
-		isPending: {
+		showPending: {
 			type: Boolean,
 			default: false
 		},
-		showPending: {
+		// A held Enter waiting on results. Separate from showPending, which is
+		// delayed by design and never rises at all on the undebounced path.
+		activationQueued: {
 			type: Boolean,
 			default: false
 		},

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteList.vue
@@ -83,7 +83,11 @@ module.exports = exports = defineComponent( {
 		function getGlobalIndex( sectionIndex, localIndex ) {
 			let offset = 0;
 			for ( let i = 0; i < sectionIndex; i++ ) {
-				offset += props.sections[ i ].items.length;
+				// Vue runs a row's `ref` callback during teardown against an
+				// already-shortened section list, so a preceding section can
+				// be gone while this index still refers to it.
+				const preceding = props.sections[ i ];
+				offset += preceding ? preceding.items.length : 0;
 			}
 			return offset + localIndex;
 		}

--- a/resources/skins.citizen.commandPalette/composables/useKeyboard.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboard.js
@@ -327,6 +327,23 @@ const coreBindings = [
 	},
 
 	// --- INPUT ZONE: Enter ---
+	// Three disjoint cases, most specific first. The fulltext row and an
+	// ordinary result activate identically; the split exists so the footer can
+	// name which meaning Enter currently carries.
+	{
+		id: 'input-enter-select-search',
+		zone: 'input',
+		keys: [ 'Enter' ],
+		when: ( state ) => state.highlightedIndex >= 0 &&
+			Boolean( state.highlightedItem ) &&
+			state.highlightedItem.source === 'queryAction:fulltext-search',
+		worksDuringHelp: true,
+		handle: ( state, event ) => {
+			event.preventDefault();
+			state.onSelect( state.items[ state.highlightedIndex ] );
+		},
+		hint: { msgKey: 'citizen-command-palette-keyhint-enter-search', kbd: '↵', order: 10 }
+	},
 	{
 		id: 'input-enter-select',
 		zone: 'input',
@@ -339,17 +356,18 @@ const coreBindings = [
 		},
 		hint: { msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', order: 10 }
 	},
+	// Nothing highlighted yet because the group that will own the highlight is
+	// still fetching. Hold the keystroke rather than dropping it.
 	{
-		id: 'input-enter-search',
+		id: 'input-enter-queue',
 		zone: 'input',
 		keys: [ 'Enter' ],
-		when: ( state ) => state.highlightedIndex < 0,
+		when: ( state ) => state.highlightedIndex < 0 && state.canQueueActivation,
 		handle: ( state, event ) => {
-			// Today's behavior: Enter with no highlight prevents default but
-			// fires no callback; the "Search" hint is shown for affordance.
 			event.preventDefault();
+			state.onQueueActivation();
 		},
-		hint: { msgKey: 'citizen-command-palette-keyhint-enter-search', kbd: '↵', order: 10 }
+		hint: { msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', order: 10 }
 	},
 
 	// --- INPUT ZONE: ArrowRight to actions ---
@@ -598,7 +616,9 @@ function actionCount( state ) {
  *
  * @param {Object} options
  * @param {Object} options.core Required. inputRef, itemRefs, items,
- *   query, requestHeaderCopy, onSelect, onClose, onClearQuery.
+ *   query, requestHeaderCopy, onSelect, onClose, onClearQuery, plus optional
+ *   canQueueActivation/onQueueActivation for surfaces that can hold an Enter
+ *   until their lead result group settles.
  * @param {Object} options.navigation Required. listNav, gridNav,
  *   isGalleryLayout, actionNav.
  * @param {Object} options.mode Required. activeMode, findModeByTrigger,
@@ -768,6 +788,10 @@ function useKeyboard( options ) {
 			),
 			helpVisible: help.helpVisible ? help.helpVisible.value : false,
 			actionsFocused: actionNav.isActive.value,
+			canQueueActivation: Boolean(
+				core.canQueueActivation && core.canQueueActivation.value
+			),
+			onQueueActivation: core.onQueueActivation,
 			onClose: core.onClose,
 			onClearQuery: core.onClearQuery,
 			onExitMode: mode.onExitMode,

--- a/resources/skins.citizen.commandPalette/composables/usePendingActivation.js
+++ b/resources/skins.citizen.commandPalette/composables/usePendingActivation.js
@@ -1,0 +1,75 @@
+const { ref, watch } = require( 'vue' );
+
+// Past the 120ms debounce plus a normal round trip, but short enough that a
+// hung request releases the key rather than firing a navigation the user has
+// stopped expecting.
+const PENDING_ACTIVATION_TIMEOUT_MS = 2000;
+
+/**
+ * Holds an Enter press until the lead result group settles for the surface it
+ * was pressed on, for surfaces where that group is asynchronous and there is
+ * therefore no highlight yet when the key lands.
+ *
+ * The wait is bound to the whole surface, not just the query: entering a mode,
+ * drilling in or out, and opening help all leave the query at `''`, so a
+ * query-only binding would let an activation armed on one level fire against
+ * another.
+ *
+ * @param {Object} options
+ * @param {import('vue').Ref<string>} options.surfaceKey Identity of the current surface.
+ * @param {import('vue').Ref<boolean>} options.isLeadReady Whether the lead group has settled.
+ * @param {import('vue').Ref<Array>} options.items Flat item list.
+ * @param {import('vue').Ref<number>} options.defaultHighlightIndex Index the highlight defaults to.
+ * @param {Function} options.onActivate Called with the item to activate.
+ * @return {{ arm: Function, cancel: Function, isActivationQueued: import('vue').Ref<boolean> }}
+ */
+function usePendingActivation( options ) {
+	// Owned solely here. The fetch lifecycle's flags know nothing about a held
+	// keystroke and would lower them on an unrelated schedule.
+	const isActivationQueued = ref( false );
+	let armedSurface = null;
+	let timeoutId = null;
+
+	function cancel() {
+		if ( !isActivationQueued.value ) {
+			return;
+		}
+		isActivationQueued.value = false;
+		armedSurface = null;
+		clearTimeout( timeoutId );
+		timeoutId = null;
+	}
+
+	function arm() {
+		armedSurface = options.surfaceKey.value;
+		isActivationQueued.value = true;
+		clearTimeout( timeoutId );
+		timeoutId = setTimeout( cancel, PENDING_ACTIVATION_TIMEOUT_MS );
+	}
+
+	watch( options.surfaceKey, () => {
+		cancel();
+	} );
+
+	watch( options.isLeadReady, ( ready ) => {
+		if ( !ready || !isActivationQueued.value ) {
+			return;
+		}
+		if ( options.surfaceKey.value !== armedSurface ) {
+			cancel();
+			return;
+		}
+		const index = options.defaultHighlightIndex.value;
+		const item = index >= 0 ? options.items.value[ index ] : null;
+		cancel();
+		// A group that settled empty has no activation to perform.
+		if ( item ) {
+			options.onActivate( item );
+		}
+	} );
+
+	return { arm, cancel, isActivationQueued };
+}
+
+module.exports = usePendingActivation;
+module.exports.PENDING_ACTIVATION_TIMEOUT_MS = PENDING_ACTIVATION_TIMEOUT_MS;

--- a/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
+++ b/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
@@ -60,14 +60,131 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	deps = deps || {};
 
 	const query = ref( '' );
-	const displayedItems = ref( [] );
 	const isPending = ref( false );
 	const showPending = ref( false );
 	const activeMode = shallowRef( null );
 	const activeModeContext = ref( [] );
 	const helpVisible = ref( false );
-	const flatItems = computed( () => displayedItems.value.flatMap( ( s ) => s.items ) );
+
+	// Identifies the surface a request belongs to. Every staleness decision
+	// keys off this one value, so a surface change cannot be half-honoured.
+	const surfaceKey = computed( () => JSON.stringify( [
+		query.value,
+		activeMode.value ? activeMode.value.id : null,
+		activeModeContext.value,
+		helpVisible.value
+	] ) );
+
+	// Every surface has at most one asynchronous group. `forSurface` is the
+	// staleness test: items are stale until a landing stamps them with the
+	// surface that is current when they arrive.
+	const content = ref( { items: [], forSurface: null, providerId: null } );
+	const related = ref( { items: [], settled: false } );
+	const recents = ref( [] );
+	const helpItems = ref( [] );
+
+	const isPresultsSurface = computed(
+		() => !query.value && !activeMode.value && !helpVisible.value
+	);
+	const isContentCurrent = computed(
+		() => content.value.forSurface === surfaceKey.value
+	);
+
+	// The lead action restates the typed query as a search, so it only leads
+	// when the query IS a search. A trigger-prefixed query (`#cat`) means
+	// something else, and its own results keep the lead. An empty query here
+	// is how modes, help and presults opt out of query actions entirely.
+	const queryActionQuery = computed(
+		() => ( activeMode.value || helpVisible.value ) ? '' : query.value
+	);
+	const leadActions = computed( () => content.value.providerId === 'search' ?
+		resultDecorator.leadActions( queryActionQuery.value ) :
+		[] );
+	const trailActions = computed( () => content.value.providerId === 'search' ?
+		resultDecorator.trailActions( queryActionQuery.value ) :
+		resultDecorator.leadActions( queryActionQuery.value )
+			.concat( resultDecorator.trailActions( queryActionQuery.value ) ) );
+
+	/**
+	 * @param {?string} heading
+	 * @param {Array} items
+	 * @return {?Object} Section, or null when there is nothing to render.
+	 */
+	function section( heading, items ) {
+		return items.length > 0 ? { heading: heading, items: items } : null;
+	}
+
+	// Each surface names its own groups, in render order. A group therefore
+	// cannot survive into a surface that does not mention it.
+	const displayedItems = computed( () => {
+		if ( helpVisible.value ) {
+			return activeMode.value ? [] : [ section(
+				'citizen-command-palette-help-section-modes', helpItems.value
+			) ].filter( Boolean );
+		}
+
+		if ( isPresultsSurface.value ) {
+			const relatedUrls = new Set(
+				related.value.items.map( ( item ) => item.url ).filter( Boolean )
+			);
+			return [
+				section(
+					'citizen-command-palette-heading-related', related.value.items
+				),
+				section(
+					'citizen-command-palette-heading-recent',
+					recents.value.filter(
+						( item ) => !item.url || !relatedUrls.has( item.url )
+					)
+				)
+			].filter( Boolean );
+		}
+
+		return [
+			section( null, leadActions.value ),
+			section( null, content.value.items ),
+			section( null, trailActions.value )
+		].filter( Boolean );
+	} );
+
+	const flatItems = computed(
+		() => displayedItems.value.flatMap( ( s ) => s.items )
+	);
 	const hasDisplayedItems = computed( () => flatItems.value.length > 0 );
+
+	// The lead group owns the default highlight: the synchronous fulltext row
+	// when there is one, otherwise the async content group.
+	const isLeadReady = computed( () => {
+		if ( helpVisible.value ) {
+			return true;
+		}
+		if ( isPresultsSurface.value ) {
+			return related.value.settled;
+		}
+		return leadActions.value.length > 0 || isContentCurrent.value;
+	} );
+
+	const isLoading = computed( () => {
+		if ( helpVisible.value ) {
+			return false;
+		}
+		if ( isPresultsSurface.value ) {
+			return !related.value.settled;
+		}
+		return !isContentCurrent.value;
+	} );
+
+	const defaultHighlightIndex = computed( () => {
+		// Presults are the only list shown without being asked for, so they
+		// get no default highlight and Enter does nothing. The help catalog
+		// and a mode's root listing also render at an empty query, but the
+		// user elicited those, so they keep theirs.
+		if ( isPresultsSurface.value ) {
+			return -1;
+		}
+		return ( isLeadReady.value && flatItems.value.length > 0 ) ? 0 : -1;
+	} );
+
 	const stateConfig = computed( () => {
 		const mode = activeMode.value;
 		if ( !mode ) {
@@ -100,15 +217,34 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	const resetDetailState = detailLifecycle.reset;
 
 	/**
-	 * Applies the result decorator and updates displayedItems.
+	 * Lands provider output on the content group, but only if the surface it
+	 * was dispatched for is still the current one. This is the single
+	 * staleness gate — it replaces the per-call combinations of query, mode
+	 * and mode-context checks that each covered a different subset.
 	 *
-	 * @param {Array} contentItems Items from the content provider.
+	 * @param {Array} items Items from the content provider.
+	 * @param {string} dispatchSurface surfaceKey captured when the request was issued.
+	 * @param {string} [providerId] Id of the provider that produced the items.
 	 */
-	function setResults( contentItems ) {
-		const items = Array.isArray( contentItems ) ? contentItems : [];
-		const decorated = resultDecorator( items, query.value );
-		displayedItems.value = decorated.length > 0 ?
-			[ { heading: null, items: decorated } ] : [];
+	function applyContent( items, dispatchSurface, providerId ) {
+		if ( surfaceKey.value !== dispatchSurface ) {
+			return;
+		}
+		content.value = {
+			items: Array.isArray( items ) ? items : [],
+			forSurface: dispatchSurface,
+			providerId: providerId !== undefined ?
+				providerId :
+				content.value.providerId
+		};
+	}
+
+	/**
+	 * Empties the content group. Used where a new level genuinely replaces the
+	 * old one (mode entry, drilling in or out) rather than refining it.
+	 */
+	function resetContent() {
+		content.value = { items: [], forSurface: null, providerId: null };
 	}
 
 	/**
@@ -116,21 +252,19 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	 *
 	 * @param {Object} provider The provider.
 	 * @param {string} currentQuery The query at dispatch time.
+	 * @param {string} dispatchSurface surfaceKey at dispatch time.
 	 */
-	async function handleSyncProvider( provider, currentQuery ) {
+	async function handleSyncProvider( provider, currentQuery, dispatchSurface ) {
 		try {
 			const result = await provider.getResults( currentQuery, undefined );
-			const items = normalizeProviderResult( result );
-			if ( query.value === currentQuery ) {
-				setResults( items );
-			}
+			applyContent(
+				normalizeProviderResult( result ), dispatchSurface, provider.id
+			);
 		} catch ( error ) {
 			mw.log.error(
 				'[commandPalette] Sync provider "' + provider.id + '" failed:', error
 			);
-			if ( query.value === currentQuery ) {
-				setResults( [] );
-			}
+			applyContent( [], dispatchSurface, provider.id );
 		}
 	}
 
@@ -139,125 +273,95 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	 *
 	 * @param {Object} provider The provider.
 	 * @param {string} currentQuery The query at dispatch time.
+	 * @param {string} dispatchSurface surfaceKey at dispatch time.
 	 */
-	function handleAsyncProvider( provider, currentQuery ) {
-		const isStale = () => query.value !== currentQuery;
+	function handleAsyncProvider( provider, currentQuery, dispatchSurface ) {
+		const isStale = () => surfaceKey.value !== dispatchSurface;
 		lifecycle.runDebouncedAbortable( {
 			debounceMs: provider.debounceMs || DEFAULT_DEBOUNCE_MS,
 			isStale,
 			run: ( signal ) => provider.getResults( currentQuery, signal ),
-			onResult: ( result ) => setResults( normalizeProviderResult( result ) ),
+			onResult: ( result ) => applyContent(
+				normalizeProviderResult( result ), dispatchSurface, provider.id
+			),
 			onError: ( error ) => {
 				mw.log.error(
 					'[commandPalette] Async provider "' + provider.id + '" failed:', error
 				);
-				if ( !isStale() ) {
-					setResults( [] );
-				}
+				applyContent( [], dispatchSurface, provider.id );
 			}
 		} );
 	}
 
 	/**
-	 * Builds presult sections from related and recent items.
-	 * Deduplicates recent items that already appear in related results.
-	 *
-	 * @param {Array} relatedItems Related article items.
-	 * @param {Array} recentItems Recent items.
-	 * @return {Array} Sections array for displayedItems.
-	 */
-	function buildPresultSections( relatedItems, recentItems ) {
-		const relatedUrls = new Set(
-			relatedItems.map( ( item ) => item.url ).filter( Boolean )
-		);
-		const filteredRecent = recentItems.filter(
-			( item ) => !item.url || !relatedUrls.has( item.url )
-		);
-
-		const sections = [];
-		if ( relatedItems.length > 0 ) {
-			sections.push( {
-				heading: 'citizen-command-palette-heading-related',
-				items: relatedItems
-			} );
-		}
-		if ( filteredRecent.length > 0 ) {
-			sections.push( {
-				heading: 'citizen-command-palette-heading-recent',
-				items: filteredRecent
-			} );
-		}
-		return sections;
-	}
-
-	/**
 	 * Clears the search and populates presults.
+	 *
+	 * Related outranks recents because navigation intent is higher. That
+	 * ranking is structural — it is the order the two appear in the presults
+	 * branch of `displayedItems` — so however late related arrives it lands
+	 * above recents. This surface has no default highlight, and an explicit
+	 * selection is restored by item id, so the list settling underneath the
+	 * user cannot redirect them.
 	 */
 	async function clearSearch() {
 		query.value = '';
 		resetOperationState();
 		resetDetailState();
+		resetContent();
 
 		let recentItems = [];
 		if ( deps.recentItemsProvider ) {
 			try {
-				const recentResult = deps.recentItemsProvider.getResults( '' );
-				recentItems = normalizeProviderResult( recentResult );
+				recentItems = normalizeProviderResult(
+					deps.recentItemsProvider.getResults( '' )
+				);
 			} catch ( e ) {
 				mw.log.error( '[commandPalette] Failed to get recent items:', e );
 			}
 		}
+		recents.value = recentItems;
+		related.value = { items: [], settled: !deps.relatedArticlesProvider };
 
-		// Show recent section immediately while related loads
-		displayedItems.value = recentItems.length > 0 ?
-			[ { heading: 'citizen-command-palette-heading-recent', items: recentItems } ] :
-			[];
-
-		if ( deps.relatedArticlesProvider ) {
-			try {
-				const relatedResult =
-					await deps.relatedArticlesProvider.getResults( '' );
-				const relatedItems = normalizeProviderResult( relatedResult );
-
-				if ( query.value === '' ) {
-					displayedItems.value =
-						buildPresultSections( relatedItems, recentItems );
-				}
-			} catch ( e ) {
-				mw.log.error(
-					'[commandPalette] Failed to get related articles:', e
-				);
-			}
+		if ( !deps.relatedArticlesProvider ) {
+			return;
 		}
-	}
 
-	/**
-	 * Renders mode-getResults output into a single section. Both the
-	 * empty-query and debounced branches funnel through this so the
-	 * staleness check stays consistent.
-	 *
-	 * @param {Object} mode
-	 * @param {string} currentQuery
-	 * @param {Array} items
-	 */
-	function applyModeResults( mode, currentQuery, items ) {
-		if ( query.value === currentQuery && activeMode.value === mode ) {
-			displayedItems.value = items.length > 0 ?
-				[ { heading: null, items: items } ] : [];
+		const dispatchSurface = surfaceKey.value;
+		let relatedItems = [];
+		try {
+			relatedItems = normalizeProviderResult(
+				await deps.relatedArticlesProvider.getResults( '' )
+			);
+		} catch ( e ) {
+			mw.log.error( '[commandPalette] Failed to get related articles:', e );
 		}
+
+		// The provider takes no AbortSignal, so this is the only gate standing
+		// between a slow related fetch and a surface that has moved on.
+		if ( surfaceKey.value !== dispatchSurface ) {
+			return;
+		}
+		related.value = { items: relatedItems, settled: true };
 	}
 
 	/**
 	 * Handles a query routed through the active mode's getResults.
+	 *
+	 * Previous results stay on screen while a refinement runs — they are
+	 * stamped with the surface that produced them, so they render but cannot
+	 * be the default Enter target.
 	 *
 	 * @param {Object} mode The active mode object.
 	 * @param {string} currentQuery The query string.
 	 */
 	function handleModeQuery( mode, currentQuery ) {
 		const tokens = deps.tokens ? deps.tokens.value : [];
+		const dispatchSurface = surfaceKey.value;
 
 		// Empty query: fire immediately. No debounce, no abort — modes
 		// load their root state on entry and the user expects no delay.
+		// Uncancellable, so `dispatchSurface` is the only thing stopping a
+		// late landing from overwriting a level the user has left.
 		if ( !currentQuery ) {
 			isPending.value = true;
 			( async () => {
@@ -265,13 +369,16 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 					const result = await mode.getResults(
 						'', undefined, tokens, activeModeContext.value
 					);
-					applyModeResults( mode, currentQuery, normalizeProviderResult( result ) );
+					applyContent(
+						normalizeProviderResult( result ), dispatchSurface
+					);
 				} catch ( error ) {
 					mw.log.error(
 						'[commandPalette] Mode "' + mode.id + '" failed:', error
 					);
+					applyContent( [], dispatchSurface );
 				} finally {
-					if ( query.value === currentQuery && activeMode.value === mode ) {
+					if ( surfaceKey.value === dispatchSurface ) {
 						isPending.value = false;
 					}
 				}
@@ -279,19 +386,19 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 			return;
 		}
 
-		const isStale = () => query.value !== currentQuery || activeMode.value !== mode;
+		const isStale = () => surfaceKey.value !== dispatchSurface;
 		lifecycle.runDebouncedAbortable( {
 			debounceMs: mode.debounceMs ?? DEFAULT_DEBOUNCE_MS,
 			isStale,
 			run: ( signal ) => mode.getResults( currentQuery, signal, tokens, activeModeContext.value ),
-			onResult: ( result ) => applyModeResults( mode, currentQuery, normalizeProviderResult( result ) ),
+			onResult: ( result ) => applyContent(
+				normalizeProviderResult( result ), dispatchSurface
+			),
 			onError: ( error ) => {
 				mw.log.error(
 					'[commandPalette] Mode "' + mode.id + '" failed:', error
 				);
-				if ( !isStale() ) {
-					displayedItems.value = [];
-				}
+				applyContent( [], dispatchSurface );
 			}
 		} );
 	}
@@ -307,7 +414,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		activeMode.value = mode;
 		activeModeContext.value = [];
 		query.value = '';
-		displayedItems.value = [];
+		resetContent();
 		handleModeQuery( mode, '' );
 	}
 
@@ -342,7 +449,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		resetOperationState();
 		resetDetailState();
 		query.value = '';
-		displayedItems.value = [];
+		resetContent();
 		handleModeQuery( activeMode.value, '' );
 	}
 
@@ -360,7 +467,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		resetOperationState();
 		resetDetailState();
 		query.value = '';
-		displayedItems.value = [];
+		resetContent();
 		handleModeQuery( activeMode.value, '' );
 	}
 
@@ -394,29 +501,33 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		const contentProvider = providers.find(
 			( p ) => p.canProvide( newQuery )
 		);
+		const dispatchSurface = surfaceKey.value;
 
 		if ( !contentProvider ) {
-			setResults( [] );
+			applyContent( [], dispatchSurface, null );
 			return;
 		}
 
-		// Show stale results while loading if configured
-		if ( contentProvider.keepStaleResults && flatItems.value.length > 0 ) {
-			const staleItems = flatItems.value.filter(
-				( item ) => item.source && (
-					item.source.startsWith( contentProvider.id + ':' ) ||
-					item.source === contentProvider.id
-				)
-			);
-			setResults( staleItems );
-		} else {
-			setResults( [] );
-		}
+		// Keep the previous fetch's rows on screen while the new one runs, when
+		// the provider opts in. They keep the surface stamp they were produced
+		// for, so they render without becoming a valid activation target.
+		content.value = {
+			items: contentProvider.keepStaleResults ?
+				content.value.items.filter(
+					( item ) => item.source && (
+						item.source.startsWith( contentProvider.id + ':' ) ||
+						item.source === contentProvider.id
+					)
+				) :
+				[],
+			forSurface: content.value.forSurface,
+			providerId: contentProvider.id
+		};
 
 		if ( contentProvider.debounceMs > 0 ) {
-			handleAsyncProvider( contentProvider, newQuery );
+			handleAsyncProvider( contentProvider, newQuery, dispatchSurface );
 		} else {
-			handleSyncProvider( contentProvider, newQuery );
+			handleSyncProvider( contentProvider, newQuery, dispatchSurface );
 		}
 	}
 
@@ -555,12 +666,9 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		if ( !deps.getHelpCatalogItems ) {
 			return;
 		}
-		const items = deps.getHelpCatalogItems() || [];
 		resetOperationState();
 		resetDetailState();
-		displayedItems.value = items.length > 0 ?
-			[ { heading: 'citizen-command-palette-help-section-modes', items: items } ] :
-			[];
+		helpItems.value = deps.getHelpCatalogItems() || [];
 	}
 
 	/**
@@ -582,7 +690,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		if ( activeMode.value ) {
 			resetOperationState();
 			resetDetailState();
-			displayedItems.value = [];
+			helpItems.value = [];
 		} else {
 			loadHelpCatalog();
 		}
@@ -598,17 +706,16 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 			return;
 		}
 		helpVisible.value = false;
+		helpItems.value = [];
 		if ( activeMode.value ) {
 			handleModeQuery( activeMode.value, query.value );
-		} else if ( !query.value ) {
+		} else if ( query.value ) {
+			// updateQuery records a query typed while help is up but skips
+			// dispatch, so the surface underneath is rebuilt on the way out.
+			updateQuery( query.value );
+		} else {
 			clearSearch();
 		}
-		// else: at root with a non-empty query is unreachable — `?` only
-		// opens help at empty input, and selecting `/help` triggers a
-		// tokenInput.clear() whose watcher empties query.value (the
-		// updateQuery guard prevents displayedItems mutation). Callers that
-		// follow up with enterMode (e.g. exitWithQuery) handle the next
-		// state themselves; closing here would race with their setup.
 	}
 
 	/**
@@ -646,6 +753,10 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 		isPending,
 		showPending,
 		hasDisplayedItems,
+		isLoading,
+		surfaceKey,
+		isLeadReady,
+		defaultHighlightIndex,
 		stateConfig,
 		activeMode,
 		activeModeContext,

--- a/resources/skins.citizen.commandPalette/utils/appendQueryActions.js
+++ b/resources/skins.citizen.commandPalette/utils/appendQueryActions.js
@@ -19,7 +19,13 @@ function createAppendQueryActions() {
 			description: mw.message( 'citizen-command-palette-queryaction-fulltext-search-description' ).text(),
 			icon: cdxIconArticleSearch,
 			showItem: true,
-			getUrl: ( query ) => mw.util.getUrl( 'Special:Search', { search: query } )
+			// Without `fulltext`, Special:Search does a near-match "go" and
+			// redirects whenever the query is an exact title, so this row
+			// would sometimes navigate rather than search. That page is
+			// already listed as a result directly below.
+			getUrl: ( query ) => mw.util.getUrl(
+				'Special:Search', { search: query, fulltext: 1 }
+			)
 		},
 		{
 			id: 'page-edit',
@@ -29,6 +35,56 @@ function createAppendQueryActions() {
 			getUrl: ( query ) => mw.util.getUrl( query, { action: 'edit' } )
 		}
 	];
+
+	/**
+	 * Builds the action rows whose ids appear in `ids`, preserving the order
+	 * declared in `queryActionDefinitions`.
+	 *
+	 * @param {string} query The current search query.
+	 * @param {string[]} ids Definition ids to include.
+	 * @return {Array} Action items.
+	 */
+	function buildActions( query, ids ) {
+		if ( !query ) {
+			return [];
+		}
+
+		return queryActionDefinitions
+			.filter( ( def ) => def.showItem && ids.includes( def.id ) )
+			.map( ( def ) => ( {
+				id: `citizen-command-palette-item-${ def.id }`,
+				type: 'action',
+				label: query,
+				description: def.description,
+				url: def.getUrl( query ),
+				thumbnailIcon: def.icon,
+				actions: [],
+				source: `queryAction:${ def.id }`
+			} ) );
+	}
+
+	/**
+	 * The action that restates the typed query as a search. It is derived
+	 * synchronously from the query, so unlike fetched results it always
+	 * matches what is currently in the input — which is what lets it be the
+	 * one row Enter can commit to without waiting.
+	 *
+	 * @param {string} query The current search query.
+	 * @return {Array} Lead action items.
+	 */
+	function leadActions( query ) {
+		return buildActions( query, [ 'fulltext-search' ] );
+	}
+
+	/**
+	 * Actions that belong after the results.
+	 *
+	 * @param {string} query The current search query.
+	 * @return {Array} Trailing action items.
+	 */
+	function trailActions( query ) {
+		return buildActions( query, [ 'page-edit' ] );
+	}
 
 	/**
 	 * Appends query action items to the given results array.
@@ -42,24 +98,11 @@ function createAppendQueryActions() {
 			return items;
 		}
 
-		const actionItems = [];
-		queryActionDefinitions.forEach( ( def ) => {
-			if ( def.showItem ) {
-				actionItems.push( {
-					id: `citizen-command-palette-item-${ def.id }`,
-					type: 'action',
-					label: query,
-					description: def.description,
-					url: def.getUrl( query ),
-					thumbnailIcon: def.icon,
-					actions: [],
-					source: `queryAction:${ def.id }`
-				} );
-			}
-		} );
-
-		return [ ...items, ...actionItems ];
+		return [ ...items, ...leadActions( query ), ...trailActions( query ) ];
 	}
+
+	appendQueryActions.leadActions = leadActions;
+	appendQueryActions.trailActions = trailActions;
 
 	return appendQueryActions;
 }

--- a/skin.json
+++ b/skin.json
@@ -425,6 +425,7 @@
 				"resources/skins.citizen.commandPalette/composables/useListNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useGridNavigation.js",
 				"resources/skins.citizen.commandPalette/composables/useOperationLifecycle.js",
+				"resources/skins.citizen.commandPalette/composables/usePendingActivation.js",
 				"resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js",
 				"resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js",
 				"resources/skins.citizen.commandPalette/composables/useKeyboard.js",

--- a/tests/vitest/commandPalette/composables/useKeyboard.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboard.test.js
@@ -30,6 +30,8 @@ function toGrouped( deps ) {
 			items: deps.items,
 			query: deps.query,
 			requestHeaderCopy: deps.requestHeaderCopy,
+			canQueueActivation: deps.canQueueActivation,
+			onQueueActivation: deps.onQueueActivation,
 			onSelect: deps.onSelect,
 			onClose: deps.onClose,
 			onClearQuery: deps.onClearQuery
@@ -127,6 +129,8 @@ describe( 'useKeyboard', () => {
 			actionNav: actionNav,
 			onSelect: vi.fn(),
 			onClose: vi.fn(),
+			canQueueActivation: ref( false ),
+			onQueueActivation: vi.fn(),
 			query: ref( '' ),
 			activeMode: ref( null ),
 			onClearQuery: vi.fn(),
@@ -638,16 +642,46 @@ describe( 'useKeyboard', () => {
 	} );
 
 	describe( 'keyboardHints', () => {
-		it( 'should return Enter/Search and Exit when no items and nothing highlighted', () => {
+		it( 'should offer no Enter hint when nothing is highlighted and nothing can be queued', () => {
 			deps.items.value = [];
 			listNav.highlightedIndex.value = -1;
 
 			const hints = keyboard.keyboardHints.value;
 
+			// Enter has nothing to act on here, so advertising it would promise
+			// a keystroke that does nothing.
 			expect( hints ).toEqual( [
-				{ msgKey: 'citizen-command-palette-keyhint-enter-search', kbd: '↵' },
 				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc' }
 			] );
+		} );
+
+		it( 'should offer the Enter hint when an activation can be queued', () => {
+			deps.items.value = [];
+			listNav.highlightedIndex.value = -1;
+			deps.canQueueActivation.value = true;
+
+			const hints = keyboard.keyboardHints.value;
+
+			expect( hints ).toContainEqual(
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' }
+			);
+		} );
+
+		it( 'should name Enter as Search when the pinned fulltext row is highlighted', () => {
+			deps.items.value = [
+				{ id: 1, type: 'action', source: 'queryAction:fulltext-search' },
+				{ id: 2, type: 'page' }
+			];
+			listNav.highlightedIndex.value = 0;
+
+			const hints = keyboard.keyboardHints.value;
+
+			expect( hints ).toContainEqual(
+				{ msgKey: 'citizen-command-palette-keyhint-enter-search', kbd: '↵' }
+			);
+			expect( hints ).not.toContainEqual(
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' }
+			);
 		} );
 
 		it( 'should return Enter/Select, Navigate, and Exit when item is highlighted with no actions', () => {

--- a/tests/vitest/commandPalette/composables/usePendingActivation.test.js
+++ b/tests/vitest/commandPalette/composables/usePendingActivation.test.js
@@ -1,0 +1,169 @@
+const { ref, nextTick } = require( 'vue' );
+
+const usePendingActivation = require(
+	'../../../../resources/skins.citizen.commandPalette/composables/usePendingActivation.js'
+);
+const { PENDING_ACTIVATION_TIMEOUT_MS } = usePendingActivation;
+
+const surfaceOf = ( query, mode, context, help ) => JSON.stringify( [
+	query, mode || null, context || [], !!help
+] );
+
+function setup( overrides = {} ) {
+	const state = {
+		surfaceKey: ref( surfaceOf( 'sun' ) ),
+		isLeadReady: ref( false ),
+		items: ref( [] ),
+		defaultHighlightIndex: ref( -1 ),
+		onActivate: vi.fn(),
+		...overrides
+	};
+
+	return { state, pending: usePendingActivation( state ) };
+}
+
+/**
+ * Settle the lead group with the given items, as the orchestration would.
+ *
+ * @param {Object} state
+ * @param {Array} items
+ * @return {Promise}
+ */
+async function settle( state, items ) {
+	state.items.value = items;
+	state.defaultHighlightIndex.value = items.length > 0 ? 0 : -1;
+	state.isLeadReady.value = true;
+	await nextTick();
+}
+
+describe( 'usePendingActivation', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	} );
+
+	it( 'fires with the default item once the lead group settles', async () => {
+		const { state, pending } = setup();
+
+		pending.arm();
+		await settle( state, [ { id: 'sunset', label: 'Sunset' } ] );
+
+		expect( state.onActivate ).toHaveBeenCalledWith( { id: 'sunset', label: 'Sunset' } );
+	} );
+
+	it( 'raises its own queued flag immediately', () => {
+		const { pending } = setup();
+
+		pending.arm();
+
+		expect( pending.isActivationQueued.value ).toBe( true );
+	} );
+
+	it( 'does nothing until the lead group settles', async () => {
+		const { state, pending } = setup();
+
+		pending.arm();
+		state.items.value = [ { id: 'stale' } ];
+		await nextTick();
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'is discarded when the query changes again', async () => {
+		const { state, pending } = setup();
+
+		pending.arm();
+		state.surfaceKey.value = surfaceOf( 'sunse' );
+		await nextTick();
+		await settle( state, [ { id: 'sunset' } ] );
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+		expect( pending.isActivationQueued.value ).toBe( false );
+	} );
+
+	// The bug this binding exists to prevent: entering a mode, drilling in or
+	// out, and opening help all leave the query at '', so a query-only binding
+	// would let an activation armed on one level fire against another.
+	it( 'is discarded when the mode context changes without the query changing', async () => {
+		const { state, pending } = setup( {
+			surfaceKey: ref( surfaceOf( '', 'category', [ 'Animals' ] ) )
+		} );
+
+		pending.arm();
+		state.surfaceKey.value = surfaceOf( '', 'category', [] );
+		await nextTick();
+		await settle( state, [ { id: 'abandoned-member' } ] );
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'is discarded when help opens without the query changing', async () => {
+		const { state, pending } = setup( {
+			surfaceKey: ref( surfaceOf( '', 'file', [] ) )
+		} );
+
+		pending.arm();
+		state.surfaceKey.value = surfaceOf( '', 'file', [], true );
+		await nextTick();
+		await settle( state, [ { id: 'never-seen' } ] );
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'is discarded when the lead group settles with no items', async () => {
+		const { state, pending } = setup();
+
+		pending.arm();
+		await settle( state, [] );
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+		expect( pending.isActivationQueued.value ).toBe( false );
+	} );
+
+	it( 'expires without navigating when the fetch never lands', async () => {
+		const { state, pending } = setup();
+
+		pending.arm();
+		vi.advanceTimersByTime( PENDING_ACTIVATION_TIMEOUT_MS );
+		await settle( state, [ { id: 'late' } ] );
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+		expect( pending.isActivationQueued.value ).toBe( false );
+	} );
+
+	it( 'cancel() drops the queued activation', async () => {
+		const { state, pending } = setup();
+
+		pending.arm();
+		pending.cancel();
+		await settle( state, [ { id: 'sunset' } ] );
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+		expect( pending.isActivationQueued.value ).toBe( false );
+	} );
+
+	it( 'does not fire when nothing was ever armed', async () => {
+		const { state } = setup();
+
+		await settle( state, [ { id: 'sunset' } ] );
+
+		expect( state.onActivate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'only fires once per arm', async () => {
+		const { state, pending } = setup();
+
+		pending.arm();
+		await settle( state, [ { id: 'sunset' } ] );
+		state.isLeadReady.value = false;
+		await nextTick();
+		state.isLeadReady.value = true;
+		await nextTick();
+
+		expect( state.onActivate ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/tests/vitest/commandPalette/composables/useProviderOrchestration.test.js
+++ b/tests/vitest/commandPalette/composables/useProviderOrchestration.test.js
@@ -36,12 +36,19 @@ describe( 'useProviderOrchestration', () => {
 			keepStaleResults: false
 		};
 
+		// Mirrors createAppendQueryActions: production always attaches the
+		// lead/trail split, so a bare function here would exercise a shape the
+		// shipped code never sees.
 		mockDecorator = vi.fn( ( items, query ) => {
 			if ( query ) {
 				return items.concat( [ { id: 'action', label: query, type: 'action' } ] );
 			}
 			return items;
 		} );
+		mockDecorator.leadActions = vi.fn( ( query ) => ( query ?
+			[ { id: 'action', label: query, type: 'action', source: 'queryAction:fulltext-search' } ] :
+			[] ) );
+		mockDecorator.trailActions = vi.fn( () => [] );
 	} );
 
 	afterEach( () => {
@@ -188,12 +195,15 @@ describe( 'useProviderOrchestration', () => {
 			expect( mockProviders[ 0 ].canProvide ).toHaveBeenCalledWith( 'test' );
 		} );
 
-		it( 'enterMode clears displayed items', () => {
+		it( 'enterMode clears displayed items and withholds the highlight while loading', () => {
 			const mode = { id: 'ns', getResults: vi.fn().mockResolvedValue( [] ) };
 
 			orch.enterMode( mode );
 
 			expect( orch.displayedItems.value ).toEqual( [] );
+			expect( orch.isLoading.value ).toBe( true );
+			expect( orch.isLeadReady.value ).toBe( false );
+			expect( orch.defaultHighlightIndex.value ).toBe( -1 );
 		} );
 
 		it( 'exitMode resets to presults', async () => {
@@ -590,6 +600,196 @@ describe( 'useProviderOrchestration', () => {
 			expect( orch.displayedItems.value ).toEqual( [
 				{ heading: 'citizen-command-palette-heading-recent', items: recentItems }
 			] );
+		} );
+	} );
+
+	describe( 'presult slots', () => {
+		const recentItems = [ { id: 'r1', url: '/R', label: 'R', source: 'recent' } ];
+		const relatedItems = [ { id: 'a1', url: '/A', label: 'A', source: 'related' } ];
+
+		const build = ( relatedResolver ) => useProviderOrchestration( [], mockDecorator, {
+			recentItemsProvider: { getResults: () => ( { items: recentItems } ) },
+			relatedArticlesProvider: { getResults: relatedResolver }
+		} );
+
+		it( 'declares related above recents before related has resolved', async () => {
+			let resolveRelated;
+			const orch = build( () => new Promise( ( resolve ) => {
+				resolveRelated = resolve;
+			} ) );
+
+			await orch.clearSearch;
+			orch.clearSearch();
+
+			// Related has not resolved, so it draws nothing yet — but it is
+			// reported as loading and holds its declared position for later.
+			expect( orch.isLoading.value ).toBe( true );
+			expect( orch.displayedItems.value.map( ( s ) => s.heading ) ).toEqual( [
+				'citizen-command-palette-heading-recent'
+			] );
+			expect( orch.flatItems.value.map( ( i ) => i.id ) ).toEqual( [ 'r1' ] );
+
+			resolveRelated( { items: relatedItems } );
+		} );
+
+		it( 'does not reorder the list when related resolves late', async () => {
+			const orch = build( () => Promise.resolve( { items: relatedItems } ) );
+
+			await orch.clearSearch();
+
+			// Related is declared above recents, so it lands above them
+			// however late it resolves.
+			expect( orch.displayedItems.value.map( ( s ) => s.heading ) ).toEqual( [
+				'citizen-command-palette-heading-related',
+				'citizen-command-palette-heading-recent'
+			] );
+			expect( orch.flatItems.value.map( ( i ) => i.id ) ).toEqual( [ 'a1', 'r1' ] );
+		} );
+
+		it( 'withholds the default highlight on presults even once settled', async () => {
+			const orch = build( () => Promise.resolve( { items: relatedItems } ) );
+
+			await orch.clearSearch();
+
+			expect( orch.flatItems.value ).toHaveLength( 2 );
+			expect( orch.defaultHighlightIndex.value ).toBe( -1 );
+		} );
+
+		it( 'retires presult slots once the user types', async () => {
+			const orch = build( () => Promise.resolve( { items: relatedItems } ) );
+			await orch.clearSearch();
+			expect( orch.flatItems.value.map( ( i ) => i.id ) ).toEqual( [ 'a1', 'r1' ] );
+
+			orch.updateQuery( 'anything' );
+
+			// Recents and related belong to the empty-query surface only; a
+			// query must not leave them rendering under its results.
+			const sources = orch.flatItems.value.map( ( i ) => i.source );
+			expect( sources ).not.toContain( 'recent' );
+			expect( sources ).not.toContain( 'related' );
+			expect( orch.displayedItems.value.map( ( sec ) => sec.heading ) )
+				.not.toContain( 'citizen-command-palette-heading-recent' );
+		} );
+
+		it( 'restores presult slots when the query is cleared again', async () => {
+			const orch = build( () => Promise.resolve( { items: relatedItems } ) );
+			await orch.clearSearch();
+			orch.updateQuery( 'anything' );
+
+			await orch.clearSearch();
+
+			expect( orch.flatItems.value.map( ( i ) => i.id ) ).toEqual( [ 'a1', 'r1' ] );
+		} );
+
+		it( 'drops a related result that lands after the user typed', async () => {
+			let resolveRelated;
+			const orch = build( () => new Promise( ( resolve ) => {
+				resolveRelated = resolve;
+			} ) );
+
+			const pending = orch.clearSearch();
+			orch.query.value = 'moved on';
+			resolveRelated( { items: relatedItems } );
+			await pending;
+
+			expect( orch.flatItems.value.map( ( i ) => i.id ) ).not.toContain( 'a1' );
+		} );
+	} );
+
+	describe( 'surface isolation', () => {
+		it( 'does not leave the help catalog behind when help closes over a query', async () => {
+			const provider = {
+				id: 'search',
+				canProvide: ( q ) => !!q,
+				getResults: () => ( { items: [ { id: 's1', label: 'Real', source: 'search' } ] } ),
+				onResultSelect: vi.fn(),
+				debounceMs: 0,
+				keepStaleResults: false
+			};
+			const orch = useProviderOrchestration( [ provider ], mockDecorator, {
+				getHelpCatalogItems: () => [ { id: 'cmd-x', source: 'command:x' } ]
+			} );
+
+			orch.openHelp();
+			orch.updateQuery( 'hello' );
+			orch.closeHelp();
+			await vi.runAllTimersAsync();
+
+			expect( orch.flatItems.value.map( ( i ) => i.source ) )
+				.not.toContain( 'command:x' );
+		} );
+
+		it( 'drops a mode result that lands after the mode context changed', async () => {
+			// One resolver per call: the drilled level's request is the one
+			// that must be ignored, and it is not the most recent.
+			const resolvers = [];
+			const mode = {
+				id: 'cat',
+				getResults: vi.fn( () => new Promise( ( resolve ) => {
+					resolvers.push( resolve );
+				} ) )
+			};
+			const orch = useProviderOrchestration( [], mockDecorator, {} );
+
+			orch.enterMode( mode );
+			orch.pushModeContext( 'Animals' );
+			// Back out before the drilled level's unabortable fetch resolves.
+			orch.popModeContext();
+			// Resolve ONLY the drilled level's request. Leaving the others
+			// pending means nothing can overwrite its landing, so the
+			// assertion tests the staleness gate rather than write order.
+			resolvers[ 1 ]( [ { id: 'abandoned', label: 'Abandoned member' } ] );
+			await vi.runAllTimersAsync();
+
+			expect( orch.flatItems.value.map( ( i ) => i.id ) )
+				.not.toContain( 'abandoned' );
+		} );
+	} );
+
+	describe( 'query action placement', () => {
+		const searchProvider = {
+			id: 'search',
+			canProvide: ( q ) => !!q && !q.startsWith( '#' ),
+			getResults: () => ( { items: [ { id: 'p1', label: 'Page', source: 'search' } ] } ),
+			onResultSelect: vi.fn(),
+			debounceMs: 0,
+			keepStaleResults: false
+		};
+		const commandProvider = {
+			id: 'command',
+			canProvide: ( q ) => q.startsWith( '#' ),
+			getResults: () => ( { items: [ { id: 'c1', label: 'Cat', source: 'command:cat' } ] } ),
+			onResultSelect: vi.fn(),
+			debounceMs: 0,
+			keepStaleResults: false
+		};
+
+		it( 'pins the fulltext action first when the search provider matched', async () => {
+			const orch = useProviderOrchestration(
+				[ commandProvider, searchProvider ], mockDecorator, {}
+			);
+
+			orch.updateQuery( 'sunset' );
+			await vi.runAllTimersAsync();
+
+			expect( orch.flatItems.value[ 0 ].source )
+				.toBe( 'queryAction:fulltext-search' );
+			expect( orch.defaultHighlightIndex.value ).toBe( 0 );
+		} );
+
+		it( 'leaves a trigger-prefixed query its own results in the lead', async () => {
+			const orch = useProviderOrchestration(
+				[ commandProvider, searchProvider ], mockDecorator, {}
+			);
+
+			orch.updateQuery( '#cat' );
+			await vi.runAllTimersAsync();
+
+			// Enter must not search for the literal "#cat"; the command
+			// results lead, and the action drops to the trailing set.
+			expect( orch.flatItems.value[ 0 ].source ).toBe( 'command:cat' );
+			expect( orch.flatItems.value.map( ( i ) => i.source ) )
+				.toContain( 'queryAction:fulltext-search' );
 		} );
 	} );
 

--- a/tests/vitest/commandPalette/utils/appendQueryActions.test.js
+++ b/tests/vitest/commandPalette/utils/appendQueryActions.test.js
@@ -29,7 +29,7 @@ describe( 'createAppendQueryActions', () => {
 		expect( fulltextAction.type ).toBe( 'action' );
 		expect( fulltextAction.label ).toBe( 'test query' );
 		expect( fulltextAction.source ).toBe( 'queryAction:fulltext-search' );
-		expect( fulltextAction.url ).toBe( '/wiki/Special:Search?search=test+query' );
+		expect( fulltextAction.url ).toBe( '/wiki/Special:Search?search=test+query&fulltext=1' );
 	} );
 
 	it( 'no longer emits the media-search action (handled by the file mode now)', () => {
@@ -53,5 +53,64 @@ describe( 'createAppendQueryActions', () => {
 		expect( result[ 0 ] ).toEqual( originalItems[ 0 ] );
 		expect( result[ 1 ] ).toEqual( originalItems[ 1 ] );
 		expect( result.length ).toBeGreaterThan( originalItems.length );
+	} );
+
+	describe( 'lead/trail split', () => {
+		it( 'always performs a full-text search, never a near-match redirect', () => {
+			const appendQueryActions = createAppendQueryActions();
+
+			// Without fulltext, Special:Search redirects to the page when the
+			// query is an exact title, so this row would sometimes navigate
+			// rather than search.
+			const lead = appendQueryActions.leadActions( 'Main Page' );
+
+			expect( lead[ 0 ].url ).toContain( 'fulltext=1' );
+		} );
+
+		it( 'exposes the fulltext action on its own so it can be positioned first', () => {
+			const appendQueryActions = createAppendQueryActions();
+
+			const lead = appendQueryActions.leadActions( 'test query' );
+
+			expect( lead ).toHaveLength( 1 );
+			expect( lead[ 0 ].source ).toBe( 'queryAction:fulltext-search' );
+		} );
+
+		it( 'keeps the fulltext action out of the trailing set', () => {
+			const appendQueryActions = createAppendQueryActions();
+
+			const trail = appendQueryActions.trailActions( 'test query' );
+
+			expect( trail.every( ( i ) => i.source !== 'queryAction:fulltext-search' ) ).toBe( true );
+		} );
+
+		it( 'returns nothing for either half when the query is empty', () => {
+			const appendQueryActions = createAppendQueryActions();
+
+			expect( appendQueryActions.leadActions( '' ) ).toEqual( [] );
+			expect( appendQueryActions.trailActions( '' ) ).toEqual( [] );
+		} );
+
+		it( 'produces a fresh row per call, so it always matches the current query', () => {
+			const appendQueryActions = createAppendQueryActions();
+
+			const first = appendQueryActions.leadActions( 'sun' );
+			const second = appendQueryActions.leadActions( 'sunset' );
+
+			expect( first[ 0 ].label ).toBe( 'sun' );
+			expect( second[ 0 ].label ).toBe( 'sunset' );
+			expect( second[ 0 ].url ).toBe( '/wiki/Special:Search?search=sunset&fulltext=1' );
+		} );
+
+		it( 'combined call still yields the same set as the two halves', () => {
+			const appendQueryActions = createAppendQueryActions();
+
+			const combined = appendQueryActions( [], 'q' ).map( ( i ) => i.source );
+			const split = appendQueryActions.leadActions( 'q' )
+				.concat( appendQueryActions.trailActions( 'q' ) )
+				.map( ( i ) => i.source );
+
+			expect( combined ).toEqual( split );
+		} );
 	} );
 } );


### PR DESCRIPTION
Closes #1196

## Problem

Typing quickly and pressing Enter navigates to a page the user never asked for. From the issue: type `Module:`, pause until suggestions appear (`Module:Arguments` at the top), type `Navbox`, press Enter immediately — the palette opens `Module:Arguments`.

Auto-selecting the first result is not the cause on its own. Three things combined:

1. Search results stay on screen while the next request runs, and nothing marked them as belonging to an older query.
2. The highlight was an index rather than an identity, so replacing the result set silently re-pointed it at a different page. Arrowing to the 4th result, typing one more character and pressing Enter landed on whatever was 4th in the new list.
3. Enter with nothing highlighted did nothing at all, while the footer advertised a "Search" hint — so simply not auto-selecting would have turned a wrong navigation into a dead key.

## Behaviour

**Enter always opens the highlighted row.** That is the only thing it does.

When a search is typed, the first row is a full-text search for exactly what is in the input, and it starts highlighted. It is rebuilt on every keystroke, so pressing Enter immediately after typing can never act on results that have not caught up. Pages matching the query — including an exact title match — are listed directly below it, one arrow key away.

That row now always searches. Previously it could redirect straight to a page when the query happened to be an exact title, which meant the row labelled *"Search the full text of all pages"* sometimes navigated instead. The page it would have redirected to is already listed below it, visible and labelled.

Trigger-prefixed queries keep their own results first, so Enter on `#cat` opens the top category rather than searching for the literal text `#cat`.

Two related changes:

- **Nothing is highlighted before anything is typed.** Opening the palette and pressing Enter does nothing, so an accidental double-tap cannot navigate away from the page being read. Recent and related pages are still there to arrow onto.
- **Inside a mode** there is no synchronous row to fall back on, so an Enter pressed before that mode's results arrive waits for them and then opens the first one, rather than acting on the previous level's rows. The header shows a progress indicator while it waits.

## Contract

Result assembly is keyed on the *surface* a request was issued for — the query, the active mode, its drill-down position, and whether help is open — rather than on the query alone. Each surface names its own result groups, so leaving a surface stops rendering them and a late-landing request cannot write into a surface the user has already left.

This matters because drilling in or out of a mode, and opening help, all leave the query untouched. Checks keyed on the query alone silently permitted those transitions.

## Accepted cost

Enter on the default highlight always reaches a search results page, never a page directly. Navigating to a page costs one arrow key onto a row that is visible and labelled. This is the deliberate trade for an Enter that never depends on a request that has yet to land, and never carries two meanings.

If it proves annoying in practice, the escape hatch is a separate affordance for "top hit" rather than reverting the default.

## Follow-ups not taken here

- Arrowing onto a row that belongs to an older query and pressing Enter still opens it. That is a deliberate act on a row the user can see, which is a different situation from Enter firing at something never looked at.
- `RelatedArticlesProvider` accepts no abort signal, so a slow related fetch can only be discarded on arrival rather than cancelled. Pre-existing, and now correctly discarded.
- The command provider is undebounced and uncancellable, issuing a request per keystroke for trigger-prefixed queries. Pre-existing and out of scope.

## Testing

1419 unit tests pass. New coverage for staleness across surface changes, presult retirement, the query-action placement gate, and the queued activation.

Verified in a browser against a dev wiki: the issue's own reproduction, opening the palette and pressing Enter immediately, an exact-title query, the command surface, mode entry and exit, and a help round-trip over an active query. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enter activation can now be queued while command palette results are loading and completed automatically when ready.
  * Full-text search actions are clearly labeled and use dedicated search URLs.
  * Command palette surfaces better preserve highlights and isolate stale results during navigation.
* **Bug Fixes**
  * Improved loading indicators and empty states.
  * Prevented errors during list updates and teardown.
  * Improved help, recent, and related result handling across queries and modes.
* **Tests**
  * Expanded coverage for queued activation, keyboard behavior, result orchestration, and search actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->