### PR TITLE
docs(config): correct what $wgCitizenGlobalToolsPortlet does

### DIFF
--- a/docs/src/config/index.md
+++ b/docs/src/config/index.md
@@ -79,11 +79,19 @@ $wgCitizenShowPageTools = true;
 
 ### `$wgCitizenGlobalToolsPortlet`
 
-The ID of the menu where global tools (like user preferences) should appear. Leave this empty to use the default location.
+Chooses which sidebar menu Citizen moves the "Upload file" link into. Leave it empty and Citizen uses the first menu in [`MediaWiki:Sidebar`](https://www.mediawiki.org/wiki/Manual:Interface/Sidebar) that isn't `SEARCH`, `TOOLBOX` or `LANGUAGES` — Navigation on a stock wiki.
 
 ```php [LocalSettings.php]
 $wgCitizenGlobalToolsPortlet = '';
 ```
+
+**Values**: A menu name from `MediaWiki:Sidebar`, such as `'navigation'`. A leading `p-` is optional, so `'p-navigation'` works the same way.
+
+The upload link is the one MediaWiki builds, so it only appears for people who are allowed to upload — see [point the upload link somewhere else](../customization/recipes.md#point-the-upload-link-somewhere-else). On MediaWiki 1.43 the "Special pages" link moves along with it.
+
+::: warning
+A name that doesn't match a menu in `MediaWiki:Sidebar` isn't an error — Citizen creates a new menu with that name, so a typo gets you a stray menu rather than a warning.
+:::
 
 ### `$wgCitizenEnableDrawerSiteStats`
 

--- a/docs/src/customization/recipes.md
+++ b/docs/src/customization/recipes.md
@@ -116,10 +116,12 @@ Users who picked a different theme before you applied this change have it stored
 
 ## Point the upload link somewhere else
 
-The "Upload file" link in the site tools menu is the one MediaWiki builds, so [`$wgUploadNavigationUrl`](https://www.mediawiki.org/wiki/Manual:$wgUploadNavigationUrl) decides where it goes. Use it to send people to UploadWizard, a shared repository like Commons, or your own upload guide:
+The "Upload file" link Citizen shows in the sidebar is the one MediaWiki builds, so [`$wgUploadNavigationUrl`](https://www.mediawiki.org/wiki/Manual:$wgUploadNavigationUrl) decides where it goes. Use it to send people to UploadWizard, a shared repository like Commons, or your own upload guide:
 
 ```php [LocalSettings.php]
 $wgUploadNavigationUrl = '/wiki/Special:UploadWizard';
 ```
 
 Leave it unset and the link points at `Special:Upload`, and only appears for people who are actually allowed to upload. Setting it shows the link to everyone, since MediaWiki can't know what permissions the destination needs.
+
+Which sidebar menu the link sits in is up to [`$wgCitizenGlobalToolsPortlet`](../config/index.md#wgcitizenglobaltoolsportlet).

--- a/skin.json
+++ b/skin.json
@@ -1047,7 +1047,7 @@
 		},
 		"GlobalToolsPortlet": {
 			"value": "",
-			"description": "ID of the portlet to attach the global tools",
+			"description": "Name of the sidebar menu to move the site tools into",
 			"descriptionmsg": "citizen-config-globaltoolsportlet",
 			"public": true
 		},


### PR DESCRIPTION
## Problem

The `$wgCitizenGlobalToolsPortlet` entry described a setting that does not exist. It said the config placed "global tools (like user preferences)" — preferences has never been placed by it, in any version. The phrase was invented in the docs and never matched any code.

It also left "the default location" unspecified, did not mention that the `p-` prefix is optional, and did not say what happens when the value names no existing menu.

The upload recipe called the destination the "site tools menu", a name that appears nowhere in the interface.

## Behaviour

What the setting actually does:

- Moves the "Upload file" link into the named sidebar menu. On MediaWiki 1.43 the "Special pages" link moves along with it; from MediaWiki 1.44 core places that one itself.
- Empty value falls back to the first menu in `MediaWiki:Sidebar` that is not `SEARCH`, `TOOLBOX` or `LANGUAGES`.
- A leading `p-` is stripped, so `p-navigation` and `navigation` are equivalent.
- A name matching no existing menu quietly creates one instead of reporting an error.

## Contract

No behaviour change. Documentation, plus one `skin.json` config `description` string that carried the same wrong framing. The `description` field is self-documentation and is not read at runtime.

The two docs pages now cross-link, since the recipe governs where the upload link points and this setting governs which menu it lands in.

## Verification

- Drove `Skin::buildSidebar()` on MediaWiki 1.43.6 across config values (`''`, `p-<menu>`, `<menu>`, an unmatched name, `p-tb`, `SEARCH`, `p-`) and read the resulting portlet ids and labels.
- Read core tags 1.43.6, 1.44.0, 1.45.0 and 1.46.0 to confirm the upload entry survives under the same key and to place the Special pages change at 1.44.
- `npm run lint:md` clean for both changed pages; `skin.json` validates.

## Follow-ups

Not included here, happy to split into a separate PR:

- `includes/Hooks/SkinHooks.php:212` — the `'n-specialpages' => 'specialPages'` comment says "remove when we drop MW 1.43 support", but core only added that icon to `getSidebarIcon()` in 1.45, so the entry is load-bearing on 1.44 as well.
- `includes/Hooks/SkinHooks.php:216` — `'t-upload' => 'upload'` is unreachable today; the task it waits on appears nowhere in core through 1.46.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for configuring global tools in sidebar menus.
  * Documented supported menu-name formats, automatic menu selection, upload-link placement, and behavior for invalid menu names.
  * Updated the upload-link recipe and configuration description to clarify sidebar placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->