### PR TITLE
feat(pwa): allow configuring the app manifest shortcuts

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -239,7 +239,7 @@ $wgCitizenEnableManifest = true;
 
 ### `$wgCitizenManifestOptions`
 
-Customizes the web app manifest settings, such as the app name, colors, and icons.
+Customizes the web app manifest settings, such as the app name, colors, icons, and shortcuts.
 
 ::: details View default configuration
 
@@ -248,9 +248,43 @@ $wgCitizenManifestOptions = [
     'background_color' => '#0d0e12',
     'description' => '',
     'short_name' => '',
-    'theme_color' => "#0d0e12",
+    'theme_color' => '#0d0e12',
     'icons' => [],
 ];
 ```
 
 :::
+
+#### `icons`
+
+The icons the installed app is represented by, as defined by the [manifest `icons` member](https://www.w3.org/TR/appmanifest/#icons-member). Each entry may set `src`, `sizes`, `type`, and `purpose`; any other key is dropped.
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['icons'] = [
+    [ 'src' => '/images/icon-192.png', 'sizes' => '192x192', 'type' => 'image/png' ],
+    [ 'src' => '/images/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable' ],
+];
+```
+
+Leave the list empty to derive the icons from [`$wgLogos`](https://www.mediawiki.org/wiki/Manual:$wgLogos) instead — Citizen reads each logo's dimensions and MIME type off the file itself, and skips any it cannot measure.
+
+#### `shortcuts`
+
+The shortcuts a long press or right click on the installed app offers, as defined by the [manifest `shortcuts` member](https://www.w3.org/TR/appmanifest/#shortcuts-member). Each entry may set `name`, `short_name`, `description`, `url`, and `icons`; any other key is dropped. `name` and `url` are both required — the spec says so, and Citizen drops entries missing either rather than shipping them incomplete.
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['shortcuts'] = [
+    [ 'name' => 'Search', 'url' => '/wiki/Special:Search' ],
+    [
+        'name' => 'Guides',
+        'short_name' => 'Guides',
+        'description' => 'Community guides',
+        'url' => '/wiki/Project:Guides',
+        'icons' => [
+            [ 'src' => '/images/guides.png', 'sizes' => '96x96' ],
+        ],
+    ],
+];
+```
+
+Leave the option unset to get Citizen's defaults — Search, Random, and Recent changes, each resolved against your wiki's own article path. Set it to `[]` to ship no shortcuts at all.

--- a/includes/Api/ApiWebappManifest.php
+++ b/includes/Api/ApiWebappManifest.php
@@ -27,6 +27,19 @@ class ApiWebappManifest extends ApiBase {
 	/* 1 week */
 	private const CACHE_MAX_AGE = 604800;
 
+	/** Icon fields taken from config, per the manifest spec. */
+	private const ICON_KEYS = [ 'src', 'sizes', 'type', 'purpose' ];
+
+	/** Shortcut fields taken from config, per the manifest spec. */
+	private const SHORTCUT_KEYS = [ 'name', 'short_name', 'description', 'url' ];
+
+	/**
+	 * Shortcuts used when the config declares none at all. They live here
+	 * rather than in skin.json because their URLs depend on the wiki's article
+	 * path, which only resolves at runtime.
+	 */
+	private const DEFAULT_SHORTCUT_PAGES = [ 'Search', 'Randompage', 'Recentchanges' ];
+
 	private readonly Config $config;
 
 	private readonly array $options;
@@ -82,17 +95,27 @@ class ApiWebappManifest extends ApiBase {
 	 * Get icons for manifest
 	 */
 	private function getIcons(): array {
-		$iconsConfig = $this->options['icons'];
+		$iconsConfig = $this->options['icons'] ?? [];
 		if ( !is_array( $iconsConfig ) || count( $iconsConfig ) === 0 ) {
 			return $this->getIconsFromLogos();
 		}
+		return $this->filterIcons( $iconsConfig );
+	}
+
+	/**
+	 * Reduce an icon list from config to the fields the manifest spec defines,
+	 * dropping entries that carry none of them.
+	 */
+	private function filterIcons( mixed $iconsConfig ): array {
+		if ( !is_array( $iconsConfig ) ) {
+			return [];
+		}
 		$icons = [];
-		$allowedKeys = [ 'src', 'sizes', 'type', 'purpose' ];
 		foreach ( $iconsConfig as $iconConfig ) {
 			if ( !is_array( $iconConfig ) ) {
 				continue;
 			}
-			$icon = array_intersect_key( $iconConfig, array_flip( $allowedKeys ) );
+			$icon = array_intersect_key( $iconConfig, array_flip( self::ICON_KEYS ) );
 			if ( count( $icon ) === 0 ) {
 				continue;
 			}
@@ -175,17 +198,72 @@ class ApiWebappManifest extends ApiBase {
 
 	/**
 	 * Get shortcuts for manifest
+	 *
+	 * A config that declares no shortcuts at all gets Citizen's defaults, so
+	 * that a $wgCitizenManifestOptions written before the option existed keeps
+	 * the shortcuts it used to get. An empty list ships none.
 	 */
 	private function getShortcuts(): array {
-		$specialPages = [ 'Search', 'Randompage', 'Recentchanges' ];
+		$shortcutsConfig = $this->options['shortcuts'] ?? null;
+		if ( $shortcutsConfig === null ) {
+			return $this->getDefaultShortcuts();
+		}
+		if ( !is_array( $shortcutsConfig ) ) {
+			return [];
+		}
+		$shortcuts = [];
+		foreach ( $shortcutsConfig as $shortcutConfig ) {
+			if ( !is_array( $shortcutConfig ) ) {
+				continue;
+			}
+			$shortcut = $this->buildShortcut( $shortcutConfig );
+			if ( $shortcut !== null ) {
+				$shortcuts[] = $shortcut;
+			}
+		}
+		return $shortcuts;
+	}
 
+	/**
+	 * Citizen's own shortcuts, resolved against this wiki's article path
+	 */
+	private function getDefaultShortcuts(): array {
 		return array_map( static function ( $specialPage ) {
 			$title = SpecialPage::getSafeTitleFor( $specialPage );
 			return [
 				'name' => $title->getBaseText(),
 				'url' => $title->getLocalURL()
 			];
-		}, $specialPages );
+		}, self::DEFAULT_SHORTCUT_PAGES );
+	}
+
+	/**
+	 * Build one manifest shortcut from its config entry, or return null when
+	 * the entry cannot produce one.
+	 *
+	 * The manifest spec requires name and url, so an entry missing either is
+	 * dropped rather than shipped incomplete.
+	 */
+	private function buildShortcut( array $shortcutConfig ): ?array {
+		$shortcut = [];
+
+		foreach ( self::SHORTCUT_KEYS as $key ) {
+			$value = $shortcutConfig[$key] ?? null;
+			if ( is_string( $value ) && $value !== '' ) {
+				$shortcut[$key] = $value;
+			}
+		}
+
+		if ( !isset( $shortcut['name'] ) || !isset( $shortcut['url'] ) ) {
+			return null;
+		}
+
+		$icons = $this->filterIcons( $shortcutConfig['icons'] ?? [] );
+		if ( $icons !== [] ) {
+			$shortcut['icons'] = $icons;
+		}
+
+		return $shortcut;
 	}
 
 	/**

--- a/includes/Api/ApiWebappManifest.php
+++ b/includes/Api/ApiWebappManifest.php
@@ -177,7 +177,7 @@ class ApiWebappManifest extends ApiBase {
 	 * Get shortcuts for manifest
 	 */
 	private function getShortcuts(): array {
-		$specialPages = [ 'Search', 'Randompage', 'RecentChanges' ];
+		$specialPages = [ 'Search', 'Randompage', 'Recentchanges' ];
 
 		return array_map( static function ( $specialPage ) {
 			$title = SpecialPage::getSafeTitleFor( $specialPage );

--- a/includes/Api/ApiWebappManifest.php
+++ b/includes/Api/ApiWebappManifest.php
@@ -63,7 +63,6 @@ class ApiWebappManifest extends ApiBase {
 		$config = $this->config;
 		$resultObj = $this->getResult();
 		$main = $this->main;
-		$options = $this->options;
 
 		$resultObj->addValue( null, 'dir', $this->contentLanguage->getDir() );
 		$resultObj->addValue( null, 'lang', $config->get( MainConfigNames::LanguageCode ) );
@@ -75,20 +74,29 @@ class ApiWebappManifest extends ApiBase {
 		$resultObj->addValue( null, 'display', 'standalone' );
 		$resultObj->addValue( null, 'orientation', 'natural' );
 		$resultObj->addValue( null, 'start_url', Title::newMainPage()->getLocalURL() );
-		$resultObj->addValue( null, 'theme_color', $options['theme_color'] );
-		$resultObj->addValue( null, 'background_color', $options['background_color'] );
+		$this->addConfiguredValue( 'theme_color' );
+		$this->addConfiguredValue( 'background_color' );
 		$resultObj->addValue( null, 'shortcuts', $this->getShortcuts() );
-
-		if ( $options['short_name'] !== '' ) {
-			$resultObj->addValue( null, 'short_name', $options['short_name'] );
-		}
-
-		if ( $options['description'] !== '' ) {
-			$resultObj->addValue( null, 'description', $options['description'] );
-		}
+		$this->addConfiguredValue( 'short_name' );
+		$this->addConfiguredValue( 'description' );
 
 		$main->setCacheMaxAge( self::CACHE_MAX_AGE );
 		$main->setCacheMode( 'public' );
+	}
+
+	/**
+	 * Add a manifest member the config carries verbatim, when it has one
+	 *
+	 * All of these are optional in the manifest spec, so a config that says
+	 * nothing about one — including a $wgCitizenManifestOptions that replaces
+	 * the whole array and leaves the key out — omits the member rather than
+	 * shipping it empty.
+	 */
+	private function addConfiguredValue( string $key ): void {
+		$value = $this->options[$key] ?? null;
+		if ( is_string( $value ) && $value !== '' ) {
+			$this->getResult()->addValue( null, $key, $value );
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
@@ -16,6 +16,10 @@ use MediaWikiUnitTestCase;
 use ReflectionMethod;
 
 /**
+ * The default shortcuts resolve special page titles through the service
+ * container, so they are covered by the integration test of the same name
+ * rather than here.
+ *
  * @group Citizen
  * @covers \MediaWiki\Skins\Citizen\Api\ApiWebappManifest
  */
@@ -51,6 +55,17 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 		$api = $this->createApiWithConfig( $config );
 
 		$method = new ReflectionMethod( $api, 'getIcons' );
+		return $method->invoke( $api );
+	}
+
+	private function callGetShortcuts( array $shortcutsConfig ): array {
+		$config = new HashConfig( [
+			'CitizenManifestOptions' => [ 'shortcuts' => $shortcutsConfig ],
+		] );
+
+		$api = $this->createApiWithConfig( $config );
+
+		$method = new ReflectionMethod( $api, 'getShortcuts' );
 		return $method->invoke( $api );
 	}
 
@@ -114,5 +129,130 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 		$icons = $method->invoke( $api );
 
 		$this->assertSame( [], $icons );
+	}
+
+	/**
+	 * A $wgCitizenManifestOptions that replaces the whole array can leave the
+	 * key out, which must fall back rather than warn.
+	 */
+	public function testGetIconsMissingConfigFallsToLogos(): void {
+		$config = new HashConfig( [
+			'CitizenManifestOptions' => [ 'theme_color' => '' ],
+			'Logos' => false,
+		] );
+
+		$api = $this->createApiWithConfig( $config );
+
+		$method = new ReflectionMethod( $api, 'getIcons' );
+		$icons = $method->invoke( $api );
+
+		$this->assertSame( [], $icons );
+	}
+
+	public function testGetShortcutsPassesThroughConfiguredEntries(): void {
+		$shortcuts = $this->callGetShortcuts( [
+			[
+				'name' => 'Guides',
+				'short_name' => 'Guides',
+				'description' => 'Community guides',
+				'url' => '/wiki/Project:Guides',
+			],
+		] );
+
+		$this->assertSame(
+			[
+				[
+					'name' => 'Guides',
+					'short_name' => 'Guides',
+					'description' => 'Community guides',
+					'url' => '/wiki/Project:Guides',
+				],
+			],
+			$shortcuts
+		);
+	}
+
+	public function testGetShortcutsEmptyConfigShipsNone(): void {
+		$shortcuts = $this->callGetShortcuts( [] );
+
+		$this->assertSame( [], $shortcuts );
+	}
+
+	public function testGetShortcutsIgnoresNonArrayConfig(): void {
+		$config = new HashConfig( [
+			'CitizenManifestOptions' => [ 'shortcuts' => 'Search' ],
+		] );
+
+		$api = $this->createApiWithConfig( $config );
+
+		$method = new ReflectionMethod( $api, 'getShortcuts' );
+
+		$this->assertSame( [], $method->invoke( $api ) );
+	}
+
+	public function testGetShortcutsDropsEntriesMissingNameOrUrl(): void {
+		$shortcuts = $this->callGetShortcuts( [
+			[ 'name' => 'No URL' ],
+			[ 'url' => '/wiki/No_name' ],
+			[ 'name' => '', 'url' => '/wiki/Empty_name' ],
+			[ 'name' => 'Valid', 'url' => '/wiki/Valid' ],
+		] );
+
+		$this->assertSame( [ 'Valid' ], array_column( $shortcuts, 'name' ) );
+	}
+
+	public function testGetShortcutsSkipsNonArrayEntries(): void {
+		$shortcuts = $this->callGetShortcuts( [
+			'Search',
+			42,
+			[ 'name' => 'Valid', 'url' => '/wiki/Valid' ],
+		] );
+
+		$this->assertSame( [ 'Valid' ], array_column( $shortcuts, 'name' ) );
+	}
+
+	public function testGetShortcutsFiltersUnknownKeys(): void {
+		$shortcuts = $this->callGetShortcuts( [
+			[ 'name' => 'Valid', 'url' => '/wiki/Valid', 'unknown_key' => 'bad' ],
+		] );
+
+		$this->assertArrayNotHasKey( 'unknown_key', $shortcuts[0] );
+	}
+
+	public function testGetShortcutsDropsNonStringFieldValues(): void {
+		$shortcuts = $this->callGetShortcuts( [
+			[ 'name' => 'Valid', 'url' => '/wiki/Valid', 'description' => [ 'nested' ] ],
+			[ 'name' => 'Bad URL', 'url' => 42 ],
+		] );
+
+		$this->assertSame(
+			[ [ 'name' => 'Valid', 'url' => '/wiki/Valid' ] ],
+			$shortcuts
+		);
+	}
+
+	public function testGetShortcutsFiltersShortcutIcons(): void {
+		$shortcuts = $this->callGetShortcuts( [
+			[
+				'name' => 'With icons',
+				'url' => '/wiki/With_icons',
+				'icons' => [
+					[ 'src' => '/search.png', 'sizes' => '96x96', 'unknown_key' => 'bad' ],
+					'not-an-array',
+					[ 'invalid_key' => 'value' ],
+				],
+			],
+			[
+				'name' => 'No usable icons',
+				'url' => '/wiki/No_usable_icons',
+				'icons' => [ [ 'invalid_key' => 'value' ] ],
+			],
+		] );
+
+		$this->assertSame(
+			[ [ 'src' => '/search.png', 'sizes' => '96x96' ] ],
+			$shortcuts[0]['icons']
+		);
+		$this->assertArrayNotHasKey( 'icons', $shortcuts[1] );
 	}
 }

--- a/tests/phpunit/integration/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/integration/Api/ApiWebappManifestTest.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace MediaWiki\Skins\Citizen\Tests\Integration\Api;
 
 use MediaWiki\Api\ApiMain;
+use MediaWiki\Api\ApiResult;
 use MediaWiki\Config\Config;
 use MediaWiki\Config\HashConfig;
 use MediaWiki\Context\IContextSource;
@@ -88,5 +89,46 @@ class ApiWebappManifestTest extends MediaWikiIntegrationTestCase {
 
 	public function testGetShortcutsEmptyConfigShipsNone(): void {
 		$this->assertSame( [], $this->callGetShortcuts( [ 'shortcuts' => [] ] ) );
+	}
+
+	/**
+	 * A $wgCitizenManifestOptions that replaces the whole array can leave any
+	 * key out. Every one of them is optional in the manifest spec, so the
+	 * member is omitted rather than emitted empty — and reading it must not
+	 * raise a warning, which is what fails this test if the guard goes away.
+	 */
+	public function testManifestOmitsMembersTheConfigDoesNotCarry(): void {
+		$result = new ApiResult( 1024 * 1024 );
+
+		$contextMock = $this->createMock( IContextSource::class );
+		$contextMock->method( 'getConfig' )->willReturn( new HashConfig( [
+			'CitizenManifestOptions' => [],
+			MainConfigNames::LanguageCode => 'en',
+			MainConfigNames::Sitename => 'Test wiki',
+			MainConfigNames::Server => 'http://localhost',
+			MainConfigNames::Logos => false,
+		] ) );
+
+		$mainMock = $this->createMock( ApiMain::class );
+		$mainMock->method( 'getContext' )->willReturn( $contextMock );
+		$mainMock->method( 'getResult' )->willReturn( $result );
+
+		$services = $this->getServiceContainer();
+		$api = new ApiWebappManifest(
+			$mainMock,
+			'appmanifest',
+			$services->getContentLanguage(),
+			$services->getHttpRequestFactory(),
+			$services->getUrlUtils(),
+		);
+
+		$api->execute();
+		$manifest = $result->getResultData();
+
+		$this->assertArrayNotHasKey( 'theme_color', $manifest );
+		$this->assertArrayNotHasKey( 'background_color', $manifest );
+		$this->assertArrayNotHasKey( 'short_name', $manifest );
+		$this->assertArrayNotHasKey( 'description', $manifest );
+		$this->assertSame( 'Test wiki', $manifest['name'] );
 	}
 }

--- a/tests/phpunit/integration/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/integration/Api/ApiWebappManifestTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Integration\Api;
+
+use MediaWiki\Api\ApiMain;
+use MediaWiki\Config\Config;
+use MediaWiki\Config\HashConfig;
+use MediaWiki\Context\IContextSource;
+use MediaWiki\MainConfigNames;
+use MediaWiki\Skins\Citizen\Api\ApiWebappManifest;
+use MediaWikiIntegrationTestCase;
+use ReflectionMethod;
+
+/**
+ * The default shortcuts resolve special page titles against the wiki's article
+ * path, which needs the service container. Everything driven purely by config
+ * is covered by the unit test of the same name.
+ *
+ * @group Citizen
+ * @covers \MediaWiki\Skins\Citizen\Api\ApiWebappManifest
+ */
+class ApiWebappManifestTest extends MediaWikiIntegrationTestCase {
+
+	private function createApiWithConfig( Config $config ): ApiWebappManifest {
+		$services = $this->getServiceContainer();
+
+		$contextMock = $this->createMock( IContextSource::class );
+		$contextMock->method( 'getConfig' )->willReturn( $config );
+
+		$mainMock = $this->createMock( ApiMain::class );
+		$mainMock->method( 'getContext' )->willReturn( $contextMock );
+
+		return new ApiWebappManifest(
+			$mainMock,
+			'appmanifest',
+			$services->getContentLanguage(),
+			$services->getHttpRequestFactory(),
+			$services->getUrlUtils(),
+		);
+	}
+
+	private function callGetShortcuts( array $manifestOptions ): array {
+		$api = $this->createApiWithConfig(
+			new HashConfig( [ 'CitizenManifestOptions' => $manifestOptions ] )
+		);
+
+		$method = new ReflectionMethod( $api, 'getShortcuts' );
+		return $method->invoke( $api );
+	}
+
+	/**
+	 * A $wgCitizenManifestOptions written before the option existed has no
+	 * 'shortcuts' key, and must keep the shortcuts it used to get.
+	 */
+	public function testGetShortcutsFallsBackToDefaultsWhenUnset(): void {
+		$shortcuts = $this->callGetShortcuts( [
+			'theme_color' => '',
+			'background_color' => '',
+			'short_name' => '',
+			'description' => '',
+			'icons' => [],
+		] );
+
+		$this->assertCount( 3, $shortcuts );
+		$this->assertSame( [ 'Search', 'Random', 'RecentChanges' ], array_column( $shortcuts, 'name' ) );
+	}
+
+	/**
+	 * The defaults exist as special page names rather than URLs precisely so
+	 * that they follow $wgArticlePath.
+	 */
+	public function testDefaultShortcutUrlsFollowTheArticlePath(): void {
+		$this->overrideConfigValue( MainConfigNames::ArticlePath, '/index.php?title=$1' );
+
+		$shortcuts = $this->callGetShortcuts( [ 'icons' => [] ] );
+
+		$this->assertSame(
+			[
+				'/index.php?title=Special:Search',
+				'/index.php?title=Special:Random',
+				'/index.php?title=Special:RecentChanges',
+			],
+			array_column( $shortcuts, 'url' )
+		);
+	}
+
+	public function testGetShortcutsEmptyConfigShipsNone(): void {
+		$this->assertSame( [], $this->callGetShortcuts( [ 'shortcuts' => [] ] ) );
+	}
+}


### PR DESCRIPTION
Closes #1274

## Problem

`$wgCitizenManifestOptions` configures every part of the web app manifest except one. Setting a `shortcuts` key did nothing — the shortcuts a long press or right click on the installed app offers were fixed at search, random page and recent changes, with no way to change them or turn them off.

## Behaviour

`shortcuts` is now read like the rest of the options. Each entry carries the fields the manifest spec defines, so a wiki can offer whatever its readers actually reach for:

```php
$wgCitizenManifestOptions['shortcuts'] = [
    [ 'name' => 'Search', 'url' => '/wiki/Special:Search' ],
    [
        'name' => 'Guides',
        'short_name' => 'Guides',
        'description' => 'Community guides',
        'url' => '/wiki/Project:Guides',
        'icons' => [ [ 'src' => '/images/guides.png', 'sizes' => '96x96' ] ],
    ],
];
```

A wiki that never mentions `shortcuts` keeps the three it has always had, so nothing changes on upgrade. An empty list is how you ask for none — previously there was no way to turn them off.

## Contract

- Recognised fields are `name`, `short_name`, `description`, `url` and `icons`. Anything else is dropped, as is any non-string value.
- `name` and `url` are both required by the spec, so an entry without both is dropped rather than shipped incomplete.
- The built-in defaults stay special page *names* resolved at request time, so they keep following `$wgArticlePath`. That is why they live in PHP rather than in `skin.json` — declaring `"shortcuts": []` as the shipped default would read as "ship none" and strip every existing wiki's shortcuts.

## Two fixes that fell out of testing this

Both are independent of the feature and sit in their own commits.

**The recent changes shortcut warned on every request.** The default list spelled that special page `RecentChanges`, where core registers it as `Recentchanges`. Core recovers by rescanning its alias list case-insensitively, so the shortcut was always correct — but it also emitted a warning on every manifest request, on every wiki running Citizen. Nothing in the suite reached that code, which is why it stayed invisible.

**A partly-specified config could put nulls in the manifest.** `$wgCitizenManifestOptions` can be written as a whole array rather than key by key, and one written that way is free to leave out a field. Reading the theme colour, background colour, short name and description assumed all four were present: a config missing any of them warned once per field per request, and the short name and description reached the manifest as `null`, where a string belongs. All four are optional in the spec, so a field the config says nothing about is now left out entirely — which is what an empty one already did.

## Notes for review

- No compat slice needed: this is an API response, not parser-cached HTML.
- No new i18n keys, and `skin.json` is untouched.
- A security pass found nothing introduced — values are JSON-encoded by core's `ApiFormatJson`, the manifest is never embedded in HTML, and `getShortcuts()` output stays content-language-only so the existing public cache is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfTraxDdxopDy6MeCVpamr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable web app manifest shortcuts, including names, URLs, descriptions, and icons.
  * Added support for customizing manifest icons and optional theme, background, short name, and description values.
  * Missing icon settings now fall back to available logos.
  * Shortcut defaults remain available unless explicitly disabled with an empty configuration.

* **Documentation**
  * Expanded manifest configuration guidance with shortcut and icon options, supported fields, examples, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->