### PR TITLE
feat(sections): move the collapse control to the end of the heading

### DIFF
--- a/resources/skins.citizen.scripts/sections.js
+++ b/resources/skins.citizen.scripts/sections.js
@@ -2,6 +2,10 @@ const COLLAPSED_CLASS = 'citizen-section--collapsed';
 const HEADING_SELECTOR = '.mw-heading, .citizen-section-heading';
 const HEADING_TAGS = 'h1, h2, h3, h4, h5, h6';
 const TOGGLE_CLASS = 'citizen-section-toggle';
+// The same Codex classes templates/IconButtonLink.mustache gives the edit
+// links, so the two stay in step as Codex moves.
+const TOGGLE_CLASSES =
+	`${ TOGGLE_CLASS } cdx-button cdx-button--weight-quiet cdx-button--icon-only`;
 const INTERACTIVE_CLASS = 'citizen-sections-interactive';
 const COLLAPSED_SECTION_SELECTOR =
 	`section[data-mw-section-id].${ COLLAPSED_CLASS }, section.citizen-section.${ COLLAPSED_CLASS }`;
@@ -83,7 +87,9 @@ function createSections( { document, bodyContent } ) {
 	 * the delegated click handler, but a bare heading is unreachable by
 	 * keyboard and announces neither that it is a control nor what state it
 	 * is in. A native button fixes both and needs no listener of its own:
-	 * Enter and Space fire a click that bubbles to the same handler.
+	 * Enter and Space fire a click that bubbles to the same handler — which
+	 * stops at `.mw-editsection`, so the button must stay a sibling of the edit
+	 * links rather than move inside them.
 	 *
 	 * @param {HTMLElement} heading
 	 * @return {void}
@@ -103,30 +109,33 @@ function createSections( { document, bodyContent } ) {
 
 		const toggle = document.createElement( 'button' );
 		toggle.type = 'button';
-		toggle.className = TOGGLE_CLASS;
+		toggle.className = TOGGLE_CLASSES;
 		toggle.setAttribute( 'aria-expanded', 'true' );
 		// Naming the control after its section is the disclosure convention:
 		// "Foo, button, collapsed" beats a generic label, and it keeps the
 		// wording out of i18n.
 		toggle.setAttribute( 'aria-labelledby', label.id );
 
-		if ( headingTag && headingTag !== heading ) {
-			// Newer markup wraps the heading tag in a container, so the
-			// button sits beside it and the heading keeps a clean accessible
-			// name. Placing it *after* the heading tag means jumping between
-			// headings and reading on reaches the control; the styles order
-			// it first, so nothing moves.
+		// After the edit links, matching where the styles render it, so reading
+		// order and rendered order agree. `.mw-editsection-like` is deliberately
+		// not matched: DiscussionTools' subscribe control is the heading's first
+		// child, so inserting after it would land the button ahead of the title.
+		const editSection = heading.querySelector( ':scope > .mw-editsection' );
+		if ( editSection ) {
+			editSection.after( toggle );
+		} else if ( headingTag && headingTag !== heading ) {
+			// Newer markup wraps the heading tag in a container, so the button
+			// sits beside it and the heading keeps a clean accessible name.
 			headingTag.after( toggle );
 		} else {
-			// Legacy markup has no wrapper, so the button goes inside the
-			// heading tag — which heading navigation lands on, so first child
-			// reads in the right order. It would otherwise be folded into the
-			// heading's accessible name, so pin that to the title text. Both
-			// can go when the legacy heading DOM does.
-			heading.insertBefore( toggle, heading.firstChild );
-			if ( headingTag && label !== heading ) {
-				heading.setAttribute( 'aria-labelledby', label.id );
-			}
+			heading.append( toggle );
+		}
+
+		if ( headingTag === heading && label !== heading ) {
+			// Legacy markup has no wrapper, so the button lands inside the
+			// heading tag and would be folded into its accessible name. Goes
+			// when the legacy heading DOM does.
+			heading.setAttribute( 'aria-labelledby', label.id );
 		}
 	}
 

--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -17,14 +17,12 @@ section[ data-mw-section-id ] > .mw-heading,
 
 // The chevron. Drawn on the heading's ::before so first paint carries the
 // affordance with no layout shift and noscript clients never see it, then
-// handed to the injected toggle button once sections.js has run. Both take
-// the same box in the same flex slot, so the handover moves nothing.
-// Trade-off: the pre-JS form claims the heading's single ::before slot, so
-// any extension or gadget styling these headings' ::before will conflict.
+// handed to the injected button once sections.js runs. Each form sets its own
+// box; they must match or the handover shifts the row.
+// Trade-off: this claims the heading's single ::before slot, so any extension
+// or gadget styling these headings' ::before will conflict.
 .mixin-citizen-section-chevron() {
 	display: block;
-	width: var( --size-icon );
-	height: var( --size-icon );
 	content: '';
 	background-color: currentcolor;
 	-webkit-mask-image: url( assets/images/cdxIconCollapse.svg );
@@ -33,8 +31,6 @@ section[ data-mw-section-id ] > .mw-heading,
 	mask-repeat: no-repeat;
 	-webkit-mask-position: center;
 	mask-position: center;
-	-webkit-mask-size: contain;
-	mask-size: contain;
 	transition: var( --transition-hover );
 	transition-property: transform;
 }
@@ -48,10 +44,14 @@ section[ data-mw-section-id ] > .mw-heading,
 		-webkit-user-select: none;
 		user-select: none;
 
+		// The flex item itself, so it carries the button's whole footprint.
 		&::before {
 			flex-shrink: 0;
-			order: -2;
-			margin-inline-end: var( --space-sm );
+			order: 3;
+			width: @min-size-interactive-pointer;
+			height: @min-size-interactive-pointer;
+			-webkit-mask-size: var( --size-icon );
+			mask-size: var( --size-icon );
 			.mixin-citizen-section-chevron();
 		}
 
@@ -80,38 +80,20 @@ section[ data-mw-section-id ] > .mw-heading,
 		}
 	}
 
+	// The Codex classes come from sections.js, so the box, colours and focus
+	// ring track the edit links rather than being restated. Order 3 keeps it
+	// outboard of them and of DiscussionTools' subscribe control, which
+	// skinStyles/extensions/DiscussionTools holds at 2.
 	.citizen-section-toggle {
-		display: flex;
 		flex-shrink: 0;
-		align-items: center;
-		justify-content: center;
-		order: -2;
-		padding: 0;
-		margin-inline-end: var( --space-sm );
-		color: inherit;
-		appearance: none;
-		cursor: pointer;
-		background: transparent;
-		border: 0;
-		border-radius: var( --border-radius-base );
+		order: 3;
 
 		&::before {
+			width: var( --size-icon );
+			height: var( --size-icon );
+			-webkit-mask-size: contain;
+			mask-size: contain;
 			.mixin-citizen-section-chevron();
-		}
-
-		&:focus-visible {
-			outline: var( --border-width-thick ) solid var( --color-progressive );
-			outline-offset: var( --space-xxs );
-		}
-
-		@media ( hover: hover ) {
-			&:hover {
-				opacity: var( --opacity-icon-base--hover );
-			}
-
-			&:active {
-				opacity: var( --opacity-icon-base--selected );
-			}
 		}
 	}
 

--- a/skinStyles/extensions/DiscussionTools/ext.discussionTools.init.styles.less
+++ b/skinStyles/extensions/DiscussionTools/ext.discussionTools.init.styles.less
@@ -43,7 +43,8 @@
 .ext-discussiontools-init-section-subscribeButton.oo-ui-buttonElement {
 	// Heading chrome icon size, as set for .mw-editsection in Sections.less.
 	--size-icon: 1.125rem;
-	order: 9999;
+	// Inboard of the collapse toggle, which components/Sections.less holds at 3.
+	order: 2;
 }
 
 .ext-discussiontools-init-section-subscribe.mw-editsection-like {

--- a/tests/vitest/skins.citizen.scripts/sections.test.js
+++ b/tests/vitest/skins.citizen.scripts/sections.test.js
@@ -327,6 +327,20 @@ describe( 'createSections', () => {
 			</div>
 		`;
 
+		it( 'should leave the markup alone when collapsible sections are off', () => {
+			// Without the body class the feature is disabled, so the server's
+			// markup has to survive untouched — no button, and no interactive
+			// class for the styles to hand the chevron over on.
+			const bodyContent = document.createElement( 'div' );
+			bodyContent.innerHTML = WRAPPED;
+			document.body.appendChild( bodyContent );
+
+			createSections( { document, bodyContent } ).init();
+
+			expect( bodyContent.querySelector( '.citizen-section-toggle' ) ).toBeNull();
+			expect( document.body.classList.contains( 'citizen-sections-interactive' ) ).toBe( false );
+		} );
+
 		it( 'should give every collapsible heading a button', () => {
 			const bodyContent = createBodyContent( WRAPPED );
 
@@ -345,18 +359,69 @@ describe( 'createSections', () => {
 			expect( toggle.getAttribute( 'aria-labelledby' ) ).toBe( 'Foo' );
 		} );
 
-		it( 'should place the button after the heading tag when markup wraps it', () => {
+		it( 'should place the button after the edit links when markup wraps the heading', () => {
 			const bodyContent = createBodyContent( WRAPPED );
 			const h2 = bodyContent.querySelector( 'h2' );
+			const editSection = bodyContent.querySelector( '.mw-editsection' );
 
 			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
 
 			// Outside the h2, so the heading keeps a clean accessible name
 			expect( toggle.closest( 'h2' ) ).toBeNull();
 			expect( h2.hasAttribute( 'aria-labelledby' ) ).toBe( false );
-			// After it, so jumping between headings and reading on reaches
-			// the control. The styles order it first visually.
+			// Outboard of the controls that act on the section's content, and in
+			// the order the styles render it, so reading order matches
+			expect( editSection.nextElementSibling ).toBe( toggle );
+		} );
+
+		it( 'should place the button after the heading tag when there are no edit links', () => {
+			const bodyContent = createBodyContent( PARSOID_NESTED );
+			const h2 = bodyContent.querySelector( 'h2' );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
 			expect( h2.nextElementSibling ).toBe( toggle );
+		} );
+
+		it( 'should carry the same Codex button classes as the edit links', () => {
+			const bodyContent = createBodyContent( WRAPPED );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
+			expect( toggle.classList.contains( 'cdx-button' ) ).toBe( true );
+			expect( toggle.classList.contains( 'cdx-button--weight-quiet' ) ).toBe( true );
+			expect( toggle.classList.contains( 'cdx-button--icon-only' ) ).toBe( true );
+		} );
+
+		it( 'should not mistake a subscribe control for the edit links', () => {
+			// DiscussionTools inserts .mw-editsection-like as the heading's first
+			// child, so placing after it would land the button ahead of the title.
+			const bodyContent = createBodyContent( `
+				<div class="mw-parser-output">
+					<section data-mw-section-id="1">
+						<div class="mw-heading mw-heading2">
+							<span class="mw-editsection-like">subscribe</span>
+							<h2 id="Foo">Foo</h2>
+						</div>
+						<p>Bar</p>
+					</section>
+				</div>
+			` );
+			const h2 = bodyContent.querySelector( 'h2' );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
+			expect( h2.nextElementSibling ).toBe( toggle );
+		} );
+
+		it( 'should stay a sibling of the edit links, not a descendant', () => {
+			// The delegated click handler returns early inside .mw-editsection,
+			// so a nested toggle would never fire.
+			const bodyContent = createBodyContent( WRAPPED );
+
+			const toggle = bodyContent.querySelector( '.citizen-section-toggle' );
+
+			expect( toggle.closest( '.mw-editsection' ) ).toBeNull();
 		} );
 
 		it( 'should pin the heading name when the button lands inside the heading tag', () => {
@@ -367,8 +432,8 @@ describe( 'createSections', () => {
 
 			expect( toggle.closest( 'h2' ) ).toBe( heading );
 			expect( heading.getAttribute( 'aria-labelledby' ) ).toBe( 'Foo' );
-			// First child, so it precedes the title the heading announces
-			expect( heading.firstElementChild ).toBe( toggle );
+			// Last, after the edit links it renders outboard of
+			expect( heading.lastElementChild ).toBe( toggle );
 		} );
 
 		it( 'should give every heading on the page its own button', () => {


### PR DESCRIPTION
## Problem

Every collapsible section's chevron sat at the head of its heading, in flow, so
every `h1`–`h6` that opened a section started 30px right of the column edge that
body text sits on. Headings and paragraphs no longer shared a left edge.

The offset is fixed in root-relative units while the reader's font-size
preference lives on `.citizen-body`, so it never scaled with reading size — it
was proportionally worst at `h5` and `h6`, where the chevron was larger than the
heading it introduced.

## Behaviour

The collapse control now sits at the trailing edge of the heading row, outboard
of the edit links and of DiscussionTools' subscribe control, and is styled as
the same Codex quiet icon-only button the edit links use.

- Headings share the content column's left edge with body text again.
- The control lands at the same horizontal position on every heading of a page.
  That position is the only one in the row that does not move as the edit
  cluster changes width — one edit link, two under VisualEditor multi-tab, plus
  a subscribe control, or none at all on a section a reader cannot edit.
- The trailing controls sit flush, with no separator and no gap, so the heading
  keeps as much width as possible for its title at narrow viewports.

## Contract

- **Ordering.** The collapse control is outermost in the heading row. Anything
  new that lands there must sort inboard of it.
- **The control is a sibling of the edit links, never a descendant.** Clicks
  inside `.mw-editsection` are excluded from the collapse handler, so a nested
  control would not toggle at all.
- **The pre-JS and post-JS chevrons must occupy the same box.** First paint
  draws the affordance on the heading itself; the injected button replaces it
  once scripts run. If the two ever differ in size, every heading jumps.
- **Clicking the heading row still collapses the section.** The chevron is an
  affordance and the keyboard/assistive-technology control, not the only way in.
- **No cache-compat slice.** The control is client-rendered and no
  PHP-generated markup changed.

## Verification

Tested against MW 1.43.9 with VisualEditor multi-tab and DiscussionTools, over
the legacy heading DOM, the `.mw-heading` wrapper shape, and DiscussionTools'
nested shape; with and without edit links; at 1280px and 360px; in light and
dark themes.

Confirmed: headings and body text share a left edge; the control holds one
horizontal position across every heading level; the pre-JS to post-JS handover
moves nothing; colour and focus treatment are identical to the edit links; no
console errors and no failed requests.

## Notes for review

- Rows that carry **no** edit link grow by up to 6px at `h3`–`h6`, because the
  control is now a 32px target rather than an 18px one. Rows that carry an edit
  link are unchanged, since that link already set a 32px floor.
- Citizen owns DiscussionTools' subscribe ordering in its skinStyles; that value
  moved so the collapse control could sit outboard of it.

## Follow-ups

- The chevron and the edit links are now adjacent 32px targets of differing
  consequence. Each satisfies the target-size minimum on its own, and the
  whole-row click keeps a cheap path to collapsing, but it is worth watching
  for mis-tap reports on touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved section toggle placement alongside edit links and subscription controls.
  * Updated section controls to use consistent button styling and pointer-sized interactive areas.
  * Corrected heading accessibility labeling in legacy layouts.
  * Positioned the subscription control before the collapse toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->