### PR TITLE
docs(showcase): 📚️ add Wikven Static Site Generator

### DIFF
--- a/docs/src/community/showcase.md
+++ b/docs/src/community/showcase.md
@@ -30,4 +30,5 @@ Check out these amazing wikis powering their content with Citizen:
  <LinkCard title="CapoeiiraWiki" href="https://capoeirawiki.org" />
  <LinkCard title="The Petit Planet Wiki" href="https://petitplanet.wiki" />
  <LinkCard title="Pleasant Goat Wiki" href="https://xyy.miraheze.org" />
+ <LinkCard title="Wikven Static Site Generator" href="https://chaotic-ground.github.io/wikven/citizen/index.html" />
 </LinkGrid>


### PR DESCRIPTION
- https://chaotic-ground.github.io/wikven/citizen/index.html
- https://chaotic-ground.github.io/wikven/citizen/Skins.html#Supported_skins

If `Wikven Static Site Generator` is too long, feel free to shorten it as `Wikven`.

Caveat: Wikven has not yet released its stable version (v1), so the URL would be changed in the future.

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Wikven Static Site Generator to the Citizen project showcase, including a link to its project page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->