### PR TITLE
fix(commandPalette): name the dismiss button and stop badges duplicating

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -124,6 +124,7 @@
 
 	"citizen-command-palette-action-view": "View",
 	"citizen-command-palette-back": "Back",
+	"citizen-command-palette-dismiss": "Remove from recent items",
 	"citizen-command-palette-label": "Command palette",
 	"citizen-command-palette-results": "Results",
 	"citizen-command-palette-heading-recent": "Recent",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -119,6 +119,7 @@
 	"citizen-user-info-joined-label": "Label for the registration date in the user info",
 	"citizen-command-palette-action-view": "Label for the per-item action button that opens the result's page for reading. Used on category results to provide access to the actual Category: page (since clicking the result drills into it instead of navigating).",
 	"citizen-command-palette-back": "Aria label for the back button in the command palette header when a mode is active.",
+	"citizen-command-palette-dismiss": "Aria label for the per-item action button that removes a result from the command palette's recent items list. The button shows only a trash icon, so this is its entire accessible name.",
 	"citizen-command-palette-label": "Accessible name of the command palette overlay, announced when a screen reader user enters it. Not visible on screen.",
 	"citizen-command-palette-results": "Accessible name of the list of results inside the command palette. Not visible on screen.\n{{Identical|Result}}",
 	"citizen-command-palette-heading-recent": "Label for the recently searched results in the command palette",

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
@@ -65,8 +65,8 @@
 		</div>
 		<div class="citizen-command-palette-list-item__metadata">
 			<div
-				v-for="item in metadata"
-				:key="item.label"
+				v-for="( item, index ) in metadata"
+				:key="index"
 				class="citizen-command-palette-list-item__metadata__item"
 				:class="item.status && `citizen-command-palette-list-item__metadata__item--status-${ item.status }`"
 			>

--- a/resources/skins.citizen.commandPalette/modes/action.js
+++ b/resources/skins.citizen.commandPalette/modes/action.js
@@ -98,7 +98,7 @@ function createActionCommand( documentRef, ApiConstructor ) {
 					thumbnailIcon: cdxIconPlay,
 					value: '/action:' + label,
 					highlightQuery: true,
-					metadata: [ { label: menuLabel } ]
+					metadata: menuLabel ? [ { label: menuLabel } ] : undefined
 				} );
 				seenUrls.add( url );
 			} );

--- a/skin.json
+++ b/skin.json
@@ -508,6 +508,7 @@
 				"action-edit",
 				"citizen-command-palette-action-view",
 				"citizen-command-palette-back",
+				"citizen-command-palette-dismiss",
 				"citizen-command-palette-label",
 				"citizen-command-palette-results",
 				"citizen-command-palette-command-action-description",

--- a/tests/vitest/commandPalette/components/CommandPaletteListItemContent.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteListItemContent.test.js
@@ -156,6 +156,20 @@ describe( 'CommandPaletteListItemContent', () => {
 
 			expect( items.length ).toBe( 0 );
 		} );
+
+		it( 'rerenders correctly when two badges share a label', async () => {
+			const wrapper = mountContent( {
+				metadata: [ { label: 'Reverted' }, { label: 'Reverted' }, { label: 'm' } ]
+			} );
+
+			await wrapper.setProps( {
+				metadata: [ { label: 'm' }, { label: 'Reverted' }, { label: 'Reverted' } ]
+			} );
+
+			const labels = wrapper.findAll( '.citizen-command-palette-list-item__metadata__item__label' );
+
+			expect( labels.map( ( el ) => el.text() ) ).toEqual( [ 'm', 'Reverted', 'Reverted' ] );
+		} );
 	} );
 
 	describe( 'previewable flag', () => {

--- a/tests/vitest/commandPalette/modes/action.test.js
+++ b/tests/vitest/commandPalette/modes/action.test.js
@@ -203,6 +203,36 @@ describe( 'action mode', () => {
 			);
 		} );
 
+		it( 'should carry the portlet heading as the item metadata', async () => {
+			mockGet.mockResolvedValue( { query: { specialpagealiases: [] } } );
+			const portlet = makePortlet( 'p-views', 'Views', [
+				{ liId: 'ca-edit', href: '/wiki/edit', label: 'Edit' }
+			] );
+			documentRef.getElementById = vi.fn( ( id ) => ( id === 'p-views' ? portlet : null ) );
+			mode = createActionCommand( documentRef, function () {
+				this.get = mockGet;
+			} );
+
+			const results = await mode.getResults( '' );
+
+			expect( results[ 0 ].metadata ).toEqual( [ { label: 'Views' } ] );
+		} );
+
+		it( 'should omit metadata when the portlet has no heading', async () => {
+			mockGet.mockResolvedValue( { query: { specialpagealiases: [] } } );
+			const portlet = makePortlet( 'p-views', undefined, [
+				{ liId: 'ca-edit', href: '/wiki/edit', label: 'Edit' }
+			] );
+			documentRef.getElementById = vi.fn( ( id ) => ( id === 'p-views' ? portlet : null ) );
+			mode = createActionCommand( documentRef, function () {
+				this.get = mockGet;
+			} );
+
+			const results = await mode.getResults( '' );
+
+			expect( results[ 0 ].metadata ).toBeUndefined();
+		} );
+
 		it( 'should deduplicate menu items by URL', async () => {
 			mockGet.mockResolvedValue( { query: { specialpagealiases: [] } } );
 


### PR DESCRIPTION
Two defects found while reviewing #1792 and deliberately left out of it, since neither is related to the redirect badge. Both predate that PR.

## The dismiss button had no name

Every recent item carries an icon-only button that drops it from the list. Its label is the whole of what a screen reader announces, and the message it asked for was never defined — so what it announced was `⧼citizen-command-palette-dismiss⧽`, in every language.

The key was introduced with the feature in `08425a670` (April 2025) but never reached `en.json`, `qqq.json` or the module's `messages` list, so it has never worked. It now reads "Remove from recent items".

## Badges duplicated when two shared a label

Result badges were keyed on their own text, so two badges reading the same thing were one element as far as Vue was concerned. One revision carrying two change tags with the same display name is enough.

On the next render the list was rebuilt against those colliding keys and came back wrong — reordered, with one badge duplicated. A three-badge row rendered four:

```
before update:  [Reverted] [Reverted] [m]
after update:   [m] [Reverted] [Reverted]      expected
                [Reverted] [m] [Reverted] [Reverted]   actual
```

Badges hold no state and are never reordered independently, so position is the honest identity for them.

Rolled in with it: a menu item in the action mode could produce a badge with no label at all, when the portlet it came from has no heading to read — an empty pill. Those items now carry no badge.

## Verification

The duplicate-badge case is covered by a test that re-renders with a changed list, which is where the bug lives; it fails on the old keying with exactly the four-badge output above. The empty-badge case has its own test. Both were confirmed to fail without their fix, rather than assumed to.

The dismiss label is the half no unit test can prove, so it was checked in a browser: the button's accessible name now reads "Remove from recent items", and no `⧼…⧽` remains anywhere in the palette.

1435 tests pass; i18n, style and JS lints clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfTraxDdxopDy6MeCVpamr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessible “Remove from recent items” label to the command palette.
* **Bug Fixes**
  * Improved command palette item updates when metadata labels are duplicated.
  * Corrected metadata display for menu items without headings.
* **Tests**
  * Added regression coverage for metadata reordering and conditional menu metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->