### PR TITLE
feat(pwa): allow configuring the app manifest screenshots

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -115,6 +115,10 @@ export default defineConfig({
 						link: "/features/preferences",
 					},
 					{
+						text: "Progressive web app",
+						link: "/features/progressive-web-app",
+					},
+					{
 						text: "Share",
 						link: "/features/share",
 					},

--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -239,7 +239,7 @@ $wgCitizenEnableManifest = true;
 
 ### `$wgCitizenManifestOptions`
 
-Customizes the web app manifest settings, such as the app name, colors, icons, and shortcuts.
+Customizes the web app manifest, such as the app description, colors, icons, shortcuts, and screenshots.
 
 ::: details View default configuration
 
@@ -255,36 +255,4 @@ $wgCitizenManifestOptions = [
 
 :::
 
-#### `icons`
-
-The icons the installed app is represented by, as defined by the [manifest `icons` member](https://www.w3.org/TR/appmanifest/#icons-member). Each entry may set `src`, `sizes`, `type`, and `purpose`; any other key is dropped.
-
-```php [LocalSettings.php]
-$wgCitizenManifestOptions['icons'] = [
-    [ 'src' => '/images/icon-192.png', 'sizes' => '192x192', 'type' => 'image/png' ],
-    [ 'src' => '/images/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable' ],
-];
-```
-
-Leave the list empty to derive the icons from [`$wgLogos`](https://www.mediawiki.org/wiki/Manual:$wgLogos) instead — Citizen reads each logo's dimensions and MIME type off the file itself, and skips any it cannot measure.
-
-#### `shortcuts`
-
-The shortcuts a long press or right click on the installed app offers, as defined by the [manifest `shortcuts` member](https://www.w3.org/TR/appmanifest/#shortcuts-member). Each entry may set `name`, `short_name`, `description`, `url`, and `icons`; any other key is dropped. `name` and `url` are both required — the spec says so, and Citizen drops entries missing either rather than shipping them incomplete.
-
-```php [LocalSettings.php]
-$wgCitizenManifestOptions['shortcuts'] = [
-    [ 'name' => 'Search', 'url' => '/wiki/Special:Search' ],
-    [
-        'name' => 'Guides',
-        'short_name' => 'Guides',
-        'description' => 'Community guides',
-        'url' => '/wiki/Project:Guides',
-        'icons' => [
-            [ 'src' => '/images/guides.png', 'sizes' => '96x96' ],
-        ],
-    ],
-];
-```
-
-Leave the option unset to get Citizen's defaults — Search, Random, and Recent changes, each resolved against your wiki's own article path. Set it to `[]` to ship no shortcuts at all.
+See the [Progressive web app page](/features/progressive-web-app) for what each option accepts, and for what browsers need before they will offer to install your wiki.

--- a/docs/src/features/progressive-web-app.md
+++ b/docs/src/features/progressive-web-app.md
@@ -1,0 +1,167 @@
+---
+title: Progressive web app
+description: Citizen generates a web app manifest so readers can install your wiki as a standalone app.
+---
+
+# Progressive web app
+
+Citizen generates a [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) for your wiki, so readers can install it and open it like any other app on their device — its own window, its own icon, no browser chrome around it.
+
+If progressive web apps are new to you, [web.dev](https://web.dev/explore/progressive-web-apps) and [MDN](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) both have a good overview. This page only covers what Citizen does.
+
+## How it works
+
+When the manifest is enabled, Citizen adds `<link rel="manifest">` to every page, pointing at `api.php?action=appmanifest`. That endpoint builds the manifest from your wiki's settings:
+
+| Manifest member | Where it comes from |
+| :--- | :--- |
+| `name` | `$wgSitename` |
+| `short_name`, `description` | [Manifest options](#manifest-options) — left out when unset |
+| `icons` | [Manifest options](#icons), or [`$wgLogos`](https://www.mediawiki.org/wiki/Manual:$wgLogos) when you set none |
+| `screenshots` | [Manifest options](#screenshots) — left out when unset |
+| `shortcuts` | [Manifest options](#shortcuts), or Citizen's defaults |
+| `theme_color`, `background_color` | [Manifest options](#manifest-options) |
+| `start_url` | Your wiki's main page |
+| `scope` | Your whole server, so `index.php` URLs stay inside the app |
+| `lang`, `dir` | Your wiki's content language |
+| `display`, `orientation` | Always `standalone` and `natural` |
+
+Citizen also sets a `<meta name="theme-color">` tag from [`$wgCitizenThemeColor`](/config/#wgcitizenthemecolor). That one tints browser UI during an ordinary visit, and is separate from the manifest's `theme_color`, which applies to the installed app.
+
+::: warning Private wikis get no manifest
+The manifest link is only added when anonymous users can read your wiki. If `$wgGroupPermissions['*']['read']` is off, nothing is linked and nothing is installable, no matter how the options below are set.
+:::
+
+::: tip Changes take a while to appear
+The manifest is served with a one-week cache, so a browser that has already fetched it keeps its copy for up to a week. When testing a change, use a fresh private window, or reload the manifest from your browser's developer tools (in Chrome: **Application ▸ Manifest**).
+:::
+
+## Making your wiki installable
+
+Browsers decide for themselves when to offer an install — [web.dev's install criteria](https://web.dev/articles/install-criteria) covers what they look for.
+
+The part worth setting up here is icons. Left alone, the manifest carries whatever your `$wgLogos` happen to be; giving it PNGs of its own is more predictable:
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['icons'] = [
+    [ 'src' => '/images/icon-192.png', 'sizes' => '192x192', 'type' => 'image/png' ],
+    [ 'src' => '/images/icon-512.png', 'sizes' => '512x512', 'type' => 'image/png' ],
+];
+```
+
+A 192×192 and a 512×512 PNG is the usual pair to start from. Adding `'purpose' => 'maskable'` on a version with padding around the artwork gives platforms that crop icons to their own shape something safe to crop.
+
+## The richer install dialog
+
+Instead of a bare "Install?" prompt, browsers can show a fuller dialog with your wiki's name, its description, and a carousel of screenshots. Citizen supports this — it needs [`screenshots`](#screenshots), and a [`description`](#description) is worth setting alongside them.
+
+## Configuration
+
+### `$wgCitizenEnableManifest`
+
+Whether to generate the manifest at all. On by default.
+
+```php [LocalSettings.php]
+$wgCitizenEnableManifest = true;
+```
+
+### Manifest options
+
+Everything else lives in `$wgCitizenManifestOptions`.
+
+::: details View default configuration
+
+```php
+$wgCitizenManifestOptions = [
+    'background_color' => '#0d0e12',
+    'description' => '',
+    'short_name' => '',
+    'theme_color' => '#0d0e12',
+    'icons' => [],
+];
+```
+
+:::
+
+#### `description`
+
+The sentence browsers show under your wiki's name in the install dialog. Keep it to a couple of lines — a long one gets truncated.
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['description'] = 'The community encyclopedia of everything.';
+```
+
+#### `short_name`
+
+The name used where the full one does not fit, such as under a home screen icon. Falls back to `$wgSitename`.
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['short_name'] = 'My wiki';
+```
+
+Both are empty by default, and an empty value is left out of the manifest entirely rather than shipped blank.
+
+#### `icons`
+
+The icons the installed app is represented by, as defined by the [manifest `icons` member](https://www.w3.org/TR/appmanifest/#icons-member). Each entry may set `src`, `sizes`, `type`, and `purpose`; any other key is dropped.
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['icons'] = [
+    [ 'src' => '/images/icon-192.png', 'sizes' => '192x192', 'type' => 'image/png' ],
+    [ 'src' => '/images/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable' ],
+];
+```
+
+Leave the list empty to derive the icons from [`$wgLogos`](https://www.mediawiki.org/wiki/Manual:$wgLogos) instead — Citizen reads each logo's dimensions and MIME type off the file itself, and skips any it cannot measure. Setting the list yourself is the more predictable route, since your logos were chosen for the wiki's header rather than for an app icon.
+
+#### `shortcuts`
+
+The shortcuts a long press or right click on the installed app offers, as defined by the [manifest `shortcuts` member](https://www.w3.org/TR/appmanifest/#shortcuts-member). Each entry may set `name`, `short_name`, `description`, `url`, and `icons`; any other key is dropped. `name` and `url` are both required — the spec says so, and Citizen drops entries missing either rather than shipping them incomplete.
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['shortcuts'] = [
+    [ 'name' => 'Search', 'url' => '/wiki/Special:Search' ],
+    [
+        'name' => 'Guides',
+        'short_name' => 'Guides',
+        'description' => 'Community guides',
+        'url' => '/wiki/Project:Guides',
+        'icons' => [
+            [ 'src' => '/images/guides.png', 'sizes' => '96x96' ],
+        ],
+    ],
+];
+```
+
+Leave the option unset to get Citizen's defaults — Search, Random, and Recent changes, each resolved against your wiki's own article path. Set it to `[]` to ship no shortcuts at all.
+
+#### `screenshots`
+
+Pictures of your wiki that browsers show in the install dialog, as defined by the [manifest `screenshots` member](https://www.w3.org/TR/appmanifest/#screenshots-member). Each entry may set `src`, `sizes`, `type`, `form_factor`, `label`, and `platform`; any other key is dropped. `src` is required — entries without one are dropped.
+
+```php [LocalSettings.php]
+$wgCitizenManifestOptions['screenshots'] = [
+    [
+        'src' => '/images/screenshot-desktop.png',
+        'sizes' => '1920x1080',
+        'type' => 'image/png',
+        'form_factor' => 'wide',
+        'label' => 'An article on desktop',
+    ],
+    [
+        'src' => '/images/screenshot-mobile.png',
+        'sizes' => '750x1334',
+        'type' => 'image/png',
+        'form_factor' => 'narrow',
+        'label' => 'An article on mobile',
+    ],
+];
+```
+
+Citizen ships no screenshots by default, because they have to be pictures of your wiki. Leave the option unset and the manifest leaves the member out.
+
+Set `form_factor` on every entry, and supply at least one of each value — an entry that leaves it out can end up shown in one place and never the other.
+
+## Service worker
+
+When your wiki is served from the root of its domain rather than a subdirectory, Citizen registers a service worker on every page load — this has nothing to do with whether a reader has installed the app. It is a placeholder: it does no caching and adds no offline support, so it is safe to ignore if you spot it in your browser's developer tools. Wikis served from a subdirectory skip it entirely.

--- a/docs/src/guide/introduction.md
+++ b/docs/src/guide/introduction.md
@@ -30,7 +30,7 @@ Unlike the other standard MediaWiki skins, Citizen has a lot more to offer:
     <LinkCard title="Collapsible sections" href="../config/#wgcitizenenablecollapsiblesections">
         Article sections on the wiki can be collapsed and expanded.
     </LinkCard>
-    <LinkCard title="Progressive web app">
+    <LinkCard title="Progressive web app" href="../features/progressive-web-app">
         Users can add a wiki using Citizen to their home screen, giving a more app-like experience.
     </LinkCard>
 </LinkGrid>

--- a/includes/Api/ApiWebappManifest.php
+++ b/includes/Api/ApiWebappManifest.php
@@ -33,6 +33,9 @@ class ApiWebappManifest extends ApiBase {
 	/** Shortcut fields taken from config, per the manifest spec. */
 	private const SHORTCUT_KEYS = [ 'name', 'short_name', 'description', 'url' ];
 
+	/** Screenshot fields taken from config, per the manifest spec. */
+	private const SCREENSHOT_KEYS = [ 'src', 'sizes', 'type', 'form_factor', 'label', 'platform' ];
+
 	/**
 	 * Shortcuts used when the config declares none at all. They live here
 	 * rather than in skin.json because their URLs depend on the wiki's article
@@ -77,6 +80,10 @@ class ApiWebappManifest extends ApiBase {
 		$this->addConfiguredValue( 'theme_color' );
 		$this->addConfiguredValue( 'background_color' );
 		$resultObj->addValue( null, 'shortcuts', $this->getShortcuts() );
+		$screenshots = $this->getScreenshots();
+		if ( $screenshots !== [] ) {
+			$resultObj->addValue( null, 'screenshots', $screenshots );
+		}
 		$this->addConfiguredValue( 'short_name' );
 		$this->addConfiguredValue( 'description' );
 
@@ -253,14 +260,7 @@ class ApiWebappManifest extends ApiBase {
 	 * dropped rather than shipped incomplete.
 	 */
 	private function buildShortcut( array $shortcutConfig ): ?array {
-		$shortcut = [];
-
-		foreach ( self::SHORTCUT_KEYS as $key ) {
-			$value = $shortcutConfig[$key] ?? null;
-			if ( is_string( $value ) && $value !== '' ) {
-				$shortcut[$key] = $value;
-			}
-		}
+		$shortcut = $this->filterStringFields( $shortcutConfig, self::SHORTCUT_KEYS );
 
 		if ( !isset( $shortcut['name'] ) || !isset( $shortcut['url'] ) ) {
 			return null;
@@ -272,6 +272,47 @@ class ApiWebappManifest extends ApiBase {
 		}
 
 		return $shortcut;
+	}
+
+	/**
+	 * Get screenshots for manifest
+	 *
+	 * Screenshots are images of the wiki itself, so Citizen has no default to
+	 * offer — a wiki that declares none ships the member empty, and execute()
+	 * leaves it out entirely.
+	 */
+	private function getScreenshots(): array {
+		$screenshotsConfig = $this->options['screenshots'] ?? null;
+		if ( !is_array( $screenshotsConfig ) ) {
+			return [];
+		}
+		$screenshots = [];
+		foreach ( $screenshotsConfig as $screenshotConfig ) {
+			if ( !is_array( $screenshotConfig ) ) {
+				continue;
+			}
+			$screenshot = $this->filterStringFields( $screenshotConfig, self::SCREENSHOT_KEYS );
+			// src is the one field the spec requires of an image resource
+			if ( isset( $screenshot['src'] ) ) {
+				$screenshots[] = $screenshot;
+			}
+		}
+		return $screenshots;
+	}
+
+	/**
+	 * Reduce a config entry to the given fields, keeping only the ones carrying
+	 * a non-empty string.
+	 */
+	private function filterStringFields( array $config, array $keys ): array {
+		$fields = [];
+		foreach ( $keys as $key ) {
+			$value = $config[$key] ?? null;
+			if ( is_string( $value ) && $value !== '' ) {
+				$fields[$key] = $value;
+			}
+		}
+		return $fields;
 	}
 
 	/**

--- a/includes/Api/ApiWebappManifest.php
+++ b/includes/Api/ApiWebappManifest.php
@@ -10,6 +10,7 @@ use MediaWiki\Api\ApiMain;
 use MediaWiki\Config\Config;
 use MediaWiki\Http\HttpRequestFactory;
 use MediaWiki\Language\Language;
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MainConfigNames;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\Title\Title;
@@ -26,6 +27,17 @@ class ApiWebappManifest extends ApiBase {
 
 	/* 1 week */
 	private const CACHE_MAX_AGE = 604800;
+
+	/**
+	 * Bounds on fetching the wiki's own logo files, in seconds.
+	 *
+	 * Without them each request inherits $wgHTTPTimeout, so a server that
+	 * cannot reach its own URL holds the worker for minutes across the logo
+	 * list. These are requests to the same server for static files, so seconds
+	 * are already generous.
+	 */
+	private const LOGO_FETCH_TIMEOUT = 3;
+	private const LOGO_FETCH_CONNECT_TIMEOUT = 1;
 
 	/** Icon fields taken from config, per the manifest spec. */
 	private const ICON_KEYS = [ 'src', 'sizes', 'type', 'purpose' ];
@@ -145,6 +157,7 @@ class ApiWebappManifest extends ApiBase {
 	private function getIconsFromLogos(): array {
 		$urlUtils = $this->urlUtils;
 		$httpRequestFactory = $this->httpRequestFactory;
+		$logger = LoggerFactory::getInstance( 'Citizen' );
 
 		$icons = [];
 		$logos = $this->config->get( MainConfigNames::Logos );
@@ -169,14 +182,32 @@ class ApiWebappManifest extends ApiBase {
 
 			$logoPath = (string)$logos[$logoKey];
 
+			$logoUrl = '';
 			try {
 				$logoUrl = $urlUtils->expand( $logoPath, PROTO_CURRENT ) ?? '';
-				$request = $httpRequestFactory->create( $logoUrl, [], __METHOD__ );
-				$request->execute();
-				$logoContent = $request->getContent();
-			} catch ( Exception ) {
-				// Log the exception or handle it accordingly
+				$request = $httpRequestFactory->create( $logoUrl, [
+					'timeout' => self::LOGO_FETCH_TIMEOUT,
+					'connectTimeout' => self::LOGO_FETCH_CONNECT_TIMEOUT,
+				], __METHOD__ );
+				$status = $request->execute();
+				if ( $status->isOK() ) {
+					$logoContent = $request->getContent();
+				} else {
+					$logoContent = '';
+					// The manifest is cached for a week, so a logo the server
+					// could not reach is missing from it for a week with
+					// nothing else to show for it.
+					$logger->warning(
+						'Could not fetch logo {logo} for the webapp manifest, HTTP {code}',
+						[ 'logo' => $logoUrl, 'code' => $request->getStatus() ]
+					);
+				}
+			} catch ( Exception $e ) {
 				$logoContent = '';
+				$logger->warning(
+					'Could not fetch logo {logo} for the webapp manifest: {exception}',
+					[ 'logo' => $logoUrl, 'exception' => $e->getMessage() ]
+				);
 			}
 
 			if ( $logoContent !== '' ) {

--- a/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
@@ -13,7 +13,9 @@ use MediaWiki\Language\Language;
 use MediaWiki\Skins\Citizen\Api\ApiWebappManifest;
 use MediaWiki\Utils\UrlUtils;
 use MediaWikiUnitTestCase;
+use MWHttpRequest;
 use ReflectionMethod;
+use StatusValue;
 
 /**
  * The default shortcuts resolve special page titles through the service
@@ -250,6 +252,92 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 		$screenshots = $this->callFilter( 'getScreenshots', $manifestOptions );
 
 		$this->assertSame( $expected, $screenshots );
+	}
+
+	/**
+	 * Build an API whose only icon source is $wgLogos, fetched through the
+	 * given factory.
+	 */
+	private function createApiWithLogos( array $logos, HttpRequestFactory $httpRequestFactory ): ApiWebappManifest {
+		$contextMock = $this->createMock( IContextSource::class );
+		$contextMock->method( 'getConfig' )->willReturn( new HashConfig( [
+			'CitizenManifestOptions' => [ 'icons' => [] ],
+			'Logos' => $logos,
+		] ) );
+
+		$mainMock = $this->createMock( ApiMain::class );
+		$mainMock->method( 'getContext' )->willReturn( $contextMock );
+
+		$urlUtils = $this->createMock( UrlUtils::class );
+		$urlUtils->method( 'expand' )->willReturnArgument( 0 );
+
+		return new ApiWebappManifest(
+			$mainMock,
+			'appmanifest',
+			$this->createMock( Language::class ),
+			$httpRequestFactory,
+			$urlUtils,
+		);
+	}
+
+	private function createLogoRequest( bool $succeeded, string $content = '' ): MWHttpRequest {
+		$request = $this->createMock( MWHttpRequest::class );
+		$request->method( 'execute' )->willReturn(
+			$succeeded ? StatusValue::newGood() : StatusValue::newFatal( 'http-timed-out' )
+		);
+		$request->method( 'getStatus' )->willReturn( $succeeded ? 200 : 0 );
+		$request->method( 'getContent' )->willReturn( $content );
+
+		return $request;
+	}
+
+	/**
+	 * Without a bound, each logo request inherits $wgHTTPTimeout, so a server
+	 * that cannot reach its own URL holds the worker for minutes.
+	 */
+	public function testGetIconsFromLogosBoundsEachRequest(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->with(
+				'/logo.png',
+				$this->callback( static fn ( array $options ): bool => ( $options['timeout'] ?? 0 ) > 0
+					&& ( $options['connectTimeout'] ?? 0 ) > 0 ),
+				$this->anything()
+			)
+			->willReturn( $this->createLogoRequest( true ) );
+		$api = $this->createApiWithLogos( [ '1x' => '/logo.png' ], $httpRequestFactory );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+		$method->invoke( $api );
+	}
+
+	public function testGetIconsFromLogosDropsALogoItCannotFetch(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->method( 'create' )->willReturn( $this->createLogoRequest( false ) );
+		$api = $this->createApiWithLogos( [ '1x' => '/logo.png' ], $httpRequestFactory );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$this->assertSame( [], $method->invoke( $api ) );
+	}
+
+	/**
+	 * An SVG needs no measuring, so it survives a fetch the server could not
+	 * make — the browser fetches it on its own account, and a server that
+	 * cannot reach its own URL is not evidence the browser cannot either.
+	 */
+	public function testGetIconsFromLogosKeepsAnSvgItCannotFetch(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->method( 'create' )->willReturn( $this->createLogoRequest( false ) );
+		$api = $this->createApiWithLogos( [ 'svg' => '/logo.svg' ], $httpRequestFactory );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$this->assertSame(
+			[ [ 'src' => '/logo.svg', 'sizes' => 'any', 'type' => 'image/svg+xml' ] ],
+			$method->invoke( $api )
+		);
 	}
 
 	/**

--- a/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
@@ -69,6 +69,17 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 		return $method->invoke( $api );
 	}
 
+	private function callGetScreenshots( array $screenshotsConfig ): array {
+		$config = new HashConfig( [
+			'CitizenManifestOptions' => [ 'screenshots' => $screenshotsConfig ],
+		] );
+
+		$api = $this->createApiWithConfig( $config );
+
+		$method = new ReflectionMethod( $api, 'getScreenshots' );
+		return $method->invoke( $api );
+	}
+
 	public function testGetIconsWithValidConfig(): void {
 		$icons = $this->callGetIcons( [
 			[ 'src' => '/icon.png', 'sizes' => '192x192', 'type' => 'image/png' ],
@@ -254,5 +265,105 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 			$shortcuts[0]['icons']
 		);
 		$this->assertArrayNotHasKey( 'icons', $shortcuts[1] );
+	}
+
+	public function testGetScreenshotsPassesThroughConfiguredEntries(): void {
+		$screenshots = $this->callGetScreenshots( [
+			[
+				'src' => '/screenshot-desktop.png',
+				'sizes' => '1920x1080',
+				'type' => 'image/png',
+				'form_factor' => 'wide',
+				'label' => 'Article on desktop',
+				'platform' => 'windows',
+			],
+		] );
+
+		$this->assertSame(
+			[
+				[
+					'src' => '/screenshot-desktop.png',
+					'sizes' => '1920x1080',
+					'type' => 'image/png',
+					'form_factor' => 'wide',
+					'label' => 'Article on desktop',
+					'platform' => 'windows',
+				],
+			],
+			$screenshots
+		);
+	}
+
+	public function testGetScreenshotsEmptyConfigShipsNone(): void {
+		$this->assertSame( [], $this->callGetScreenshots( [] ) );
+	}
+
+	/**
+	 * Unlike shortcuts, an absent key cannot fall back to anything — the images
+	 * would have to be of the wiki itself.
+	 */
+	public function testGetScreenshotsMissingConfigShipsNone(): void {
+		$config = new HashConfig( [
+			'CitizenManifestOptions' => [ 'icons' => [] ],
+		] );
+
+		$api = $this->createApiWithConfig( $config );
+
+		$method = new ReflectionMethod( $api, 'getScreenshots' );
+
+		$this->assertSame( [], $method->invoke( $api ) );
+	}
+
+	public function testGetScreenshotsIgnoresNonArrayConfig(): void {
+		$config = new HashConfig( [
+			'CitizenManifestOptions' => [ 'screenshots' => '/screenshot.png' ],
+		] );
+
+		$api = $this->createApiWithConfig( $config );
+
+		$method = new ReflectionMethod( $api, 'getScreenshots' );
+
+		$this->assertSame( [], $method->invoke( $api ) );
+	}
+
+	public function testGetScreenshotsSkipsNonArrayEntries(): void {
+		$screenshots = $this->callGetScreenshots( [
+			'/screenshot.png',
+			42,
+			[ 'src' => '/valid.png' ],
+		] );
+
+		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
+	}
+
+	public function testGetScreenshotsDropsEntriesMissingSrc(): void {
+		$screenshots = $this->callGetScreenshots( [
+			[ 'sizes' => '1920x1080', 'type' => 'image/png' ],
+			[ 'src' => '', 'sizes' => '1920x1080' ],
+			[ 'src' => '/valid.png' ],
+		] );
+
+		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
+	}
+
+	/**
+	 * purpose belongs to icons, not screenshots, so it must not survive — which
+	 * is what fails here if the icon filter gets reused for screenshots.
+	 */
+	public function testGetScreenshotsFiltersUnknownKeys(): void {
+		$screenshots = $this->callGetScreenshots( [
+			[ 'src' => '/valid.png', 'purpose' => 'maskable', 'unknown_key' => 'bad' ],
+		] );
+
+		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
+	}
+
+	public function testGetScreenshotsDropsNonStringFieldValues(): void {
+		$screenshots = $this->callGetScreenshots( [
+			[ 'src' => '/valid.png', 'sizes' => [ 'nested' ] ],
+			[ 'src' => 42, 'sizes' => '1920x1080' ],
+		] );
+
+		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
 	}
 }

--- a/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
@@ -41,329 +41,240 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 		);
 	}
 
-	private function callGetIcons( array $iconsConfig ): array {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [
-				'icons' => $iconsConfig,
-				'theme_color' => '',
-				'background_color' => '',
-				'short_name' => '',
-				'description' => '',
-			],
-		] );
+	/**
+	 * Invoke one of the private members that turn $wgCitizenManifestOptions
+	 * into a manifest list.
+	 */
+	private function callFilter( string $method, array $manifestOptions ): array {
+		$api = $this->createApiWithConfig(
+			new HashConfig( [ 'CitizenManifestOptions' => $manifestOptions ] )
+		);
 
-		$api = $this->createApiWithConfig( $config );
-
-		$method = new ReflectionMethod( $api, 'getIcons' );
-		return $method->invoke( $api );
-	}
-
-	private function callGetShortcuts( array $shortcutsConfig ): array {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [ 'shortcuts' => $shortcutsConfig ],
-		] );
-
-		$api = $this->createApiWithConfig( $config );
-
-		$method = new ReflectionMethod( $api, 'getShortcuts' );
-		return $method->invoke( $api );
-	}
-
-	private function callGetScreenshots( array $screenshotsConfig ): array {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [ 'screenshots' => $screenshotsConfig ],
-		] );
-
-		$api = $this->createApiWithConfig( $config );
-
-		$method = new ReflectionMethod( $api, 'getScreenshots' );
-		return $method->invoke( $api );
-	}
-
-	public function testGetIconsWithValidConfig(): void {
-		$icons = $this->callGetIcons( [
-			[ 'src' => '/icon.png', 'sizes' => '192x192', 'type' => 'image/png' ],
-			[ 'src' => '/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable' ],
-		] );
-
-		$this->assertCount( 2, $icons );
-		$this->assertSame( '/icon.png', $icons[0]['src'] );
-		$this->assertSame( 'any maskable', $icons[1]['purpose'] );
-	}
-
-	public function testGetIconsFiltersUnknownKeys(): void {
-		$icons = $this->callGetIcons( [
-			[ 'src' => '/icon.png', 'sizes' => '192x192', 'unknown_key' => 'bad' ],
-		] );
-
-		$this->assertCount( 1, $icons );
-		$this->assertArrayNotHasKey( 'unknown_key', $icons[0] );
-		$this->assertSame( '/icon.png', $icons[0]['src'] );
-	}
-
-	public function testGetIconsSkipsNonArrayEntries(): void {
-		$icons = $this->callGetIcons( [
-			'not-an-array',
-			42,
-			[ 'src' => '/valid.png' ],
-		] );
-
-		$this->assertCount( 1, $icons );
-		$this->assertSame( '/valid.png', $icons[0]['src'] );
-	}
-
-	public function testGetIconsSkipsEntriesWithNoValidKeys(): void {
-		$icons = $this->callGetIcons( [
-			[ 'invalid_key' => 'value' ],
-			[ 'also_bad' => 'value' ],
-			[ 'src' => '/valid.png' ],
-		] );
-
-		$this->assertCount( 1, $icons );
-	}
-
-	public function testGetIconsEmptyConfigFallsToLogos(): void {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [
-				'icons' => [],
-				'theme_color' => '',
-				'background_color' => '',
-				'short_name' => '',
-				'description' => '',
-			],
-			'Logos' => false,
-		] );
-
-		$api = $this->createApiWithConfig( $config );
-
-		$method = new ReflectionMethod( $api, 'getIcons' );
-		$icons = $method->invoke( $api );
-
-		$this->assertSame( [], $icons );
+		$reflectionMethod = new ReflectionMethod( $api, $method );
+		return $reflectionMethod->invoke( $api );
 	}
 
 	/**
-	 * A $wgCitizenManifestOptions that replaces the whole array can leave the
-	 * key out, which must fall back rather than warn.
+	 * @return iterable<string, array{array, array}>
 	 */
-	public function testGetIconsMissingConfigFallsToLogos(): void {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [ 'theme_color' => '' ],
-			'Logos' => false,
-		] );
+	public static function provideIcons(): iterable {
+		yield 'passes through the fields the spec defines' => [
+			[ 'icons' => [
+				[ 'src' => '/icon.png', 'sizes' => '192x192', 'type' => 'image/png' ],
+				[ 'src' => '/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable' ],
+			] ],
+			[
+				[ 'src' => '/icon.png', 'sizes' => '192x192', 'type' => 'image/png' ],
+				[ 'src' => '/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable' ],
+			],
+		];
 
-		$api = $this->createApiWithConfig( $config );
+		yield 'drops unknown keys' => [
+			[ 'icons' => [ [ 'src' => '/icon.png', 'sizes' => '192x192', 'unknown_key' => 'bad' ] ] ],
+			[ [ 'src' => '/icon.png', 'sizes' => '192x192' ] ],
+		];
 
-		$method = new ReflectionMethod( $api, 'getIcons' );
-		$icons = $method->invoke( $api );
+		yield 'skips non-array entries' => [
+			[ 'icons' => [ 'not-an-array', 42, [ 'src' => '/valid.png' ] ] ],
+			[ [ 'src' => '/valid.png' ] ],
+		];
 
-		$this->assertSame( [], $icons );
+		yield 'skips entries with no valid keys' => [
+			[ 'icons' => [ [ 'invalid_key' => 'value' ], [ 'also_bad' => 'value' ], [ 'src' => '/valid.png' ] ] ],
+			[ [ 'src' => '/valid.png' ] ],
+		];
 	}
 
-	public function testGetShortcutsPassesThroughConfiguredEntries(): void {
-		$shortcuts = $this->callGetShortcuts( [
-			[
+	/**
+	 * @dataProvider provideIcons
+	 */
+	public function testGetIcons( array $manifestOptions, array $expected ): void {
+		$icons = $this->callFilter( 'getIcons', $manifestOptions );
+
+		$this->assertSame( $expected, $icons );
+	}
+
+	/**
+	 * @return iterable<string, array{array, array}>
+	 */
+	public static function provideShortcuts(): iterable {
+		yield 'passes through the fields the spec defines' => [
+			[ 'shortcuts' => [ [
 				'name' => 'Guides',
 				'short_name' => 'Guides',
 				'description' => 'Community guides',
 				'url' => '/wiki/Project:Guides',
-			],
-		] );
+			] ] ],
+			[ [
+				'name' => 'Guides',
+				'short_name' => 'Guides',
+				'description' => 'Community guides',
+				'url' => '/wiki/Project:Guides',
+			] ],
+		];
 
-		$this->assertSame(
+		yield 'empty list ships none' => [ [ 'shortcuts' => [] ], [] ];
+
+		yield 'non-array config ships none' => [ [ 'shortcuts' => 'Search' ], [] ];
+
+		yield 'drops entries missing name or url' => [
+			[ 'shortcuts' => [
+				[ 'name' => 'No URL' ],
+				[ 'url' => '/wiki/No_name' ],
+				[ 'name' => '', 'url' => '/wiki/Empty_name' ],
+				[ 'name' => 'Valid', 'url' => '/wiki/Valid' ],
+			] ],
+			[ [ 'name' => 'Valid', 'url' => '/wiki/Valid' ] ],
+		];
+
+		yield 'skips non-array entries' => [
+			[ 'shortcuts' => [ 'Search', 42, [ 'name' => 'Valid', 'url' => '/wiki/Valid' ] ] ],
+			[ [ 'name' => 'Valid', 'url' => '/wiki/Valid' ] ],
+		];
+
+		yield 'drops unknown keys' => [
+			[ 'shortcuts' => [ [ 'name' => 'Valid', 'url' => '/wiki/Valid', 'unknown_key' => 'bad' ] ] ],
+			[ [ 'name' => 'Valid', 'url' => '/wiki/Valid' ] ],
+		];
+
+		yield 'drops non-string field values' => [
+			[ 'shortcuts' => [
+				[ 'name' => 'Valid', 'url' => '/wiki/Valid', 'description' => [ 'nested' ] ],
+				[ 'name' => 'Bad URL', 'url' => 42 ],
+			] ],
+			[ [ 'name' => 'Valid', 'url' => '/wiki/Valid' ] ],
+		];
+
+		yield 'filters shortcut icons and drops the key when none survive' => [
+			[ 'shortcuts' => [
+				[
+					'name' => 'With icons',
+					'url' => '/wiki/With_icons',
+					'icons' => [
+						[ 'src' => '/search.png', 'sizes' => '96x96', 'unknown_key' => 'bad' ],
+						'not-an-array',
+						[ 'invalid_key' => 'value' ],
+					],
+				],
+				[
+					'name' => 'No usable icons',
+					'url' => '/wiki/No_usable_icons',
+					'icons' => [ [ 'invalid_key' => 'value' ] ],
+				],
+			] ],
 			[
 				[
-					'name' => 'Guides',
-					'short_name' => 'Guides',
-					'description' => 'Community guides',
-					'url' => '/wiki/Project:Guides',
+					'name' => 'With icons',
+					'url' => '/wiki/With_icons',
+					'icons' => [ [ 'src' => '/search.png', 'sizes' => '96x96' ] ],
 				],
+				[ 'name' => 'No usable icons', 'url' => '/wiki/No_usable_icons' ],
 			],
-			$shortcuts
-		);
+		];
 	}
 
-	public function testGetShortcutsEmptyConfigShipsNone(): void {
-		$shortcuts = $this->callGetShortcuts( [] );
+	/**
+	 * @dataProvider provideShortcuts
+	 */
+	public function testGetShortcuts( array $manifestOptions, array $expected ): void {
+		$shortcuts = $this->callFilter( 'getShortcuts', $manifestOptions );
 
-		$this->assertSame( [], $shortcuts );
+		$this->assertSame( $expected, $shortcuts );
 	}
 
-	public function testGetShortcutsIgnoresNonArrayConfig(): void {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [ 'shortcuts' => 'Search' ],
-		] );
-
-		$api = $this->createApiWithConfig( $config );
-
-		$method = new ReflectionMethod( $api, 'getShortcuts' );
-
-		$this->assertSame( [], $method->invoke( $api ) );
-	}
-
-	public function testGetShortcutsDropsEntriesMissingNameOrUrl(): void {
-		$shortcuts = $this->callGetShortcuts( [
-			[ 'name' => 'No URL' ],
-			[ 'url' => '/wiki/No_name' ],
-			[ 'name' => '', 'url' => '/wiki/Empty_name' ],
-			[ 'name' => 'Valid', 'url' => '/wiki/Valid' ],
-		] );
-
-		$this->assertSame( [ 'Valid' ], array_column( $shortcuts, 'name' ) );
-	}
-
-	public function testGetShortcutsSkipsNonArrayEntries(): void {
-		$shortcuts = $this->callGetShortcuts( [
-			'Search',
-			42,
-			[ 'name' => 'Valid', 'url' => '/wiki/Valid' ],
-		] );
-
-		$this->assertSame( [ 'Valid' ], array_column( $shortcuts, 'name' ) );
-	}
-
-	public function testGetShortcutsFiltersUnknownKeys(): void {
-		$shortcuts = $this->callGetShortcuts( [
-			[ 'name' => 'Valid', 'url' => '/wiki/Valid', 'unknown_key' => 'bad' ],
-		] );
-
-		$this->assertArrayNotHasKey( 'unknown_key', $shortcuts[0] );
-	}
-
-	public function testGetShortcutsDropsNonStringFieldValues(): void {
-		$shortcuts = $this->callGetShortcuts( [
-			[ 'name' => 'Valid', 'url' => '/wiki/Valid', 'description' => [ 'nested' ] ],
-			[ 'name' => 'Bad URL', 'url' => 42 ],
-		] );
-
-		$this->assertSame(
-			[ [ 'name' => 'Valid', 'url' => '/wiki/Valid' ] ],
-			$shortcuts
-		);
-	}
-
-	public function testGetShortcutsFiltersShortcutIcons(): void {
-		$shortcuts = $this->callGetShortcuts( [
-			[
-				'name' => 'With icons',
-				'url' => '/wiki/With_icons',
-				'icons' => [
-					[ 'src' => '/search.png', 'sizes' => '96x96', 'unknown_key' => 'bad' ],
-					'not-an-array',
-					[ 'invalid_key' => 'value' ],
-				],
-			],
-			[
-				'name' => 'No usable icons',
-				'url' => '/wiki/No_usable_icons',
-				'icons' => [ [ 'invalid_key' => 'value' ] ],
-			],
-		] );
-
-		$this->assertSame(
-			[ [ 'src' => '/search.png', 'sizes' => '96x96' ] ],
-			$shortcuts[0]['icons']
-		);
-		$this->assertArrayNotHasKey( 'icons', $shortcuts[1] );
-	}
-
-	public function testGetScreenshotsPassesThroughConfiguredEntries(): void {
-		$screenshots = $this->callGetScreenshots( [
-			[
+	/**
+	 * @return iterable<string, array{array, array}>
+	 */
+	public static function provideScreenshots(): iterable {
+		yield 'passes through the fields the spec defines' => [
+			[ 'screenshots' => [ [
 				'src' => '/screenshot-desktop.png',
 				'sizes' => '1920x1080',
 				'type' => 'image/png',
 				'form_factor' => 'wide',
 				'label' => 'Article on desktop',
 				'platform' => 'windows',
-			],
-		] );
+			] ] ],
+			[ [
+				'src' => '/screenshot-desktop.png',
+				'sizes' => '1920x1080',
+				'type' => 'image/png',
+				'form_factor' => 'wide',
+				'label' => 'Article on desktop',
+				'platform' => 'windows',
+			] ],
+		];
 
-		$this->assertSame(
-			[
-				[
-					'src' => '/screenshot-desktop.png',
-					'sizes' => '1920x1080',
-					'type' => 'image/png',
-					'form_factor' => 'wide',
-					'label' => 'Article on desktop',
-					'platform' => 'windows',
-				],
-			],
-			$screenshots
-		);
-	}
+		yield 'empty list ships none' => [ [ 'screenshots' => [] ], [] ];
 
-	public function testGetScreenshotsEmptyConfigShipsNone(): void {
-		$this->assertSame( [], $this->callGetScreenshots( [] ) );
-	}
+		// Unlike shortcuts, an absent key cannot fall back to anything — the
+		// images would have to be of the wiki itself.
+		yield 'absent key ships none' => [ [ 'icons' => [] ], [] ];
 
-	/**
-	 * Unlike shortcuts, an absent key cannot fall back to anything — the images
-	 * would have to be of the wiki itself.
-	 */
-	public function testGetScreenshotsMissingConfigShipsNone(): void {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [ 'icons' => [] ],
-		] );
+		yield 'non-array config ships none' => [ [ 'screenshots' => '/screenshot.png' ], [] ];
 
-		$api = $this->createApiWithConfig( $config );
+		yield 'skips non-array entries' => [
+			[ 'screenshots' => [ '/screenshot.png', 42, [ 'src' => '/valid.png' ] ] ],
+			[ [ 'src' => '/valid.png' ] ],
+		];
 
-		$method = new ReflectionMethod( $api, 'getScreenshots' );
+		yield 'drops entries missing src' => [
+			[ 'screenshots' => [
+				[ 'sizes' => '1920x1080', 'type' => 'image/png' ],
+				[ 'src' => '', 'sizes' => '1920x1080' ],
+				[ 'src' => '/valid.png' ],
+			] ],
+			[ [ 'src' => '/valid.png' ] ],
+		];
 
-		$this->assertSame( [], $method->invoke( $api ) );
-	}
+		// purpose belongs to icons, not screenshots, so it must not survive —
+		// which is what fails here if the icon filter gets reused.
+		yield 'drops unknown keys, including the icon-only purpose' => [
+			[ 'screenshots' => [ [ 'src' => '/valid.png', 'purpose' => 'maskable', 'unknown_key' => 'bad' ] ] ],
+			[ [ 'src' => '/valid.png' ] ],
+		];
 
-	public function testGetScreenshotsIgnoresNonArrayConfig(): void {
-		$config = new HashConfig( [
-			'CitizenManifestOptions' => [ 'screenshots' => '/screenshot.png' ],
-		] );
-
-		$api = $this->createApiWithConfig( $config );
-
-		$method = new ReflectionMethod( $api, 'getScreenshots' );
-
-		$this->assertSame( [], $method->invoke( $api ) );
-	}
-
-	public function testGetScreenshotsSkipsNonArrayEntries(): void {
-		$screenshots = $this->callGetScreenshots( [
-			'/screenshot.png',
-			42,
-			[ 'src' => '/valid.png' ],
-		] );
-
-		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
-	}
-
-	public function testGetScreenshotsDropsEntriesMissingSrc(): void {
-		$screenshots = $this->callGetScreenshots( [
-			[ 'sizes' => '1920x1080', 'type' => 'image/png' ],
-			[ 'src' => '', 'sizes' => '1920x1080' ],
-			[ 'src' => '/valid.png' ],
-		] );
-
-		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
+		yield 'drops non-string field values' => [
+			[ 'screenshots' => [
+				[ 'src' => '/valid.png', 'sizes' => [ 'nested' ] ],
+				[ 'src' => 42, 'sizes' => '1920x1080' ],
+			] ],
+			[ [ 'src' => '/valid.png' ] ],
+		];
 	}
 
 	/**
-	 * purpose belongs to icons, not screenshots, so it must not survive — which
-	 * is what fails here if the icon filter gets reused for screenshots.
+	 * @dataProvider provideScreenshots
 	 */
-	public function testGetScreenshotsFiltersUnknownKeys(): void {
-		$screenshots = $this->callGetScreenshots( [
-			[ 'src' => '/valid.png', 'purpose' => 'maskable', 'unknown_key' => 'bad' ],
-		] );
+	public function testGetScreenshots( array $manifestOptions, array $expected ): void {
+		$screenshots = $this->callFilter( 'getScreenshots', $manifestOptions );
 
-		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
+		$this->assertSame( $expected, $screenshots );
 	}
 
-	public function testGetScreenshotsDropsNonStringFieldValues(): void {
-		$screenshots = $this->callGetScreenshots( [
-			[ 'src' => '/valid.png', 'sizes' => [ 'nested' ] ],
-			[ 'src' => 42, 'sizes' => '1920x1080' ],
-		] );
+	/**
+	 * @return iterable<string, array{array}>
+	 */
+	public static function provideIconConfigsThatFallBackToLogos(): iterable {
+		yield 'empty list' => [ [ 'icons' => [] ] ];
+		// A $wgCitizenManifestOptions that replaces the whole array can leave
+		// the key out, which must fall back rather than warn.
+		yield 'absent key' => [ [ 'theme_color' => '' ] ];
+	}
 
-		$this->assertSame( [ [ 'src' => '/valid.png' ] ], $screenshots );
+	/**
+	 * @dataProvider provideIconConfigsThatFallBackToLogos
+	 */
+	public function testGetIconsFallsBackToLogos( array $manifestOptions ): void {
+		$config = new HashConfig( [
+			'CitizenManifestOptions' => $manifestOptions,
+			'Logos' => false,
+		] );
+		$api = $this->createApiWithConfig( $config );
+
+		$method = new ReflectionMethod( $api, 'getIcons' );
+		$icons = $method->invoke( $api );
+
+		$this->assertSame( [], $icons );
 	}
 }

--- a/tests/phpunit/integration/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/integration/Api/ApiWebappManifestTest.php
@@ -91,18 +91,12 @@ class ApiWebappManifestTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( [], $this->callGetShortcuts( [ 'shortcuts' => [] ] ) );
 	}
 
-	/**
-	 * A $wgCitizenManifestOptions that replaces the whole array can leave any
-	 * key out. Every one of them is optional in the manifest spec, so the
-	 * member is omitted rather than emitted empty — and reading it must not
-	 * raise a warning, which is what fails this test if the guard goes away.
-	 */
-	public function testManifestOmitsMembersTheConfigDoesNotCarry(): void {
+	private function executeManifest( array $manifestOptions ): array {
 		$result = new ApiResult( 1024 * 1024 );
 
 		$contextMock = $this->createMock( IContextSource::class );
 		$contextMock->method( 'getConfig' )->willReturn( new HashConfig( [
-			'CitizenManifestOptions' => [],
+			'CitizenManifestOptions' => $manifestOptions,
 			MainConfigNames::LanguageCode => 'en',
 			MainConfigNames::Sitename => 'Test wiki',
 			MainConfigNames::Server => 'http://localhost',
@@ -123,12 +117,59 @@ class ApiWebappManifestTest extends MediaWikiIntegrationTestCase {
 		);
 
 		$api->execute();
-		$manifest = $result->getResultData();
+
+		return $result->getResultData();
+	}
+
+	/**
+	 * A $wgCitizenManifestOptions that replaces the whole array can leave any
+	 * key out. Every one of them is optional in the manifest spec, so the
+	 * member is omitted rather than emitted empty — and reading it must not
+	 * raise a warning, which is what fails this test if the guard goes away.
+	 */
+	public function testManifestOmitsMembersTheConfigDoesNotCarry(): void {
+		$manifest = $this->executeManifest( [] );
 
 		$this->assertArrayNotHasKey( 'theme_color', $manifest );
 		$this->assertArrayNotHasKey( 'background_color', $manifest );
 		$this->assertArrayNotHasKey( 'short_name', $manifest );
 		$this->assertArrayNotHasKey( 'description', $manifest );
+		$this->assertArrayNotHasKey( 'screenshots', $manifest );
 		$this->assertSame( 'Test wiki', $manifest['name'] );
+	}
+
+	/**
+	 * An explicitly empty list has no member to carry, so it must be left out
+	 * rather than emitted as [] — which is what execute() decides, not the
+	 * filter the unit test covers.
+	 */
+	public function testManifestOmitsAnEmptyScreenshotList(): void {
+		$manifest = $this->executeManifest( [ 'screenshots' => [] ] );
+
+		$this->assertArrayNotHasKey( 'screenshots', $manifest );
+	}
+
+	public function testManifestCarriesConfiguredScreenshots(): void {
+		$manifest = $this->executeManifest( [
+			'screenshots' => [
+				[
+					'src' => '/screenshot-desktop.png',
+					'sizes' => '1920x1080',
+					'type' => 'image/png',
+					'form_factor' => 'wide',
+				],
+				[
+					'src' => '/screenshot-mobile.png',
+					'sizes' => '750x1334',
+					'type' => 'image/png',
+					'form_factor' => 'narrow',
+				],
+			],
+		] );
+
+		$this->assertSame(
+			[ 'wide', 'narrow' ],
+			array_column( $manifest['screenshots'], 'form_factor' )
+		);
 	}
 }


### PR DESCRIPTION
## Problem

Citizen's web app manifest carried no `screenshots` member, so browsers could only ever offer the plain install prompt — never the richer install dialog that shows the wiki's name, description and a carousel of screenshots.

Closes #1084.

## Behaviour

`$wgCitizenManifestOptions['screenshots']` now reaches the manifest, read the same way `icons` and `shortcuts` already are.

- Entries are reduced to the fields the manifest spec defines for a screenshot: `src`, `sizes`, `type`, `form_factor`, `label`, `platform`. Anything else is dropped.
- `src` is required. An entry without one is dropped rather than shipped incomplete, the same rule `shortcuts` applies to `name`/`url`.
- Citizen ships no defaults, because the images have to be pictures of the wiki itself. A wiki that configures none gets no `screenshots` member at all, rather than an empty one.

Nothing changes for a wiki that does not set the option.

## Contract

`purpose` is deliberately not a screenshot field — it belongs to `icons`. Anyone reaching for the existing icon filter to serve both will silently start emitting it.

## Also in here

**Logo requests are bounded.** Deriving icons from `$wgLogos` fetches each logo from the wiki's own server and passed no options, so every request inherited `$wgHTTPTimeout` at 25 seconds — a server that cannot quickly reach its own URL held the worker across the whole logo list. The result was also discarded, so a logo that 404s or times out was indistinguishable from one that was never there: the icon lost its size, got dropped, and the wiki silently offered nothing installable for as long as the manifest stayed cached. Both now have an answer — a short timeout, and a warning naming the logo. A logo that needs no measuring is unaffected, since a server that cannot reach its own URL is no evidence that a browser cannot.

**A feature page for the manifest**, since it had outgrown a configuration entry: what Citizen puts in the manifest, what to set, and what happens when you set nothing. Browser behaviour is left to the guides it links — screenshot dimensions, formats and counts are each browser's own business and change without us.

**The option filters share data providers**, so adding a case is adding a row, and each case asserts the whole returned list rather than a projection of it.

## Follow-up, not in this PR

The manifest is served with a one-week cache, so an options change does not reach a browser that already fetched it. Dropping that TTL is the only thing that shortens the loop, and it helps every wiki regardless of how its manifest is configured.
