### PR TITLE
fix(commandPalette): cancel in-flight requests for trigger-prefixed queries

### DIFF
--- a/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
+++ b/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
@@ -248,37 +248,21 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	}
 
 	/**
-	 * Handles a synchronous provider.
+	 * Dispatches a provider with debouncing, abort and pending state.
+	 *
+	 * A provider declaring `debounceMs: 0` still comes through here: it skips
+	 * the wait, not the cancellation. Resolving that 0 with `||` would silently
+	 * promote it to the default and was why a no-debounce provider previously
+	 * had to bypass abort and pending state altogether.
 	 *
 	 * @param {Object} provider The provider.
 	 * @param {string} currentQuery The query at dispatch time.
 	 * @param {string} dispatchSurface surfaceKey at dispatch time.
 	 */
-	async function handleSyncProvider( provider, currentQuery, dispatchSurface ) {
-		try {
-			const result = await provider.getResults( currentQuery, undefined );
-			applyContent(
-				normalizeProviderResult( result ), dispatchSurface, provider.id
-			);
-		} catch ( error ) {
-			mw.log.error(
-				'[commandPalette] Sync provider "' + provider.id + '" failed:', error
-			);
-			applyContent( [], dispatchSurface, provider.id );
-		}
-	}
-
-	/**
-	 * Handles an asynchronous provider with debouncing and abort.
-	 *
-	 * @param {Object} provider The provider.
-	 * @param {string} currentQuery The query at dispatch time.
-	 * @param {string} dispatchSurface surfaceKey at dispatch time.
-	 */
-	function handleAsyncProvider( provider, currentQuery, dispatchSurface ) {
+	function dispatchProvider( provider, currentQuery, dispatchSurface ) {
 		const isStale = () => surfaceKey.value !== dispatchSurface;
 		lifecycle.runDebouncedAbortable( {
-			debounceMs: provider.debounceMs || DEFAULT_DEBOUNCE_MS,
+			debounceMs: provider.debounceMs ?? DEFAULT_DEBOUNCE_MS,
 			isStale,
 			run: ( signal ) => provider.getResults( currentQuery, signal ),
 			onResult: ( result ) => applyContent(
@@ -524,11 +508,7 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 			providerId: contentProvider.id
 		};
 
-		if ( contentProvider.debounceMs > 0 ) {
-			handleAsyncProvider( contentProvider, newQuery, dispatchSurface );
-		} else {
-			handleSyncProvider( contentProvider, newQuery, dispatchSurface );
-		}
+		dispatchProvider( contentProvider, newQuery, dispatchSurface );
 	}
 
 	/**

--- a/resources/skins.citizen.commandPalette/providers/PaletteCommandProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/PaletteCommandProvider.js
@@ -8,9 +8,10 @@ const MAX_COMMAND_RESULTS = 10;
  * @param {Object} paletteRegistry The palette registry service.
  * @param {Object} match The matched command { handler, trigger, id }.
  * @param {string} query The full query string.
+ * @param {AbortSignal} [signal] Cancels the handler's own request.
  * @return {Promise<Object>} Provider result with items.
  */
-async function getMatchedCommandResults( paletteRegistry, match, query ) {
+async function getMatchedCommandResults( paletteRegistry, match, query, signal ) {
 	const { handler, trigger, id } = match;
 	if ( typeof handler.getResults !== 'function' ) {
 		const listItems = paletteRegistry.getCommandListItems();
@@ -25,7 +26,7 @@ async function getMatchedCommandResults( paletteRegistry, match, query ) {
 		subQuery.slice( 1 ).trim() : subQuery;
 
 	try {
-		const results = await handler.getResults( actualSubQuery );
+		const results = await handler.getResults( actualSubQuery, signal );
 		const processedResults = ( Array.isArray( results ) ? results : [] )
 			.map( ( item ) => {
 				if ( item.highlightQuery ) {
@@ -37,6 +38,12 @@ async function getMatchedCommandResults( paletteRegistry, match, query ) {
 			.slice( 0, MAX_COMMAND_RESULTS );
 		return { items: processedResults };
 	} catch ( err ) {
+		// A cancelled request is not a failure. Rethrowing lets the
+		// orchestration's lifecycle swallow it, so an aborted keystroke
+		// neither logs an error nor renders an empty list.
+		if ( err && err.name === 'AbortError' ) {
+			throw err;
+		}
 		mw.log.error(
 			'[commandPalette] Command handler "' + id + '" failed:', err
 		);
@@ -59,7 +66,7 @@ function createPaletteCommandProvider( paletteRegistry ) {
 			return paletteRegistry.hasMatchingTrigger( query );
 		},
 
-		async getResults( query ) {
+		async getResults( query, signal ) {
 			// Case 1: Root "/" — show all commands
 			if ( query === '/' ) {
 				return {
@@ -71,7 +78,9 @@ function createPaletteCommandProvider( paletteRegistry ) {
 			// Case 2: Specific command trigger matched
 			const match = paletteRegistry.findMatchingCommand( query );
 			if ( match ) {
-				return getMatchedCommandResults( paletteRegistry, match, query );
+				return getMatchedCommandResults(
+					paletteRegistry, match, query, signal
+				);
 			}
 
 			// Case 3: Prefix search for "/"

--- a/tests/vitest/commandPalette/composables/useProviderOrchestration.test.js
+++ b/tests/vitest/commandPalette/composables/useProviderOrchestration.test.js
@@ -66,23 +66,60 @@ describe( 'useProviderOrchestration', () => {
 		expect( orch.isPending.value ).toBe( false );
 	} );
 
-	describe( 'updateQuery — sync provider', () => {
+	describe( 'updateQuery — zero-debounce provider', () => {
 		it( 'should find the matching provider and display results', async () => {
 			const orch = useProviderOrchestration(
 				[ mockSyncProvider ], mockDecorator
 			);
 
 			orch.updateQuery( 'sync-query' );
-			await vi.waitFor( () => {
-				expect( orch.displayedItems.value ).toHaveLength( 1 );
-			} );
+			await vi.runAllTimersAsync();
 
-			expect( mockSyncProvider.getResults ).toHaveBeenCalledWith( 'sync-query', undefined );
+			expect( mockSyncProvider.getResults ).toHaveBeenCalledWith(
+				'sync-query', expect.any( AbortSignal )
+			);
 			expect( orch.flatItems.value ).toHaveLength( 2 );
 			expect( orch.flatItems.value[ 0 ].label ).toBe( 'Result 1' );
 			expect( orch.flatItems.value[ 1 ].type ).toBe( 'action' );
 		} );
 	} );
+
+		it( 'dispatches without waiting when debounceMs is 0', async () => {
+			const orch = useProviderOrchestration(
+				[ mockSyncProvider ], mockDecorator
+			);
+
+			orch.updateQuery( 'sync-query' );
+			// A zero-debounce provider skips the wait, not the cancellation:
+			// resolving that 0 to the default would delay it by 120ms.
+			await vi.advanceTimersByTimeAsync( 0 );
+
+			expect( mockSyncProvider.getResults ).toHaveBeenCalled();
+		} );
+
+		it( 'aborts an in-flight zero-debounce request when the query moves on', async () => {
+			const orch = useProviderOrchestration(
+				[ mockSyncProvider ], mockDecorator
+			);
+
+			orch.updateQuery( 'sync-query' );
+			await vi.advanceTimersByTimeAsync( 0 );
+			const firstSignal = mockSyncProvider.getResults.mock.calls[ 0 ][ 1 ];
+			orch.updateQuery( 'sync-query-2' );
+			await vi.runAllTimersAsync();
+
+			expect( firstSignal.aborted ).toBe( true );
+		} );
+
+		it( 'tracks pending state for a zero-debounce provider', () => {
+			const orch = useProviderOrchestration(
+				[ mockSyncProvider ], mockDecorator
+			);
+
+			orch.updateQuery( 'sync-query' );
+
+			expect( orch.isPending.value ).toBe( true );
+		} );
 
 	describe( 'updateQuery — async provider', () => {
 		it( 'should debounce and show results after delay', async () => {

--- a/tests/vitest/commandPalette/providers/PaletteCommandProvider.test.js
+++ b/tests/vitest/commandPalette/providers/PaletteCommandProvider.test.js
@@ -64,7 +64,40 @@ describe( 'createPaletteCommandProvider', () => {
 			await provider.getResults( '/ns:Talk' );
 
 			const nsHandler = registry.getHandler( 'namespace' );
-			expect( nsHandler.getResults ).toHaveBeenCalledWith( 'Talk' );
+			expect( nsHandler.getResults ).toHaveBeenCalledWith( 'Talk', undefined );
+		} );
+
+		it( 'should forward the abort signal to the handler', async () => {
+			const controller = new AbortController();
+
+			await provider.getResults( '/ns:Talk', controller.signal );
+
+			const nsHandler = registry.getHandler( 'namespace' );
+			expect( nsHandler.getResults ).toHaveBeenCalledWith(
+				'Talk', controller.signal
+			);
+		} );
+
+		it( 'should rethrow an abort rather than logging it as a failure', async () => {
+			const abort = Object.assign( new Error( 'aborted' ), { name: 'AbortError' } );
+			registry.getHandler( 'namespace' ).getResults =
+				vi.fn().mockRejectedValue( abort );
+
+			await expect( provider.getResults( '/ns:Talk' ) ).rejects.toThrow( 'aborted' );
+			// A cancelled keystroke is not a failure: logging it would fill the
+			// console on every keystroke, and returning [] would render an
+			// empty list over results that are still valid.
+			expect( mw.log.error ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should still log and swallow a genuine handler failure', async () => {
+			registry.getHandler( 'namespace' ).getResults =
+				vi.fn().mockRejectedValue( new Error( 'boom' ) );
+
+			const result = await provider.getResults( '/ns:Talk' );
+
+			expect( result.items ).toEqual( [] );
+			expect( mw.log.error ).toHaveBeenCalled();
 		} );
 
 		it( 'should tag results with command source', async () => {


### PR DESCRIPTION
Follow-up to #1790.

## Problem

Typing a trigger-prefixed query such as `#cat` or `@user` issued an API request per keystroke that could not be cancelled and showed no progress indication. Each one ran to completion even once its result could no longer be used.

Two separate causes:

- The command provider's `getResults` took no abort signal at all, so there was nothing to cancel with. Handlers already accept one; nothing was passing it.
- Providers declaring no debounce were routed down a path with no `AbortController` and no pending state. That path existed because the debounced path resolved its wait with `||`, which promotes an explicit `0` to the default — so a provider asking for no delay would have been given 120ms of it.

## Behaviour

Requests behind a trigger-prefixed query are cancelled as soon as the next keystroke arrives, and the palette header shows progress while one is in flight.

A cancelled request is no longer reported as a failure. Previously an abort would have been logged and flattened into an empty result, which would both fill the console on every keystroke and blank the list over results still on screen.

Nothing gets slower: a provider declaring no debounce still dispatches without waiting. Verified in a browser — the local `/` catalog renders in full at 30ms, which is the case that would have regressed to 120ms had the `||` been left in place.

## Contract

`debounceMs: 0` now means *skip the wait*, not *skip cancellation*. Every provider shares one dispatch path, so abort and pending state are properties of dispatching a provider rather than of opting into a debounce.

## Not taken

Two other follow-ups from #1790 are deliberately left alone:

- **Arrowing onto a row from an older query and pressing Enter still opens it.** Every fix costs more than the problem: suppressing activation leaves a highlighted row that Enter refuses to open, skipping those rows on arrow-down is stranger still, and dropping stale results reintroduces flicker. The outcome is also mild — the row is labelled with the page it opens.
- **`RelatedArticlesProvider` still cannot be aborted.** `mw.loader.using` has no abort, and `gateway.getForCurrentPage()` is the RelatedArticles extension's own API and takes no signal. A `signal` parameter would be ceremony on top of the staleness gate that already discards the result correctly. This needs an upstream change, not a local one.

## Testing

1425 unit tests pass. New coverage for signal forwarding, abort propagation versus genuine handler failure, zero-debounce dispatch timing, and cancellation of an in-flight zero-debounce request.

Both new behaviours were mutation-tested — removing the abort rethrow and removing the signal forwarding each fail the suite, so the tests are not passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command search handling when queries change rapidly by cancelling outdated requests.
  * Preserved immediate searches configured with zero delay.
  * Abort-related errors are handled cleanly, while other search failures continue to provide safe fallback results.
  * Search requests now consistently receive cancellation information, improving responsiveness and preventing stale results.

* **Tests**
  * Added coverage for immediate searches, request cancellation, pending states, abort handling, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->