### PR TITLE
fix(sections): hold section content in its own element

### DIFF
--- a/includes/Components/CitizenComponentBodyContent.php
+++ b/includes/Components/CitizenComponentBodyContent.php
@@ -31,6 +31,24 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	public const SECTION_CLASS = 'citizen-section';
 
 	/**
+	 * Class name for the element holding everything after a section's heading.
+	 * Collapsing hides this rather than each content child, so that the box
+	 * carrying `hidden` is one the skin owns rather than arbitrary wiki markup.
+	 *
+	 * It must stay a bare block box. Padding, borders and backgrounds paint
+	 * through a collapse; `overflow`, `contain`, `display` and `position` can
+	 * trap the section's floats; and blocking the margin that collapses out of
+	 * it detaches a leading float from the text it sits beside.
+	 */
+	public const SECTION_BODY_CLASS = 'citizen-section-body';
+
+	/**
+	 * Class marking a section's heading. Kept in step with the frontend's own
+	 * heading selector, which also accepts core's `mw-heading`.
+	 */
+	public const SECTION_HEADING_CLASS = 'citizen-section-heading';
+
+	/**
 	 * Sentinel nesting level for the lead section: no heading level nests
 	 * beneath it, matching Parsoid's lead section semantics.
 	 */
@@ -54,7 +72,8 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	 * starts a <section> that contains the heading and everything up to the
 	 * next heading of equal or higher rank; lower-ranked headings nest their
 	 * sections inside the current one. Content before the first heading goes
-	 * into a headingless lead section.
+	 * into a headingless lead section, which needs no body wrapper because
+	 * nothing can collapse it.
 	 */
 	private function makeSections( Document $doc ): Document {
 		$container = DOMCompat::querySelector( $doc, 'div.mw-parser-output' );
@@ -65,35 +84,37 @@ class CitizenComponentBodyContent implements CitizenComponent {
 
 		$sectionNumber = 0;
 		$currentLevel = self::LEAD_SECTION_LEVEL;
-		$currentSection = $this->createSectionBodyElement( $doc, $sectionNumber );
-		$container->insertBefore( $currentSection, $container->firstChild );
+		$leadSection = $this->createSection( $doc, $sectionNumber );
+		$container->insertBefore( $leadSection, $container->firstChild );
+		$currentBody = $leadSection;
 
-		/** @var array<array{0: int, 1: Element}> Open ancestor sections */
+		/** @var array<array{0: int, 1: Element}> Bodies of the open ancestor sections */
 		$stack = [];
 
 		// The lead section is the container's first child now; walk what follows it
-		$currentNode = $currentSection->nextSibling;
+		$currentNode = $leadSection->nextSibling;
 		while ( $currentNode ) {
 			$nextNode = $currentNode->nextSibling;
 
 			// @phan-suppress-next-line PhanTypeMismatchArgument DOMNode is a Parsoid DOM\Node alias
 			$level = $this->getSectionHeadingLevel( $currentNode );
 			if ( $level === null ) {
-				$currentSection->appendChild( $currentNode );
+				$currentBody->appendChild( $currentNode );
 			} else {
 				// Pop ancestors that cannot contain a section of this rank
 				while ( $stack && end( $stack )[0] >= $level ) {
 					array_pop( $stack );
 				}
 				if ( $currentLevel < $level ) {
-					$stack[] = [ $currentLevel, $currentSection ];
+					$stack[] = [ $currentLevel, $currentBody ];
 				}
 
 				$sectionNumber++;
-				$newSection = $this->createSectionBodyElement( $doc, $sectionNumber );
-				$parent = $stack ? end( $stack )[1] : null;
-				if ( $parent ) {
-					$parent->appendChild( $newSection );
+				$newSection = $this->createSection( $doc, $sectionNumber );
+				// Subsections are content, so they collapse with the parent.
+				$parentBody = $stack ? end( $stack )[1] : null;
+				if ( $parentBody ) {
+					$parentBody->appendChild( $newSection );
 				} else {
 					$container->insertBefore( $newSection, $currentNode );
 				}
@@ -103,14 +124,68 @@ class CitizenComponentBodyContent implements CitizenComponent {
 					$this->prepareHeading( $currentNode );
 				}
 
+				$currentBody = $this->createSectionBody( $doc );
+				$newSection->appendChild( $currentBody );
+
 				$currentLevel = $level;
-				$currentSection = $newSection;
 			}
 
 			$currentNode = $nextNode;
 		}
 
 		return $doc;
+	}
+
+	/**
+	 * Give every native Parsoid section the body wrapper the legacy transform
+	 * builds, so both parsers collapse through the same element.
+	 *
+	 * A section only gets one when the frontend can collapse it, which needs a
+	 * heading it recognises. The lead section has none, and core leaves
+	 * HTML-syntax headings unwrapped (T353489), so both are left alone.
+	 */
+	private function wrapSectionBodies( Document $doc ): void {
+		foreach ( DOMCompat::querySelectorAll( $doc, 'section[data-mw-section-id]' ) as $section ) {
+			$heading = $this->getFirstElementChild( $section );
+			if ( $heading === null || !$this->isSectionHeading( $heading ) ) {
+				continue;
+			}
+
+			// A wrapper from another pipeline is wrapped in turn rather than
+			// adopted, so the collapse target is always skin-owned.
+			$existing = DOMCompat::getNextElementSibling( $heading );
+			if ( $existing !== null
+				&& DOMCompat::getClassList( $existing )->contains( self::SECTION_BODY_CLASS )
+			) {
+				continue;
+			}
+
+			$body = $this->createSectionBody( $doc );
+			while ( $heading->nextSibling !== null ) {
+				$body->appendChild( $heading->nextSibling );
+			}
+			$section->appendChild( $body );
+		}
+	}
+
+	/**
+	 * Whether the frontend will treat this element as a section heading.
+	 */
+	private function isSectionHeading( Element $element ): bool {
+		$classes = DOMCompat::getClassList( $element );
+		return $classes->contains( 'mw-heading' )
+			|| $classes->contains( self::SECTION_HEADING_CLASS );
+	}
+
+	/**
+	 * DOMCompat has getLastElementChild but no first-child equivalent.
+	 */
+	private function getFirstElementChild( Element $element ): ?Element {
+		$node = $element->firstChild;
+		while ( $node !== null && !( $node instanceof Element ) ) {
+			$node = $node->nextSibling;
+		}
+		return $node;
 	}
 
 	/**
@@ -149,19 +224,30 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	 * ::before, the same way native Parsoid sections are styled.
 	 */
 	private function prepareHeading( Element $heading ): void {
-		DOMCompat::getClassList( $heading )->add( 'citizen-section-heading' );
+		DOMCompat::getClassList( $heading )->add( self::SECTION_HEADING_CLASS );
 	}
 
 	/**
-	 * Creates a Section body element
+	 * Creates a section element, which holds a heading and a body
 	 */
-	private function createSectionBodyElement( Document $doc, int $sectionNumber ): Element {
-		$sectionBody = $doc->createElement( 'section' );
-		$sectionBody->setAttribute( 'id', 'citizen-section-' . $sectionNumber );
-		$sectionBody->setAttribute( 'class', self::SECTION_CLASS );
+	private function createSection( Document $doc, int $sectionNumber ): Element {
+		$section = $doc->createElement( 'section' );
+		$section->setAttribute( 'id', 'citizen-section-' . $sectionNumber );
+		$section->setAttribute( 'class', self::SECTION_CLASS );
 
 		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType DOMElement is a Parsoid DOM\Element alias
-		return $sectionBody;
+		return $section;
+	}
+
+	/**
+	 * Creates the element holding everything after a section's heading
+	 */
+	private function createSectionBody( Document $doc ): Element {
+		$body = $doc->createElement( 'div' );
+		$body->setAttribute( 'class', self::SECTION_BODY_CLASS );
+
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType DOMElement is a Parsoid DOM\Element alias
+		return $body;
 	}
 
 	/**
@@ -180,17 +266,23 @@ class CitizenComponentBodyContent implements CitizenComponent {
 	public function getTemplateData(): array {
 		$html = $this->html;
 
-		// Parsoid content already ships section wrappers; the heading walk
-		// below expects headings as direct children of the parser output and
-		// would fold the whole page into a single section.
-		if ( $this->shouldMakeSections && !$this->isParsoidContent( $html ) ) {
-			$doc = DOMUtils::parseHTML( $html );
+		if ( !$this->shouldMakeSections ) {
+			return [ 'html-body-content' => $html ];
+		}
+
+		$doc = DOMUtils::parseHTML( $html );
+
+		// Parsoid already ships the section wrappers, so it only needs the
+		// bodies adding. The heading walk expects headings as direct children
+		// of the parser output and would fold such a page into one section.
+		if ( $this->isParsoidContent( $html ) ) {
+			$this->wrapSectionBodies( $doc );
+		} else {
 			$this->makeSections( $doc );
-			$html = DOMCompat::getInnerHTML( DOMCompat::getBody( $doc ) );
 		}
 
 		return [
-			'html-body-content' => $html,
+			'html-body-content' => DOMCompat::getInnerHTML( DOMCompat::getBody( $doc ) ),
 		];
 	}
 }

--- a/resources/compat/3.22.less
+++ b/resources/compat/3.22.less
@@ -1,0 +1,28 @@
+@import ( reference ) '../variables.less';
+@import ( reference ) '../mixins.less';
+
+@media screen {
+	// The marker lists the slices that existed when the page was rendered, so
+	// older HTML lacks this token — or the attribute entirely, this being the
+	// first slice.
+	html:not( [ data-mw-citizen-html~='3.22' ] ) {
+		// Section content moved into `.citizen-section-body` (PR #1809). Older
+		// HTML sets `hidden` on wiki content, where containment empties the box
+		// of its contents and nothing else — a specified size, margin, padding,
+		// border, outline and shadow all survive as a hollow strip under the
+		// heading. Gated because this matches the new wrapper too, which has to
+		// keep collapsing its first child's margin out through itself, and
+		// `margin: 0` would disturb that. `&` because `.client-js` is on the
+		// same element as the marker.
+		&.client-js .citizen-sections-enabled section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > [ hidden='until-found' ] {
+			block-size: 0;
+			min-block-size: 0;
+			padding: 0;
+			margin: 0;
+			outline: 0;
+			background: none;
+			border: 0;
+			box-shadow: none;
+		}
+	}
+}

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -148,8 +148,27 @@ section[ data-mw-section-id ] > .mw-heading,
 	// canonically cased by the time these rules can match.
 	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > [ hidden='until-found' ] {
 		display: block;
-		// A size-contained box is zero-height but keeps its margins, which
-		// would stack the whole section's dead space under the heading.
-		margin-block: 0;
+		// Both specs that define this state say the box carrying it must be
+		// empty — containment skips the contents and nothing else, so a
+		// specified size still reserves space and the margin, padding,
+		// border, outline and shadow still draw. That holds when the
+		// attribute goes on a wrapper the author owns. Here it lands on
+		// whatever wiki content the section happens to start with, and a
+		// child styled as a card — hatnote, navbox, table — outlives the
+		// collapse as a hollow strip under the heading. So the box is
+		// flattened by force: every property that reserves space, then every
+		// one that paints. Author `!important` and inline sizes still win;
+		// closing that needs the attribute to move onto a section body
+		// wrapper the skin owns, rather than onto wiki content.
+		// `all: revert` is not the tidy shortcut for this — it reverts the
+		// UA's own `content-visibility` and unhides the whole section.
+		block-size: 0;
+		min-block-size: 0;
+		padding: 0;
+		margin: 0;
+		outline: 0;
+		background: none;
+		border: 0;
+		box-shadow: none;
 	}
 }

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -148,27 +148,5 @@ section[ data-mw-section-id ] > .mw-heading,
 	// canonically cased by the time these rules can match.
 	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > [ hidden='until-found' ] {
 		display: block;
-		// Both specs that define this state say the box carrying it must be
-		// empty — containment skips the contents and nothing else, so a
-		// specified size still reserves space and the margin, padding,
-		// border, outline and shadow still draw. That holds when the
-		// attribute goes on a wrapper the author owns. Here it lands on
-		// whatever wiki content the section happens to start with, and a
-		// child styled as a card — hatnote, navbox, table — outlives the
-		// collapse as a hollow strip under the heading. So the box is
-		// flattened by force: every property that reserves space, then every
-		// one that paints. Author `!important` and inline sizes still win;
-		// closing that needs the attribute to move onto a section body
-		// wrapper the skin owns, rather than onto wiki content.
-		// `all: revert` is not the tidy shortcut for this — it reverts the
-		// UA's own `content-visibility` and unhides the whole section.
-		block-size: 0;
-		min-block-size: 0;
-		padding: 0;
-		margin: 0;
-		outline: 0;
-		background: none;
-		border: 0;
-		box-shadow: none;
 	}
 }

--- a/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
+++ b/tests/phpunit/Unit/Components/CitizenComponentBodyContentTest.php
@@ -8,13 +8,12 @@ use MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent;
 use MediaWikiIntegrationTestCase;
 
 /**
- * @coversDefaultClass \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent
  * @group Citizen
  */
 class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 
 	/**
-	 * @covers ::getTemplateData
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::getTemplateData
 	 */
 	public function testSectioningDisabled() {
 		$html = '<h2>Foo</h2><p>Bar</p>';
@@ -27,11 +26,15 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 
 	/**
 	 * @dataProvider provideSectioningCases
-	 * @covers ::createSectionBodyElement
-	 * @covers ::getSectionHeadingLevel
-	 * @covers ::getTemplateData
-	 * @covers ::makeSections
-	 * @covers ::prepareHeading
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::createSection
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::createSectionBody
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::getFirstElementChild
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::getSectionHeadingLevel
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::isSectionHeading
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::getTemplateData
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::makeSections
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::prepareHeading
+	 * @covers \MediaWiki\Skins\Citizen\Components\CitizenComponentBodyContent::wrapSectionBodies
 	 */
 	public function testSectioning( string $message, string $inputHtml, string $expectedHtml ): void {
 		$component = new CitizenComponentBodyContent( $inputHtml, true );
@@ -48,19 +51,22 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
 			'<section id="citizen-section-1" class="citizen-section">' .
-			'<h2 class="citizen-section-heading">Foo</h2><p>Bar</p></section>' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
+			'<div class="citizen-section-body"><p>Bar</p></div></section>' .
 			'<section id="citizen-section-2" class="citizen-section">' .
-			'<h2 class="citizen-section-heading">Baz</h2><p>Quux</p></section>' .
+			'<h2 class="citizen-section-heading">Baz</h2>' .
+			'<div class="citizen-section-body"><p>Quux</p></div></section>' .
 			'</div>'
 		];
 
 		yield 'Content before first heading' => [
-			'Content before first heading',
+			'Nothing can collapse the lead section, so its content stays unwrapped',
 			'<div class="mw-parser-output"><p>Lead content.</p><h2>Foo</h2><p>Bar</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"><p>Lead content.</p></section>' .
 			'<section id="citizen-section-1" class="citizen-section">' .
-			'<h2 class="citizen-section-heading">Foo</h2><p>Bar</p></section>' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
+			'<div class="citizen-section-body"><p>Bar</p></div></section>' .
 			'</div>'
 		];
 
@@ -72,13 +78,25 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'</div>'
 		];
 
+		yield 'Section with no content still gets a body' => [
+			'A body with nothing in it keeps the shape uniform for the frontend',
+			'<div class="mw-parser-output"><h2>Foo</h2></div>',
+			'<div class="mw-parser-output">' .
+			'<section id="citizen-section-0" class="citizen-section"></section>' .
+			'<section id="citizen-section-1" class="citizen-section">' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
+			'<div class="citizen-section-body"></div></section>' .
+			'</div>'
+		];
+
 		yield 'mw-heading wrapper' => [
 			'mw-heading wrapper',
 			'<div class="mw-parser-output"><div class="mw-heading"><h2>Foo</h2></div><p>Bar</p></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
 			'<section id="citizen-section-1" class="citizen-section">' .
-			'<div class="mw-heading citizen-section-heading"><h2>Foo</h2></div><p>Bar</p></section>' .
+			'<div class="mw-heading citizen-section-heading"><h2>Foo</h2></div>' .
+			'<div class="citizen-section-body"><p>Bar</p></div></section>' .
 			'</div>'
 		];
 
@@ -92,22 +110,26 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<section id="citizen-section-0" class="citizen-section">' .
 			'<div class="toctitle"><h2>Contents</h2></div></section>' .
 			'<section id="citizen-section-1" class="citizen-section">' .
-			'<h2 class="citizen-section-heading">Real Heading</h2><p>Content</p></section>' .
+			'<h2 class="citizen-section-heading">Real Heading</h2>' .
+			'<div class="citizen-section-body"><p>Content</p></div></section>' .
 			'</div>'
 		];
 
 		yield 'Subsections nest like Parsoid' => [
-			'An h3 inside an h2 section nests; the next h2 pops back to the top level',
+			'A subsection is content of its parent, so it sits inside the parent body',
 			'<div class="mw-parser-output"><h2>Foo</h2><h3>Sub</h3><p>Bar</p><h2>Baz</h2></div>',
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
 			'<section id="citizen-section-1" class="citizen-section">' .
 			'<h2 class="citizen-section-heading">Foo</h2>' .
+			'<div class="citizen-section-body">' .
 			'<section id="citizen-section-2" class="citizen-section">' .
-			'<h3 class="citizen-section-heading">Sub</h3><p>Bar</p></section>' .
-			'</section>' .
+			'<h3 class="citizen-section-heading">Sub</h3>' .
+			'<div class="citizen-section-body"><p>Bar</p></div></section>' .
+			'</div></section>' .
 			'<section id="citizen-section-3" class="citizen-section">' .
-			'<h2 class="citizen-section-heading">Baz</h2></section>' .
+			'<h2 class="citizen-section-heading">Baz</h2>' .
+			'<div class="citizen-section-body"></div></section>' .
 			'</div>'
 		];
 
@@ -117,9 +139,11 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output">' .
 			'<section id="citizen-section-0" class="citizen-section"></section>' .
 			'<section id="citizen-section-1" class="citizen-section">' .
-			'<h3 class="citizen-section-heading">Deep first</h3><p>A</p></section>' .
+			'<h3 class="citizen-section-heading">Deep first</h3>' .
+			'<div class="citizen-section-body"><p>A</p></div></section>' .
 			'<section id="citizen-section-2" class="citizen-section">' .
-			'<h2 class="citizen-section-heading">Top</h2><p>B</p></section>' .
+			'<h2 class="citizen-section-heading">Top</h2>' .
+			'<div class="citizen-section-body"><p>B</p></div></section>' .
 			'</div>'
 		];
 
@@ -140,12 +164,13 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			// The serializer normalizes &gt; to a bare > in text content
 			'<pre>&lt;section data-mw-section-id="1"></pre></section>' .
 			'<section id="citizen-section-1" class="citizen-section">' .
-			'<h2 class="citizen-section-heading">Foo</h2><p>Bar</p></section>' .
+			'<h2 class="citizen-section-heading">Foo</h2>' .
+			'<div class="citizen-section-body"><p>Bar</p></div></section>' .
 			'</div>'
 		];
 
-		yield 'Parsoid content is left untouched' => [
-			'Parsoid wraps sections natively; the transform must not run',
+		yield 'Parsoid sections gain a body' => [
+			'Parsoid ships the section wrappers, so only the bodies are added',
 			'<div class="mw-parser-output">' .
 			'<section data-mw-section-id="0" id="mwAQ"><p>Lead</p></section>' .
 			'<section data-mw-section-id="1" id="mwAg">' .
@@ -155,8 +180,89 @@ class CitizenComponentBodyContentTest extends MediaWikiIntegrationTestCase {
 			'<div class="mw-parser-output">' .
 			'<section data-mw-section-id="0" id="mwAQ"><p>Lead</p></section>' .
 			'<section data-mw-section-id="1" id="mwAg">' .
-			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div><p>Bar</p>' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div>' .
+			'<div class="citizen-section-body"><p>Bar</p></div>' .
 			'</section>' .
+			'</div>'
+		];
+
+		yield 'A heading the frontend cannot collapse gets no body' => [
+			'Core leaves HTML-syntax headings unwrapped, so the section stays as it is',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<h2 id="Foo" class="mw-html-heading">Foo</h2><p>Bar</p>' .
+			'</section>' .
+			'</div>',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<h2 id="Foo" class="mw-html-heading">Foo</h2><p>Bar</p>' .
+			'</section>' .
+			'</div>'
+		];
+
+		yield 'Parsoid subsections nest inside the parent body' => [
+			'A nested section moves into its parent body along with the rest of the content',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div><p>Bar</p>' .
+			'<section data-mw-section-id="2">' .
+			'<div class="mw-heading mw-heading3"><h3 id="Sub">Sub</h3></div><p>Baz</p>' .
+			'</section>' .
+			'</section>' .
+			'</div>',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div>' .
+			'<div class="citizen-section-body"><p>Bar</p>' .
+			'<section data-mw-section-id="2">' .
+			'<div class="mw-heading mw-heading3"><h3 id="Sub">Sub</h3></div>' .
+			'<div class="citizen-section-body"><p>Baz</p></div>' .
+			'</section>' .
+			'</div>' .
+			'</section>' .
+			'</div>'
+		];
+
+		yield "A foreign wrapper is wrapped in turn, not adopted" => [
+			'Adopting it would put the collapse attribute on a box the skin does not own',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div>' .
+			'<div class="mw-collapsible-content"><p>Bar</p></div>' .
+			'</section>' .
+			'</div>',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div>' .
+			'<div class="citizen-section-body">' .
+			'<div class="mw-collapsible-content"><p>Bar</p></div></div>' .
+			'</section>' .
+			'</div>'
+		];
+
+		yield 'Wrapping is idempotent' => [
+			'A section that already has its body is left alone',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div>' .
+			'<div class="citizen-section-body"><p>Bar</p></div>' .
+			'</section>' .
+			'</div>',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1">' .
+			'<div class="mw-heading mw-heading2"><h2 id="Foo">Foo</h2></div>' .
+			'<div class="citizen-section-body"><p>Bar</p></div>' .
+			'</section>' .
+			'</div>'
+		];
+
+		yield 'A Parsoid section without a heading is left alone' => [
+			'Core leaves HTML-syntax headings unwrapped, and those sections cannot collapse',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1"><p>No heading here</p></section>' .
+			'</div>',
+			'<div class="mw-parser-output">' .
+			'<section data-mw-section-id="1"><p>No heading here</p></section>' .
 			'</div>'
 		];
 	}

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -95,6 +95,73 @@ describe( 'createSections', () => {
 		} );
 	} );
 
+	describe( 'sections with a body wrapper', () => {
+		const WRAPPED = `
+			<div class="mw-parser-output">
+				<section id="citizen-section-0" class="citizen-section"><p>Lead</p></section>
+				<section id="citizen-section-1" class="citizen-section">
+					<div class="mw-heading citizen-section-heading"><h2 id="Foo">Foo</h2></div>
+					<div class="citizen-section-body">
+						<p>Bar</p>
+						<section id="citizen-section-2" class="citizen-section">
+							<h3 class="citizen-section-heading" id="Sub">Sub</h3>
+							<div class="citizen-section-body"><p>Nested</p></div>
+						</section>
+					</div>
+				</section>
+			</div>
+		`;
+
+		it( 'should hide the body wrapper and nothing else', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const section = bodyContent.querySelector( '#citizen-section-1' );
+			const heading = section.querySelector( ':scope > .mw-heading' );
+			const body = section.querySelector( ':scope > .citizen-section-body' );
+
+			click( heading );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+			expect( body.hidden ).toBeTruthy();
+			expect( heading.hidden ).toBeFalsy();
+			// The content itself is untouched, which is the whole point: only a
+			// skin-owned box carries the attribute, so no wiki styling leaks out.
+			expect( body.querySelector( 'p' ).hidden ).toBeFalsy();
+
+			click( heading );
+
+			expect( section.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+			expect( body.hidden ).toBeFalsy();
+		} );
+
+		it( 'should toggle a subsection independently of its parent', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const nested = bodyContent.querySelector( '#citizen-section-2' );
+			const nestedBody = nested.querySelector( ':scope > .citizen-section-body' );
+			const parentBody = bodyContent.querySelector( '#citizen-section-1 > .citizen-section-body' );
+
+			click( nested.querySelector( ':scope > h3' ) );
+
+			expect( nested.classList.contains( 'citizen-section--collapsed' ) ).toBe( true );
+			expect( nestedBody.hidden ).toBeTruthy();
+			expect( parentBody.hidden ).toBeFalsy();
+		} );
+
+		it( 'should expand the whole chain on a find-in-page match', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+			const parent = bodyContent.querySelector( '#citizen-section-1' );
+			const nested = bodyContent.querySelector( '#citizen-section-2' );
+
+			click( parent.querySelector( ':scope > .mw-heading' ) );
+			click( nested.querySelector( ':scope > h3' ) );
+			nested.querySelector( 'p' ).dispatchEvent( new Event( 'beforematch', { bubbles: true } ) );
+
+			expect( parent.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+			expect( nested.classList.contains( 'citizen-section--collapsed' ) ).toBe( false );
+			expect( parent.querySelector( ':scope > .citizen-section-body' ).hidden ).toBeFalsy();
+			expect( nested.querySelector( ':scope > .citizen-section-body' ).hidden ).toBeFalsy();
+		} );
+	} );
+
 	describe( 'parsoid sections (native markup)', () => {
 		const PARSOID = `
 			<div class="mw-parser-output">


### PR DESCRIPTION
## Problem

Collapsing a section left anything that drew its own box painted as a hollow strip under the heading — a hatnote kept its padding, border and background, cards and navboxes kept their border. Reported on [starcitizen.tools/Basher](https://starcitizen.tools/Basher), Paints section.

Collapsing sets `hidden="until-found"` on every non-heading child, and the UA renders that as `content-visibility: hidden`. Size containment empties a box of its *contents* and does nothing else, so a child's own padding, border, background, shadow and specified size all keep drawing. The children are wiki content, so the skin was neutralising boxes it does not own — which works until an author uses `!important` or an inline size, and neither can be beaten from a stylesheet.

## Behaviour

Everything after a section heading now sits in `<div class="citizen-section-body">`, and collapsing hides that one skin-owned element instead of N pieces of wiki content. Nothing on the wiki styles it, so there is nothing left to neutralise.

Both parsers converge on the shape. The legacy transform builds it; native Parsoid sections get it too, where previously the body content was passed through untouched and content children were hidden individually — so Parsoid pages get the fix as well.

The legacy transform emitted exactly this shape until sections gained their own headings in `bdf3af8b1`, when the `<section>` stopped being a body. This restores the hide target inside the newer semantics rather than reverting to the old markup, and matches the shape MediaWiki produces for collapsible sections.

## Contract

**Cache status: covered by compat.** `resources/compat/3.22.less` carries the box-neutralising declarations that pre-wrapper HTML still needs, gated on the generation marker so it cannot reach the new wrapper. This is the skin's first slice, so it also starts stamping `data-mw-citizen-html` — previously the framework was present but no marker was emitted, since the marker is derived from the slice directory.

Verified both directions against frozen pre-wrapper HTML with `$wgCitizenCompat` on: old markup collapses with no residue, and the new wrapper does not match the gated selector even though it *is* a collapsed `[hidden='until-found']` child. With the flag off the strip returns on old pages, which is the documented opt-in trade.

Two things wikis should know:

- **CSS keyed on section structure needs review.** Selectors matching a heading's adjacent sibling, or a section's first or nth child, now resolve against the wrapper. `bdf3af8b1` already asked for a similar review this cycle.
- **Parsoid pages pay a DOM round-trip they did not before** — roughly 8 ms for a 45 KB article, 19 ms at 113 KB, on pages where the skin previously did no DOM work at all. Legacy pages, already transformed, pay 1.5–2.5% more.

The wrapper must stay a bare block box — no padding, border, `overflow`, `contain`, `display`, `position`, `transform` or `filter`. Beyond keeping the collapse clean, that is what keeps a thumbnail written under a heading beside the text it illustrates: the first child's margin collapsing out through the wrapper is what puts the wrapper's top edge and the text's top edge on the same line. Blocking it pins the float to the heading instead, 11px above a paragraph and 29px above a subsection.

## Follow-ups

- Deleting the slice once the 6-release window passes; `npm run lint:compat` enforces it.
- Citizen's content spacing is symmetric (`--space-md` both sides) where upstream moved to 0.5em/1em in T366389. Adopting that would modernise the rhythm and shrink the heading-to-content margin collapse, but it touches every vertical margin and wants its own audit.

## Testing

- 284 PHPUnit assertions incl. 16 transform cases: both parsers, nested subsections, empty bodies, headingless and foreign-wrapper sections, idempotence; plus `CompatSliceCompileTest` over the new slice
- 1438 Vitest, with new cases for collapse, nested toggling and find-in-page reveal against the wrapped shape
- Browser: click, keyboard, `beforematch` chain unwinding, a11y tree, console clean; collapsed-state residue measured at zero; block-to-block spacing compared pair-by-pair against `main` on a content-rich page; slice verified against frozen pre-wrapper HTML in both gate directions
