### PR TITLE
Lift bordered content boxes one step off the page

### DIFF
--- a/resources/skins.citizen.styles/skinning/elements.less
+++ b/resources/skins.citizen.styles/skinning/elements.less
@@ -111,7 +111,7 @@ pre,
 code,
 .mw-code {
 	color: var( --color-emphasized );
-	background-color: var( --color-surface-2 );
+	background-color: var( --color-surface-1 );
 	border: var( --border-width-base ) solid var( --border-color-base );
 }
 

--- a/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
+++ b/skinStyles/extensions/AccountInfo/ext.AccountInfo.special.less
@@ -32,7 +32,7 @@
 	padding: var( --space-md );
 	margin-top: var( --space-md );
 	color: var( --color-base );
-	background: var( --color-surface-2 );
+	background: var( --color-surface-1 );
 	border: var( --border-width-base ) solid var( --border-color-base );
 	border-radius: var( --border-radius-medium );
 	.mixin-citizen-font-styles( 'small' );

--- a/skinStyles/extensions/Capiunto/capiunto.infobox.main.less
+++ b/skinStyles/extensions/Capiunto/capiunto.infobox.main.less
@@ -16,7 +16,7 @@
 	margin: 0 auto var( --space-md ) auto;
 	font-size: var( --font-size-small );
 	color: var( --color-base );
-	background-color: var( --color-surface-2 );
+	background-color: var( --color-surface-1 );
 	border-color: var( --border-color-base );
 	border-radius: var( --border-radius-medium );
 

--- a/skinStyles/extensions/CiteThisPage/ext.citeThisPage.less
+++ b/skinStyles/extensions/CiteThisPage/ext.citeThisPage.less
@@ -46,7 +46,7 @@
 		font-family: var( --font-family-serif );
 		font-variant-numeric: lining-nums;
 		color: var( --color-emphasized );
-		background: var( --color-surface-2 );
+		background: var( --color-surface-1 );
 		border: var( --border-width-base ) solid var( --border-color-base );
 		border-radius: var( --border-radius-large );
 		.mixin-citizen-font-styles( 'small' );

--- a/skinStyles/extensions/SemanticMediaWiki/ext.smw.styles.less
+++ b/skinStyles/extensions/SemanticMediaWiki/ext.smw.styles.less
@@ -41,7 +41,7 @@
 /* make divs look like <pre> */
 .smwpre {
 	color: var( --color-base );
-	background-color: var( --color-surface-2 );
+	background-color: var( --color-surface-1 );
 	border-color: var( --border-color-base );
 }
 
@@ -56,7 +56,7 @@
 }
 
 div.smwtimeline {
-	background-color: var( --color-surface-2 );
+	background-color: var( --color-surface-1 );
 	border-color: var( --border-color-base );
 }
 
@@ -140,7 +140,7 @@ hr.smw-form-horizontalrule {
 }
 
 .smw-editpage-help {
-	background-color: var( --color-surface-2 );
+	background-color: var( --color-surface-1 );
 	border-color: var( --border-color-base );
 }
 

--- a/skinStyles/extensions/SemanticMediaWiki/smw.jsonview.less
+++ b/skinStyles/extensions/SemanticMediaWiki/smw.jsonview.less
@@ -64,7 +64,7 @@
 }
 
 .smw-jsonview-menu + pre {
-	background-color: var( --color-surface-2 );
+	background-color: var( --color-surface-1 );
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 }


### PR DESCRIPTION
## Problem

The reading area is transparent, so anything inside it sits directly on the page surface. Boxes in that area were painted two steps up the surface ladder rather than one, which made them read heavier than anything else on the page — a code block carried more visual weight than the prose around it, despite already having a border to mark where it starts and ends.

## Behaviour

Code blocks, and the boxes SemanticMediaWiki, CiteThisPage, AccountInfo and Capiunto render into the reading area, now sit one step above the page instead of two. Text contrast inside them is unchanged and remains well clear of the accessibility threshold in both light and dark themes.

## Contract

The rule this establishes: a box is one step above whatever surface it actually sits on. In the reading area that surface is the page itself.

The exception, and the reason most boxes were left alone: the skin resets border width to zero for everything, so a rule that sets only a border *colour* paints no border at all. For those boxes the fill is the only thing marking their edges, and a lighter fill would erase them. They keep the deeper surface. Table bands keep it too, since their contrast job is against the adjacent rows rather than against the page.

## Not covered

Skin chrome, which nests differently and has its own ladder. State colours — selected, current, hover, review status — keep their extra step, because the contrast there is carrying meaning rather than marking a container.

## Cache status

Clean. Values only; no selector, class or server-rendered markup changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated backgrounds for code blocks, infoboxes, bibliographic content, account information, and Semantic MediaWiki elements.
  * Applied a more consistent surface color across these components for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->