### PR TITLE
Scale content and heading spacing to the reading text size

### DIFF
--- a/resources/skins.citizen.styles/common/common.less
+++ b/resources/skins.citizen.styles/common/common.less
@@ -69,7 +69,8 @@ textarea {
 }
 
 blockquote {
-	margin: var( --space-md );
+	margin-block: var( --space-content-unit );
+	margin-inline: var( --space-md );
 	color: var( --color-subtle );
 
 	cite {

--- a/resources/skins.citizen.styles/common/content.less
+++ b/resources/skins.citizen.styles/common/content.less
@@ -59,22 +59,11 @@
 
 // Heading HTML changes
 // See https://phabricator.wikimedia.org/T13555
-// TODO: Clean up heading spacing someday
-// TODO: This should go into one of the skinning files, revisit when we move to 1.43
+// Spacing lives beside the bare-heading ladder in skinning/elements.less; only
+// layout is left here.
 .mw-heading {
 	display: flex;
 	align-items: center;
-	margin-top: var( --space-md );
-
-	&1,
-	&2 {
-		margin-top: 3rem;
-	}
-
-	&3,
-	&4 {
-		margin-top: 2rem;
-	}
 
 	h1,
 	h2,
@@ -83,6 +72,5 @@
 	h5,
 	h6 {
 		flex-grow: 1;
-		margin: 0;
 	}
 }

--- a/resources/skins.citizen.styles/common/hacks.less
+++ b/resources/skins.citizen.styles/common/hacks.less
@@ -24,7 +24,7 @@ a.feedlink {
 
 div.tleft,
 div.tright {
-	margin: var( --space-xs ) 0 var( --space-md ) 0;
+	margin: var( --space-content-half ) 0 var( --space-content-unit ) 0;
 }
 
 @media ( min-width: @min-width-breakpoint-tablet ) {

--- a/resources/skins.citizen.styles/common/typography.less
+++ b/resources/skins.citizen.styles/common/typography.less
@@ -34,7 +34,7 @@ p:not( .mw-empty-elt ) {
 	+ table,
 	+ dl,
 	+ blockquote {
-		margin-top: calc( var( --space-xs ) * -1 );
+		margin-top: calc( var( --space-content-half ) * -1 );
 	}
 }
 

--- a/resources/skins.citizen.styles/components/OverflowElements.less
+++ b/resources/skins.citizen.styles/components/OverflowElements.less
@@ -26,7 +26,7 @@
 			// the `max-width` a bare `.wikitable` carries. Anything else
 			// opted in by hand is a plain block and stays full width.
 			max-width: max-content;
-			margin-block: var( --space-md );
+			margin-block: var( --space-content-unit );
 			margin-inline: var( --border-width-base ); // Fix clipping border
 			border-radius: var( --border-radius-medium );
 			box-shadow: var( --box-shadow-border );
@@ -42,7 +42,7 @@
 		// `.wikitable` is not in the list: the card rule above already gives
 		// the wrapper this margin.
 		&:has( .citizen-overflow-content > :is( ul, ol, dl, blockquote ) ) {
-			margin-block: var( --space-md );
+			margin-block: var( --space-content-unit );
 
 			// hacks.less zeroes the margins of a `floatleft`/`floatright`
 			// element, and that class migrates to the wrapper — so the zero
@@ -61,7 +61,7 @@
 		// below it, drops by that much the moment the script runs. Keep the
 		// element list in step with typography.less.
 		p:not( .mw-empty-elt ) + &:has( .citizen-overflow-content > :is( ul, ol, table, dl, blockquote ) ) {
-			margin-top: calc( var( --space-xs ) * -1 );
+			margin-top: calc( var( --space-content-half ) * -1 );
 		}
 
 		// Both spellings of a floated wrapper: `--float*` when the float was

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -116,6 +116,13 @@ section[ data-mw-section-id ] > .mw-heading,
 	}
 
 	section:is( [ data-mw-section-id ], .citizen-section ).citizen-section--collapsed > :is( .mw-heading, .citizen-section-heading ) {
+		// Nothing is left for this margin to separate the heading from, and it
+		// can no longer collapse away: hiding the body applies
+		// `content-visibility: hidden`, whose implied layout containment makes
+		// the body a formatting context, so whatever follows adds to this
+		// margin instead of merging with it.
+		margin-block-end: 0;
+
 		&::before,
 		> .citizen-section-toggle::before {
 			transform: rotate3d( 1, 0, 0, 180deg );

--- a/resources/skins.citizen.styles/skinning/content.media-common.less
+++ b/resources/skins.citizen.styles/skinning/content.media-common.less
@@ -33,7 +33,7 @@ figure[ typeof~='mw:File/Frameless' ] {
 figure[ typeof~='mw:File/Thumb' ],
 figure[ typeof~='mw:File/Frame' ] {
 	display: table;
-	margin: var( --space-xs ) auto var( --space-md ) auto;
+	margin: var( --space-content-half ) auto var( --space-content-unit ) auto;
 	text-align: center;
 	.mixin-citizen-font-styles( 'small' );
 

--- a/resources/skins.citizen.styles/skinning/content.tables.less
+++ b/resources/skins.citizen.styles/skinning/content.tables.less
@@ -10,7 +10,7 @@
 .wikitable {
 	display: block;
 	max-width: max-content; // Needed for the border
-	margin-block: var( --space-md );
+	margin-block: var( --space-content-unit );
 	// The border is a box-shadow, which paints outside the border box. The
 	// inline margin keeps it clear of an ancestor scroll container that
 	// would otherwise clip it, and keeps this box aligned with the wrapper

--- a/resources/skins.citizen.styles/skinning/elements.less
+++ b/resources/skins.citizen.styles/skinning/elements.less
@@ -19,30 +19,38 @@ hr {
 }
 
 /* Structural Elements */
+// Two heading markups are live on the same wiki — a bare `hN`, and MediaWiki's
+// `<div class="mw-heading mw-headingN">` wrapper (T13555) — so every gap is
+// spelled twice below and only the measure differs. A bare heading uses `em`,
+// safe because the skin pins its font-size, so a deliberate override still
+// scales its spacing to match. The wrapper is a plain div inheriting body text
+// size, so it names its heading's font token instead.
+.mixin-citizen-heading-space( @ratio, @font-size ) {
+	margin-block: calc( @ratio * @font-size ) calc( var( --heading-space-end ) * @font-size );
+}
+
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-	// It seems that many wikis have the expectation that headers have a bottom margin
-	margin-block-end: 0.25em;
 	color: var( --color-emphasized );
 }
 
 h1,
 h2 {
-	margin-block-start: 2em;
+	.mixin-citizen-heading-space( var( --heading-space-h1-h2 ), 1em );
 }
 
 h3,
 h4 {
-	margin-block-start: 1.5em;
+	.mixin-citizen-heading-space( var( --heading-space-h3-h4 ), 1em );
 }
 
 h5,
 h6 {
-	margin-block-start: 1.25em;
+	.mixin-citizen-heading-space( var( --heading-space-h5-h6 ), 1em );
 	font-size: var( --font-size-medium );
 	font-weight: var( --font-weight-semi-bold );
 }
@@ -61,6 +69,36 @@ h3 {
 
 h4 {
 	.mixin-citizen-font-styles( 'heading-4' );
+}
+
+// Only hand-written wikitext omits the level class, and nothing here can tell
+// which heading the wrapper holds, so it takes the smallest step. The levelled
+// rules share this specificity and must follow it.
+.mw-heading {
+	.mixin-citizen-heading-space( var( --heading-space-h5-h6 ), var( --font-size-medium ) );
+}
+
+.mw-heading1 {
+	.mixin-citizen-heading-space( var( --heading-space-h1-h2 ), var( --font-size-xxx-large ) );
+}
+
+.mw-heading2 {
+	.mixin-citizen-heading-space( var( --heading-space-h1-h2 ), var( --font-size-xx-large ) );
+}
+
+.mw-heading3 {
+	.mixin-citizen-heading-space( var( --heading-space-h3-h4 ), var( --font-size-x-large ) );
+}
+
+.mw-heading4 {
+	.mixin-citizen-heading-space( var( --heading-space-h3-h4 ), var( --font-size-large ) );
+}
+
+// The wrapper owns the spacing in every medium, so the heading inside it is
+// fully reset; that also neutralises any `hN` margin an extension or on-wiki
+// stylesheet lands inside the wrapper.
+.mw-heading :is( h1, h2, h3, h4, h5, h6 ) {
+	margin: 0;
 }
 
 p {

--- a/resources/skins.citizen.styles/skinning/elements.less
+++ b/resources/skins.citizen.styles/skinning/elements.less
@@ -13,7 +13,7 @@ img {
 }
 
 hr {
-	margin-block: var( --space-md );
+	margin-block: var( --space-content-unit );
 	border: 0;
 	border-top: var( --border-width-base ) solid var( --border-color-base );
 }
@@ -64,7 +64,7 @@ h4 {
 }
 
 p {
-	margin-block: var( --space-md );
+	margin-block: var( --space-content-unit );
 	overflow-wrap: break-word; // Force wrap to preserve layout
 }
 
@@ -75,7 +75,7 @@ p img {
 ol,
 ul {
 	padding: 0;
-	margin-block: var( --space-md );
+	margin-block: var( --space-content-unit );
 	margin-inline: var( --space-xxl ) 0;
 
 	ol,
@@ -90,7 +90,7 @@ dt {
 }
 
 dl {
-	margin-block: var( --space-md );
+	margin-block: var( --space-content-unit );
 }
 
 dd {

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -83,6 +83,14 @@
 	--space-xxl: calc( 2 * var( --space-unit ) );
 	.mixin-citizen-content-space( var( --space-md ) );
 
+	// Multiples of the heading's own font size. Both heading markups read these,
+	// so they cannot drift apart.
+	--heading-space-h1-h2: 2;
+	--heading-space-h3-h4: 1.5;
+	--heading-space-h5-h6: 1.25;
+	// Many wikis expect headings to carry a bottom margin.
+	--heading-space-end: 0.25;
+
 	// Transition
 	--transition-timing-function-ease: cubic-bezier( 0.2, 0, 0, 1 );
 	--transition-timing-function-ease-in: cubic-bezier( 0.3, 0, 0.8, 0.15 );

--- a/resources/skins.citizen.styles/tokens-citizen.less
+++ b/resources/skins.citizen.styles/tokens-citizen.less
@@ -7,6 +7,17 @@
  * TODO: Remove HSL fallback when OKLCH is supported in all browsers.
  * TODO: Use CSS relative color syntax when supported in all browsers.
  */
+
+// Spacing for wiki content, scaled to the reading text rather than the root.
+// Emitted at the root too: the consumers are bare element selectors that also
+// match chrome, where an undefined custom property would drop the declaration.
+// Not `em` — wikitext templates nest their own font-size percentages, which
+// would compound.
+.mixin-citizen-content-space( @unit ) {
+	--space-content-unit: @unit;
+	--space-content-half: calc( 0.5 * var( --space-content-unit ) );
+}
+
 :root {
 	// Border
 	--border-radius-medium: calc( var( --border-radius-base ) * 2 );
@@ -70,6 +81,7 @@
 	--space-lg: calc( 1.25 * var( --space-unit ) );
 	--space-xl: calc( 1.5 * var( --space-unit ) );
 	--space-xxl: calc( 2 * var( --space-unit ) );
+	.mixin-citizen-content-space( var( --space-md ) );
 
 	// Transition
 	--transition-timing-function-ease: cubic-bezier( 0.2, 0, 0, 1 );
@@ -256,6 +268,13 @@
 	--box-shadow-drop-small: var( --box-shadow-small );
 	--box-shadow-drop-medium: var( --box-shadow-medium );
 	--box-shadow-drop-xx-large: var( --box-shadow-large );
+}
+
+.citizen-body {
+	// The reader's font-size preference is declared on this element, and a
+	// `var()` substitutes where it is declared — deriving this at the root
+	// instead would freeze it at the default size.
+	.mixin-citizen-content-space( var( --font-size-medium ) );
 }
 
 // TODO: Update with implementation on T376559 when it is finalized

--- a/skinStyles/extensions/CiteThisPage/ext.citeThisPage.less
+++ b/skinStyles/extensions/CiteThisPage/ext.citeThisPage.less
@@ -41,7 +41,7 @@
 
 	/* Similar to pre styles */
 	> h3 + p,
-	.mw-heading-3 + p {
+	.mw-heading3 + p {
 		padding: var( --space-md );
 		font-family: var( --font-family-serif );
 		font-variant-numeric: lining-nums;


### PR DESCRIPTION
## Problem

Citizen lets a reader choose one of four text sizes. The text and its line height follow that choice, but the space *between* blocks did not — every gap in the reading area was pinned to 16px. So a reader who enlarged the text got bigger glyphs and bigger leading inside each paragraph, while the separation between paragraphs stayed put. Measured against line height, spacing went from 0.73 at the smallest setting to 0.53 at the largest: the page got tighter exactly for the people who enlarged it to make reading easier.

Headings had a second, unrelated problem. MediaWiki emits two heading markups — a bare `<h2>`, and a `<div class="mw-heading mw-heading2">` wrapper on newer parser output — and Citizen styled them with two different spacing systems that disagreed. They matched only for `h2`, and only at the default text size. `h3` was wrong on every wiki at every setting (30px against 32px), and `h5`/`h6` were out by 4px.

## Behaviour

Spacing in the reading area now scales with the reader's chosen text size — paragraphs, rules, lists, definition lists, quotations, tables, thumbnails and floated wrappers alike. At the default setting nothing moves: every value is identical to before, so an existing wiki looks the same until someone changes the setting.

Both heading markups now follow one scale, so they agree at every level and every text size. Bare headings do not move at all, which is every page on a wiki still using the legacy parser.

Collapsing a section used to add a few pixels to the gap below its heading rather than merging it, so a page with everything collapsed drifted out of step with the scale. Collapsed headings now sit at the same spacing as everywhere else.

## Contract

Nothing to enable and no configuration. Spacing in the reading area is derived from the reading text size, and chrome outside it is unaffected.

Two constraints are load-bearing and worth knowing before changing this code:

- The derivation lives in the scope that carries the reader's preference. Deriving it at the document root instead compiles and lints, renders correctly at the default setting, and silently never tracks the preference at all.
- The scale deliberately does **not** use `em` in the reading area. Content is user-generated wikitext where templates set their own font-size percentages and nest, so an `em` there compounds with them: three ordinary levels of nesting took a 16px gap down to 10.8px, and three quarters of the content blocks on a real article already sit at a non-root font size. Headings are the exception, and can use `em`, because the skin pins each heading's own font size.

## Not covered

- The heading scale itself is unchanged; only the disagreement between the two markups is fixed. Retuning the ratios is a separate decision that would move every heading on every page.
- Spacing inside components — a caption against its own image, form controls — is untouched. This is about the gaps between blocks.
- A wrapper carrying no level class cannot know which heading it holds, so it takes the smallest step. Only hand-written wikitext produces that shape.

## Cache status

Clean. No class or ID is renamed, no server-rendered markup is restructured, so cached HTML needs no compat slice.

## Follow-ups

- The deprecated `--font-size-base` alias has the same root-scope problem described above and never tracks the preference. One consumer, unrelated to the reading area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing consistency across paragraphs, lists, tables, blockquotes, media, and overflow content.
  * Added content-relative spacing that adapts to reader-configured text sizes.
  * Refined heading spacing and wrapped heading presentation.
  * Improved collapsed section heading behavior.
  * Updated CiteThisPage heading-related styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->