### PR TITLE
fix(userMenu): correct user group links, real name display and stats label

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -120,7 +120,7 @@
 	"citizen-user-info-text-anon-temp": "If you make an edit, a temporary account will be created for you.",
 	"citizen-user-info-text-temp": "This temporary account was created after an edit was made without an account on this browser and device.",
 	"citizen-user-info-edits-label": "Edits",
-	"citizen-user-info-joined-label": "Joined",
+	"citizen-user-info-joined-label": "Member since",
 
 	"citizen-command-palette-action-view": "View",
 	"citizen-command-palette-back": "Back",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -116,7 +116,7 @@
 	"citizen-user-info-text-anon-temp": "Description in the user menu when the user is not logged in and temporary accounts are enabled, so an edit will create a temporary account rather than expose the user's IP address.",
 	"citizen-user-info-text-temp": "Description in the user menu when user is using a temporary account.",
 	"citizen-user-info-edits-label": "Label for the edit count in the user info",
-	"citizen-user-info-joined-label": "Label for the registration date in the user info",
+	"citizen-user-info-joined-label": "Label for the account registration date in the user info. Note this is when the account was created, not when the user first edited.",
 	"citizen-command-palette-action-view": "Label for the per-item action button that opens the result's page for reading. Used on category results to provide access to the actual Category: page (since clicking the result drills into it instead of navigating).",
 	"citizen-command-palette-back": "Aria label for the back button in the command palette header when a mode is active.",
 	"citizen-command-palette-dismiss": "Aria label for the per-item action button that removes a result from the command palette's recent items list. The button shows only a trash icon, so this is its entire accessible name.",

--- a/includes/Components/CitizenComponentMenuListItem.php
+++ b/includes/Components/CitizenComponentMenuListItem.php
@@ -9,18 +9,24 @@ namespace MediaWiki\Skins\Citizen\Components;
  */
 class CitizenComponentMenuListItem implements CitizenComponent {
 
+	/**
+	 * A null $link renders $text as plain content, for items that have no
+	 * meaningful target.
+	 */
 	public function __construct(
-		private readonly CitizenComponentLink $link,
+		private readonly ?CitizenComponentLink $link,
 		private readonly string $class = '',
-		private readonly string $id = ''
+		private readonly string $id = '',
+		private readonly string $text = ''
 	) {
 	}
 
 	public function getTemplateData(): array {
 		return [
-			'array-links' => $this->link->getTemplateData(),
+			'array-links' => $this->link?->getTemplateData(),
 			'item-class' => $this->class,
 			'item-id' => $this->id,
+			'text' => $this->text,
 		];
 	}
 }

--- a/includes/Components/CitizenComponentUserInfo.php
+++ b/includes/Components/CitizenComponentUserInfo.php
@@ -6,11 +6,10 @@ namespace MediaWiki\Skins\Citizen\Components;
 
 use MediaWiki\Html\Html;
 use MediaWiki\Language\Language;
-use MediaWiki\Title\MalformedTitleException;
-use MediaWiki\Title\Title;
 use MediaWiki\User\TempUser\TempUserConfig;
 use MediaWiki\User\User;
 use MediaWiki\User\UserGroupManager;
+use MediaWiki\User\UserGroupMembership;
 use MessageLocalizer;
 use Wikimedia\Parsoid\Utils\DOMCompat;
 use Wikimedia\Parsoid\Utils\DOMUtils;
@@ -24,7 +23,6 @@ class CitizenComponentUserInfo implements CitizenComponent {
 		private readonly UserGroupManager $userGroupManager,
 		private readonly Language $lang,
 		private readonly MessageLocalizer $localizer,
-		private readonly Title $title,
 		private readonly User $user,
 		private readonly TempUserConfig $tempUserConfig,
 		private readonly array $userPageData,
@@ -76,6 +74,16 @@ class CitizenComponentUserInfo implements CitizenComponent {
 
 	/**
 	 * Build the template data for the user groups
+	 *
+	 * Follows UserGroupMembership::getLinkHTML(), as used by Special:Preferences:
+	 * the label is the group member name in the user's interface language (with
+	 * GENDER), while the target comes from grouppage-<group> in the content
+	 * language. Groups without that message render as plain text, since there is
+	 * no page to point at.
+	 *
+	 * One deliberate difference: the label is capitalised. Core leaves it lower
+	 * case because it reads inside a sentence there ("member of: administrator"),
+	 * whereas here each name stands on its own.
 	 */
 	private function getUserGroups(): ?array {
 		$groups = $this->userGroupManager->getUserGroups( $this->user );
@@ -85,27 +93,26 @@ class CitizenComponentUserInfo implements CitizenComponent {
 		}
 
 		$listItems = [];
-		$msgKey = 'group-%s-member';
 		foreach ( $groups as $group ) {
-			$id = sprintf( $msgKey, $group );
-			$text = $this->localizer->msg( $id )->text();
-			$title = null;
-			try {
-				$title = $this->title->newFromTextThrow( $text, NS_PROJECT );
-			} catch ( MalformedTitleException ) {
-				// ignore
-			}
+			$text = $this->lang->ucfirst(
+				$this->lang->getGroupMemberName( $group, $this->user )
+			);
 
-			if ( !$text || !$title ) {
+			if ( $text === '' ) {
 				continue;
 			}
 
-			$link = new CitizenComponentLink(
-				$title->getLinkURL(),
-				ucfirst( $text )
-			);
+			$title = UserGroupMembership::getGroupPage( $group );
+			$link = $title
+				? new CitizenComponentLink( $title->getLinkURL(), $text )
+				: null;
 
-			$listItem = new CitizenComponentMenuListItem( $link, 'citizen-userInfo-usergroup', $id );
+			$listItem = new CitizenComponentMenuListItem(
+				$link,
+				'citizen-userInfo-usergroup',
+				sprintf( 'group-%s-member', $group ),
+				$link ? '' : $text
+			);
 
 			$listItems[] = $listItem->getTemplateData();
 		}

--- a/includes/Components/CitizenComponentUserInfo.php
+++ b/includes/Components/CitizenComponentUserInfo.php
@@ -11,6 +11,8 @@ use MediaWiki\User\User;
 use MediaWiki\User\UserGroupManager;
 use MediaWiki\User\UserGroupMembership;
 use MessageLocalizer;
+use Wikimedia\Parsoid\DOM\Element;
+use Wikimedia\Parsoid\DOM\Text;
 use Wikimedia\Parsoid\Utils\DOMCompat;
 use Wikimedia\Parsoid\Utils\DOMUtils;
 
@@ -131,8 +133,10 @@ class CitizenComponentUserInfo implements CitizenComponent {
 
 		$htmlItems = $userPageData['html-items'];
 		$realname = $user->getRealName();
-		if ( $realname !== '' ) {
-			$username = $user->getName();
+		$username = $user->getName();
+		// Showing both is only useful when they differ; when they match it would
+		// print the same word twice.
+		if ( $realname !== '' && $realname !== $username ) {
 			$htmlItems = $this->replaceUsernameWithRealName( $htmlItems, $username, $realname );
 		}
 
@@ -155,25 +159,63 @@ class CitizenComponentUserInfo implements CitizenComponent {
 		$body = DOMCompat::getBody( $doc );
 
 		foreach ( DOMCompat::querySelectorAll( $body, 'a' ) as $anchor ) {
-			foreach ( $anchor->childNodes as $child ) {
-				if ( $child->nodeType === XML_TEXT_NODE && $child->textContent === $username ) {
-					$realnameSpan = $doc->createElement( 'span' );
-					$realnameSpan->setAttribute( 'id', 'pt-userpage-realname' );
-					$realnameSpan->appendChild( $doc->createTextNode( $realname ) );
+			// The username is not a direct child of the anchor: core wraps portlet
+			// link text in a span, and the keyboard hint adds a further sibling.
+			// Search descendants and replace the text node where it actually sits,
+			// which also puts both spans inside the wrapper that
+			// `#pt-userpage-2 > a > span` lays out.
+			$textNode = $this->findTextNode( $anchor, $username );
 
-					$usernameSpan = $doc->createElement( 'span' );
-					$usernameSpan->setAttribute( 'id', 'pt-userpage-username' );
-					$usernameSpan->appendChild( $doc->createTextNode( $username ) );
+			if ( !$textNode ) {
+				continue;
+			}
 
-					$anchor->replaceChild( $usernameSpan, $child );
-					$anchor->insertBefore( $realnameSpan, $usernameSpan );
-					$anchor->insertBefore( $doc->createTextNode( ' ' ), $usernameSpan );
-					break 2;
+			$realnameSpan = $doc->createElement( 'span' );
+			$realnameSpan->setAttribute( 'id', 'pt-userpage-realname' );
+			$realnameSpan->appendChild( $doc->createTextNode( $realname ) );
+
+			$usernameSpan = $doc->createElement( 'span' );
+			$usernameSpan->setAttribute( 'id', 'pt-userpage-username' );
+			$usernameSpan->appendChild( $doc->createTextNode( $username ) );
+
+			$parent = $textNode->parentNode;
+			$parent->replaceChild( $usernameSpan, $textNode );
+			$parent->insertBefore( $realnameSpan, $usernameSpan );
+			// Kept for contexts where the flex gap does not apply; a whitespace-only
+			// text node is not rendered as a flex item where it does.
+			$parent->insertBefore( $doc->createTextNode( ' ' ), $usernameSpan );
+			break;
+		}
+
+		return DOMCompat::getInnerHTML( $body );
+	}
+
+	/**
+	 * Find the first descendant text node whose content is exactly $text.
+	 *
+	 * Typed on Parsoid's DOM namespace rather than \DOMNode: PHP 8.4 introduced a
+	 * separate Dom\* hierarchy, and MediaWiki 1.46+ returns those from
+	 * parseHTML(), so a \DOMNode hint is a TypeError there.
+	 */
+	private function findTextNode( Element $node, string $text ): ?Text {
+		foreach ( $node->childNodes as $child ) {
+			if ( $child instanceof Text ) {
+				if ( $child->textContent === $text ) {
+					return $child;
+				}
+				continue;
+			}
+
+			// Only elements can hold further children worth descending into.
+			if ( $child instanceof Element ) {
+				$found = $this->findTextNode( $child, $text );
+				if ( $found ) {
+					return $found;
 				}
 			}
 		}
 
-		return DOMCompat::getInnerHTML( $body );
+		return null;
 	}
 
 	public function getTemplateData(): array {

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -283,7 +283,6 @@ class SkinCitizen extends SkinMustache {
 				$this->userGroupManager,
 				$lang,
 				$localizer,
-				$title,
 				$user,
 				$this->tempUserConfig,
 				$parentData['data-portlets']['data-user-page']

--- a/resources/skins.citizen.styles/components/UserInfo.less
+++ b/resources/skins.citizen.styles/components/UserInfo.less
@@ -44,14 +44,46 @@
 	}
 
 	&-usergroups {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0 var( --space-xs );
+		// Runs as text rather than as a row of boxes. Group names vary too much
+		// in length to pack as fixed items — in a panel this narrow each long
+		// name claims a row of its own and leaves the rest empty — whereas
+		// inline content reflows to fill each line.
+		//
+		// Capped at the dropdown's own min-width less this panel's padding, so
+		// an account in many groups wraps instead of stretching the card: the
+		// menu is sized by its content, and without this an eight-group account
+		// widens the whole thing by 200px.
+		max-width: ~'calc( 16rem - var( --space-md ) * 2 )';
 		margin: 0;
+		color: var( --color-subtle );
 		list-style: none;
 
+		> li {
+			display: inline;
+			overflow-wrap: break-word;
+		}
+
+		> li + li::before {
+			margin-inline: var( --space-xxs );
+			// Alt text is empty so the separator is not announced; the list
+			// markup already conveys the boundary to assistive technology.
+			content: '·' / '';
+		}
+
 		a {
-			color: var( --color-subtle );
+			// Grows the hit area without disturbing line layout, since vertical
+			// padding on an inline box does not affect line height.
+			padding-block: var( --space-xxs );
+			// Codex link colours are wrapped in :where(), which zeroes their
+			// specificity, so this rule wins at rest, on hover and when visited.
+			// Hover has to be restated here or the link never responds at all.
+			color: var( --color-progressive );
+			text-decoration: none;
+
+			&:hover {
+				color: var( --color-progressive--hover );
+				text-decoration: underline;
+			}
 		}
 	}
 

--- a/resources/skins.citizen.styles/components/UserInfo.less
+++ b/resources/skins.citizen.styles/components/UserInfo.less
@@ -21,9 +21,11 @@
 		> a > span {
 			display: flex;
 			flex-grow: 1;
-			flex-wrap: wrap;
-			gap: var( --space-xs );
-			align-items: baseline;
+			// Stacked, so the real name reads as the heading and the username as
+			// its qualifier. Only ever holds those two spans, or a single text
+			// node when no real name is set.
+			flex-direction: column;
+			align-items: flex-start;
 		}
 
 		.citizen-keyboard-hint-key {
@@ -36,7 +38,9 @@
 	}
 
 	#pt-userpage-username {
+		font-weight: var( --font-weight-normal );
 		color: var( --color-subtle );
+		.mixin-citizen-font-styles( 'small' );
 	}
 
 	&-text {

--- a/tests/phpunit/Unit/Components/CitizenComponentUserInfoTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentUserInfoTest.php
@@ -6,7 +6,6 @@ namespace MediaWiki\Skins\Citizen\Tests\Unit\Components;
 
 use MediaWiki\Language\Language;
 use MediaWiki\Skins\Citizen\Components\CitizenComponentUserInfo;
-use MediaWiki\Title\Title;
 use MediaWiki\User\TempUser\TempUserConfig;
 use MediaWiki\User\User;
 use MediaWiki\User\UserGroupManager;
@@ -80,7 +79,6 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 
 		$lang = $this->createMock( Language::class );
 		$localizer = $this->createMockLocalizer();
-		$title = $this->createMock( Title::class );
 
 		// Simulate MediaWiki's HTML output where O'Brien becomes O&#039;Brien
 		$encodedUsername = htmlspecialchars( $username, ENT_QUOTES );
@@ -95,7 +93,6 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 			$userGroupManager,
 			$lang,
 			$localizer,
-			$title,
 			$user,
 			$this->createMockTempUserConfig( false ),
 			$userPageData
@@ -123,7 +120,6 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 
 		$lang = $this->createMock( Language::class );
 		$localizer = $this->createMockLocalizer();
-		$title = $this->createMock( Title::class );
 
 		$encodedUsername = htmlspecialchars( $username, ENT_QUOTES );
 		$htmlItems = '<li id="pt-userpage"><a href="/wiki/User:'
@@ -137,7 +133,6 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 			$userGroupManager,
 			$lang,
 			$localizer,
-			$title,
 			$user,
 			$this->createMockTempUserConfig( false ),
 			$userPageData
@@ -164,7 +159,6 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 			$this->createMock( UserGroupManager::class ),
 			$this->createMock( Language::class ),
 			$this->createKeyEchoLocalizer(),
-			$this->createMock( Title::class ),
 			$user,
 			$this->createMockTempUserConfig( false ),
 			[]
@@ -186,7 +180,6 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 			$this->createMock( UserGroupManager::class ),
 			$this->createMock( Language::class ),
 			$this->createKeyEchoLocalizer(),
-			$this->createMock( Title::class ),
 			$user,
 			$this->createMockTempUserConfig( true ),
 			[]

--- a/tests/phpunit/Unit/Components/CitizenComponentUserInfoTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentUserInfoTest.php
@@ -80,10 +80,13 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 		$lang = $this->createMock( Language::class );
 		$localizer = $this->createMockLocalizer();
 
-		// Simulate MediaWiki's HTML output where O'Brien becomes O&#039;Brien
+		// Taken from real skin output: core wraps portlet link text in a span, so
+		// the username is never a direct text child of the anchor. A fixture without
+		// that span passes even when the replacement cannot fire.
 		$encodedUsername = htmlspecialchars( $username, ENT_QUOTES );
-		$htmlItems = '<li id="pt-userpage"><a href="/wiki/User:'
-			. $encodedUsername . '">' . $encodedUsername . '</a></li>';
+		$htmlItems = '<li id="pt-userpage-2" class="mw-list-item"><a href="/wiki/User:'
+			. $encodedUsername . '" class="new" accesskey="."><span>'
+			. $encodedUsername . '</span></a></li>';
 
 		$userPageData = [
 			'html-items' => $htmlItems,
@@ -109,6 +112,69 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 	}
 
 	/**
+	 * Realnames ships a same-name style, so real name equal to username is a
+	 * configuration people actually run. Printing both would repeat the word.
+	 *
+	 * @covers ::getTemplateData
+	 */
+	public function testRealNameMatchingUsernameIsNotDuplicated(): void {
+		$username = 'NotifTest';
+
+		$user = $this->createMockUser( $username, $username );
+		$userGroupManager = $this->createMock( UserGroupManager::class );
+		$userGroupManager->method( 'getUserGroups' )->willReturn( [] );
+
+		$htmlItems = '<li id="pt-userpage-2" class="mw-list-item">'
+			. '<a href="/wiki/User:' . $username . '" class="new" accesskey="."><span>'
+			. $username . '</span></a></li>';
+
+		$component = new CitizenComponentUserInfo(
+			$userGroupManager,
+			$this->createMock( Language::class ),
+			$this->createMockLocalizer(),
+			$user,
+			$this->createMockTempUserConfig( false ),
+			[ 'html-items' => $htmlItems ]
+		);
+
+		$data = $component->getTemplateData();
+
+		$this->assertSame( $htmlItems, $data['data-user-page']['html-items'] );
+	}
+
+	/**
+	 * Extension:Realnames rewrites the portlet text before Citizen sees it, so the
+	 * username is no longer present verbatim and the replacement must not fire.
+	 *
+	 * @covers ::getTemplateData
+	 */
+	public function testRealNamesExtensionOutputIsLeftAlone(): void {
+		$username = 'NotifTest';
+
+		$user = $this->createMockUser( $username, 'Test Person' );
+		$userGroupManager = $this->createMock( UserGroupManager::class );
+		$userGroupManager->method( 'getUserGroups' )->willReturn( [] );
+
+		// Exactly what Realnames' paren-reverse style leaves in data-portlets.
+		$htmlItems = '<li id="pt-userpage-2" class="mw-list-item">'
+			. '<a href="/wiki/User:' . $username . '" class="new" accesskey=".">'
+			. '<span>Test Person (' . $username . ')</span></a></li>';
+
+		$component = new CitizenComponentUserInfo(
+			$userGroupManager,
+			$this->createMock( Language::class ),
+			$this->createMockLocalizer(),
+			$user,
+			$this->createMockTempUserConfig( false ),
+			[ 'html-items' => $htmlItems ]
+		);
+
+		$data = $component->getTemplateData();
+
+		$this->assertSame( $htmlItems, $data['data-user-page']['html-items'] );
+	}
+
+	/**
 	 * @covers ::getTemplateData
 	 */
 	public function testGetTemplateDataWithNoRealName(): void {
@@ -122,8 +188,9 @@ class CitizenComponentUserInfoTest extends MediaWikiUnitTestCase {
 		$localizer = $this->createMockLocalizer();
 
 		$encodedUsername = htmlspecialchars( $username, ENT_QUOTES );
-		$htmlItems = '<li id="pt-userpage"><a href="/wiki/User:'
-			. $encodedUsername . '">' . $encodedUsername . '</a></li>';
+		$htmlItems = '<li id="pt-userpage-2" class="mw-list-item"><a href="/wiki/User:'
+			. $encodedUsername . '" class="new" accesskey="."><span>'
+			. $encodedUsername . '</span></a></li>';
 
 		$userPageData = [
 			'html-items' => $htmlItems,

--- a/tests/phpunit/integration/Components/CitizenComponentUserInfoGroupsTest.php
+++ b/tests/phpunit/integration/Components/CitizenComponentUserInfoGroupsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Skins\Citizen\Tests\Integration\Components;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Skins\Citizen\Components\CitizenComponentUserInfo;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * Group links resolve through UserGroupMembership::getGroupPage(), which reads
+ * grouppage-<group> via wfMessage(), so these need real services rather than a
+ * unit-test double.
+ *
+ * @group Citizen
+ * @group Components
+ * @group Database
+ * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentUserInfo
+ */
+class CitizenComponentUserInfoGroupsTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * @param string[] $groups
+	 * @param string $langCode Interface language the component renders labels in
+	 */
+	private function buildGroupItems( array $groups, string $langCode = 'en' ): array {
+		$user = $this->getMutableTestUser( $groups )->getUser();
+
+		$component = new CitizenComponentUserInfo(
+			$this->getServiceContainer()->getUserGroupManager(),
+			$this->getServiceContainer()->getLanguageFactory()->getLanguage( $langCode ),
+			RequestContext::getMain(),
+			$user,
+			$this->getServiceContainer()->getTempUserConfig(),
+			[ 'html-items' => '' ]
+		);
+
+		$data = $component->getTemplateData();
+
+		return $data['data-user-groups']['array-list-items'] ?? [];
+	}
+
+	public function testGroupWithGroupPageMessageLinksToIt(): void {
+		$items = $this->buildGroupItems( [ 'sysop' ] );
+
+		$this->assertCount( 1, $items );
+		$item = $items[0];
+
+		$this->assertSame( 'group-sysop-member', $item['item-id'] );
+		$this->assertSame( 'citizen-userInfo-usergroup', $item['item-class'] );
+		$this->assertNotNull( $item['array-links'], 'sysop has a grouppage message, so it must link' );
+		$this->assertSame( '', $item['text'], 'a linked group carries no plain-text fallback' );
+		$this->assertStringContainsString(
+			'Administrators',
+			$item['array-links']['href'],
+			'target comes from grouppage-sysop, not the singular member name'
+		);
+		$this->assertSame( 'Administrator', $item['array-links']['text'] );
+	}
+
+	public function testGroupWithoutGroupPageMessageRendersAsPlainText(): void {
+		$items = $this->buildGroupItems( [ 'citizen-test-nogrouppage' ] );
+
+		$this->assertCount( 1, $items );
+		$item = $items[0];
+
+		$this->assertNull( $item['array-links'], 'no grouppage message means no link' );
+		$this->assertNotSame( '', $item['text'], 'the name still has to be shown' );
+	}
+
+	/**
+	 * The bug this component had: the target was derived from the translated
+	 * member name, so it moved with the interface language. Label and target must
+	 * come from different languages — interface for one, content for the other.
+	 */
+	public function testInterfaceLanguageMovesTheLabelButNotTheTarget(): void {
+		$items = $this->buildGroupItems( [ 'interface-admin' ], 'de' );
+		$link = $items[0]['array-links'];
+
+		$this->assertSame(
+			'Oberflächenadministrator',
+			$link['text'],
+			'label follows the interface language'
+		);
+		$this->assertStringContainsString(
+			'Interface_administrators',
+			$link['href'],
+			'target stays on the content-language grouppage message'
+		);
+		$this->assertStringNotContainsString( 'Oberfl', $link['href'] );
+	}
+
+	public function testNoGroupsProducesNoSection(): void {
+		$this->assertSame( [], $this->buildGroupItems( [] ) );
+	}
+}


### PR DESCRIPTION
## Problem

Three defects in the user info panel at the top of the user menu, all long-standing.

**User group links point at the wrong page.** The target was built from `group-<group>-member` — the name of a *person*, resolved in the *interface* language — and forced into `NS_PROJECT`. MediaWiki has a dedicated message for this, `grouppage-<group>`, resolved in the *content* language, which is what `Special:Preferences` uses. On a default English wiki this already pointed somewhere wrong: `group-sysop-member` is "administrator", so the link went to `Project:Administrator`, while `grouppage-sysop` is `Project:Administrators`. Changing the interface language moved it further off, and a wiki whose group pages live outside the project namespace was never reachable.

Two defects sat in the same block. The label was requested without a username, so `{{GENDER:$1|…}}` collapsed to its default form for everyone. And it was capitalised with PHP's byte-based `ucfirst()` rather than the language object's.

**Real name display has never worked.** `replaceUsernameWithRealName()` looked for the username as a *direct* text child of the anchor, but the server wraps portlet link text in a `<span>`, so it never matched. `#pt-userpage-realname` and `#pt-userpage-username` were never emitted, and the CSS targeting them — including the flex layout written specifically to lay the two names out — was dead. Setting a real name in preferences changed nothing.

**The group list had no delimiter.** Names ran together as "BotInterface administrator", and none of them read as links: `.citizen-userInfo-usergroups a` outranks Codex's link rules, which are wrapped in `:where()` and so carry zero specificity.

## Behaviour

- Group links resolve through `grouppage-<group>` in the content language, so the target no longer moves with the interface language.
- Groups whose `grouppage-<group>` message does not exist render as plain text instead of linking to a page that cannot exist, matching Preferences.
- Group labels resolve GENDER and use language-aware capitalisation.
- A user with a real name set sees it as the heading, with the username beneath it, smaller and subdued.
- Groups render as an inline list rather than a row of chips. Boxes do not survive volume: an account in eight groups took six rows and widened the dropdown from 256px to 457px, because the menu is sized by its content. The same eight now take two rows, and the list is capped so it wraps rather than stretching the card.
- The registration date is labelled "Member since" rather than "Joined".

## Contract

- **No compat slice needed.** No class or ID is renamed or removed, and no server-rendered markup is restructured in a way that breaks old cached HTML against new CSS. The `<li>` shape and the template's `{{text}}` slot already existed; the real-name spans and their CSS also already existed and were simply inert. This activates dead capacity rather than changing live markup.
- **No new queries.** Page-existence checks were considered and rejected: `Special:Preferences` red-links a missing group page, but the container rule suppresses red here at rest, on hover and when visited, so a red link would be invisible while costing a lookup per group per page view for group members.
- `CitizenComponentMenuListItem` takes a nullable link. Single call site, and the new `$text` parameter defaults to `''`.
- `Extension:Realnames` rewrites the portlet text before this component sees it, so the real-name replacement correctly no-ops and Realnames' own formatting wins. Covered by a test.

## Verification

- PHPUnit 278/278, PHPCS 64/64, stylelint and banana clean.
- New integration tests cover the group path, which had none: linked and unlinked groups, and the label/target language split that was the original bug. They need to be integration tests because `getGroupPage()` resolves through `wfMessage()`.
- The real-name test fixture now uses real skin output; the previous hand-written fixture passed even with the bug present, which is why this went unnoticed.
- Checked in a browser against eight groups, mixed linked and unlinked, and against an account with no real name.

## Follow-ups (not in this PR)

- Unlinked groups are distinguished from linked ones by colour alone. Acceptable inline, but a non-colour cue would be better.
- `.mixin-citizen-font-styles()` silently compiles to nothing when passed a type it has no guard for. No current call site does, but nothing catches it if one does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profiles now display “Member since” for account creation dates.
  * User groups link to their information pages when available and display as plain text otherwise.
  * Improved handling of usernames and real names, including nested formatting.
* **Style**
  * Updated profile identity and group layouts for clearer alignment, wrapping, and readability.
* **Bug Fixes**
  * Prevented duplicate display when a user’s real name matches their username.
  * Preserved compatibility with existing real-name extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->