### PR TITLE
fix(siteStats): tell screen readers what each statistic counts

### DIFF
--- a/includes/Components/CitizenComponentSiteStats.php
+++ b/includes/Components/CitizenComponentSiteStats.php
@@ -112,15 +112,24 @@ class CitizenComponentSiteStats implements CitizenComponent {
 		$items = [];
 
 		foreach ( self::SITESTATS_ICON_MAP as $key => $icon ) {
+			$value = $this->getSiteStatValue( $key );
+
+			// A zero stat formats to an empty string. Emitting the item anyway leaves a bare icon
+			// with no number beside it, and a label that screen readers announce without a count.
+			if ( $value === '' ) {
+				continue;
+			}
+
 			$items[] = [
 				'id' => $key,
 				'icon' => $icon,
-				'value' => $this->getSiteStatValue( $key ),
+				'value' => $value,
 				'label' => $this->localizer->msg( "citizen-sitestats-$key-label" )->text(),
 			];
 		}
 
 		return [
+			'msg-statistics' => $this->localizer->msg( 'statistics' )->text(),
 			'array-sitestats-items' => $items
 		];
 	}

--- a/resources/skins.citizen.styles/components/Sitestats.less
+++ b/resources/skins.citizen.styles/components/Sitestats.less
@@ -1,14 +1,23 @@
+// The list reset below is keyed on the class rather than `ul`, so it stays inert against HTML
+// cached before this block became a list.
 .citizen-siteStats {
 	--size-icon: 0.875rem;
 	display: flex;
 	gap: var( --space-md );
-	.mixin-citizen-font-styles( 'overline' );
+	padding: 0;
+	margin: 0;
 	white-space: nowrap;
+	list-style: none;
+	.mixin-citizen-font-styles( 'overline' );
 
 	&__item {
 		display: flex;
 		gap: var( --space-xs );
 		align-items: center;
+	}
+
+	&__label {
+		.mixin-citizen-screen-reader-only;
 	}
 
 	.citizen-ui-icon {

--- a/templates/SiteStats.mustache
+++ b/templates/SiteStats.mustache
@@ -1,8 +1,17 @@
-<div class="citizen-siteStats">
+{{!
+	string msg-statistics Names the block, so assistive tech can identify and skip it.
+}}
+<ul class="citizen-siteStats" role="list" aria-label="{{msg-statistics}}">
 	{{#array-sitestats-items}}
-	<div class="citizen-siteStats__item" id="citizen-siteStats__item--{{id}}" title="{{label}}">
-		<span class="citizen-ui-icon mw-ui-icon-{{icon}} mw-ui-icon-wikimedia-{{icon}}"></span>
+	{{! Both roles are load-bearing: `list-style: none` on the block and `display: flex` on the item
+	    each strip list semantics in Safari, so neither survives on the implicit role alone. }}
+	<li class="citizen-siteStats__item" id="citizen-siteStats__item--{{id}}" role="listitem">
+		{{! title sits on the icon, not the item: a listitem takes its name from title, which would
+		    collide with the text below. It reaches pointers only, so the label is repeated for
+		    assistive tech and the two must stay in sync. }}
+		<span class="citizen-ui-icon mw-ui-icon-{{icon}} mw-ui-icon-wikimedia-{{icon}}" title="{{label}}"></span>
 		<span>{{value}}</span>
-	</div>
+		<span class="citizen-siteStats__label">{{label}}</span>
+	</li>
 	{{/array-sitestats-items}}
-</div>
+</ul>


### PR DESCRIPTION
## Problem

Each drawer statistic's label only lived in `title` on a plain `div`. ARIA prohibits naming an element with the `generic` role, so the title never reached the accessibility tree at all — screen readers announced four bare numbers, `150 32 40 707`, with nothing saying what they counted, that they were site statistics, or where the block ended. `aria-label` would have failed for the same reason.

Separately, a statistic of zero formats to an empty string, so its item rendered as a bare icon with no number beside it. MediaWiki disables uploads by default, so the file count is zero and every fresh wiki shows this.

## Behaviour

- Screen readers now get a named, skippable unit: "Statistics, list, 4 items", then "150 articles", "32 files", and so on. `L` / `Shift+L` in NVDA and JAWS jump the whole block.
- Statistics with no value are no longer rendered at all, instead of leaving an empty shell.
- **Nothing changes visually.** Measured identical geometry before and after — block 215.06 × 22, item widths unchanged, wordmark unmoved, no list bullets or indent.
- Mouse users keep the hover tooltip, but it now sits on the icon rather than the whole item, so the target is smaller (14 × 14 instead of 45.7 × 22). This is the trade for the item being a `listitem`, which — unlike a `div` — *does* take its accessible name from `title` and would collide with the text beside it.

## Contract

- **Cache compatibility: `clean`.** No class or id is renamed or removed, and nothing in JS targets this markup. The list reset is keyed on the class rather than `ul`, and `list-style` does not apply to a `div` while `margin`/`padding: 0` are already its computed defaults — so already-cached HTML renders pixel-identically and simply does not receive the improvement until re-parsed. No compat slice, no gate, no purge note.
- **No new i18n keys.** Reuses the four existing `citizen-sitestats-*-label` messages plus core's `statistics`, so there is no translatewiki round trip.
- No config change, no public API change. `docs/src/config/index.md` documents the `$wgCitizenEnableDrawerSiteStats` toggle rather than the markup, so no docs update is owed.

Both `role="list"` and `role="listitem"` are explicit rather than redundant: `list-style: none` on the block and `display: flex` on the item each strip list semantics in Safari, so neither survives on its implicit role alone.

## Verification

`composer test`, `composer phpunit` (271 tests, 525 assertions), `npm run lint:styles` and `npm run lint:compat` all pass. `?uselang=x-xss` confirms the new `aria-label` escapes correctly. Phan reports two `UnusedPluginSuppression` issues in `CitizenComponentBodyContent.php`; these were confirmed identical on a clean tree and are unrelated to this change.

The accessibility tree, the unchanged geometry, and the zero-value path (by temporarily setting `ss_images` to 0) were each verified against a running wiki in Chrome. **VoiceOver is untested** — the Safari list-semantics behaviour is handled defensively rather than confirmed.

## Follow-ups, deliberately not in this PR

- The drawer contains no headings at all — `.citizen-menu__heading` is a `div` — so it cannot be navigated by heading. Larger than anything here.
- `templates/MenuContents.mustache` is missing `role="list"`, the same Safari issue on the main menu.
- `tests/phpunit/Unit/Components/CitizenComponentSiteStatsTest.php` is still a stub, so the new zero-value guard ships untested.
- `PLURAL` labels would read better in languages with case agreement, but need four new messages taking the raw integer as a second parameter, since the displayed value is compact-formatted.
- Linking the block to `Special:Statistics` — the right answer for anyone who wants exact, uncached numbers, but a design change rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139eJZ32zk9bRncfzTcGSMR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved site statistics markup with semantic lists and clearer labels for screen readers.
  * Added accessible labeling for statistic icons while preserving visible values.
* **Bug Fixes**
  * Site statistics with empty or zero-valued results are no longer displayed.
* **Style**
  * Updated site statistics styling to remove unwanted list spacing and markers while maintaining the existing visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->