### PR TITLE
fix(commandPalette): open a result in a new tab with Ctrl+Enter

### DIFF
--- a/resources/skins.citizen.commandPalette/components/App.vue
+++ b/resources/skins.citizen.commandPalette/components/App.vue
@@ -335,7 +335,7 @@ module.exports = exports = defineComponent( {
 			isLeadReady: orch.isLeadReady,
 			items: orch.flatItems,
 			defaultHighlightIndex: orch.defaultHighlightIndex,
-			onActivate: ( item ) => selectResult( item )
+			onActivate: selectResult
 		} );
 		cancelPendingActivation = pendingActivation.cancel;
 

--- a/resources/skins.citizen.commandPalette/composables/useKeyboard.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboard.js
@@ -14,6 +14,15 @@ const {
 const IS_MAC = isMacPlatform( typeof navigator !== 'undefined' ? navigator : null );
 const COPY_KBD = IS_MAC ? '⌘C' : 'Ctrl+C';
 
+// `modifierClick` is the router's existing "not the row's default action"
+// signal; `newTab` is what makes it open the context itself.
+const NEW_TAB_ACTIVATION = { modifierClick: true, newTab: true };
+
+// Shared by the plain-Enter bindings and their accelerator twins, so the pairs
+// cannot drift apart.
+const hasHighlight = ( state ) => state.highlightedIndex >= 0;
+const canQueue = ( state ) => state.highlightedIndex < 0 && state.canQueueActivation;
+
 // Arrow keys are physical; the bindings below are logical (previous/next, and
 // input → action row). CSSJanus mirrors the inline axis for RTL interface
 // languages, so on an RTL wiki the two horizontal arrows have to be swapped
@@ -348,7 +357,7 @@ const coreBindings = [
 		id: 'input-enter-select',
 		zone: 'input',
 		keys: [ 'Enter' ],
-		when: ( state ) => state.highlightedIndex >= 0,
+		when: hasHighlight,
 		worksDuringHelp: true,
 		handle: ( state, event ) => {
 			event.preventDefault();
@@ -362,12 +371,43 @@ const coreBindings = [
 		id: 'input-enter-queue',
 		zone: 'input',
 		keys: [ 'Enter' ],
-		when: ( state ) => state.highlightedIndex < 0 && state.canQueueActivation,
+		when: canQueue,
 		handle: ( state, event ) => {
 			event.preventDefault();
 			state.onQueueActivation();
 		},
 		hint: { msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', order: 10 }
+	},
+	// Ctrl+Enter opens the row in a new tab, as Ctrl+click on the same anchor
+	// already does. Ctrl+Shift+Enter is folded in: it differs only in whether
+	// the new tab takes focus, which no script can choose. No footer hint -- a
+	// chip on every highlighted row would crowd the ones that change per row.
+	{
+		id: 'input-enter-select-new-tab',
+		zone: 'input',
+		keys: [ 'Enter' ],
+		modifiers: [ 'accel', 'accel+shift' ],
+		when: hasHighlight,
+		worksDuringHelp: true,
+		handle: ( state, event ) => {
+			event.preventDefault();
+			state.onSelect( Object.assign(
+				{}, state.items[ state.highlightedIndex ], NEW_TAB_ACTIVATION
+			) );
+		},
+		hint: null
+	},
+	{
+		id: 'input-enter-queue-new-tab',
+		zone: 'input',
+		keys: [ 'Enter' ],
+		modifiers: [ 'accel', 'accel+shift' ],
+		when: canQueue,
+		handle: ( state, event ) => {
+			event.preventDefault();
+			state.onQueueActivation( NEW_TAB_ACTIVATION );
+		},
+		hint: null
 	},
 
 	// --- INPUT ZONE: ArrowRight to actions ---

--- a/resources/skins.citizen.commandPalette/composables/usePendingActivation.js
+++ b/resources/skins.citizen.commandPalette/composables/usePendingActivation.js
@@ -20,7 +20,8 @@ const PENDING_ACTIVATION_TIMEOUT_MS = 2000;
  * @param {import('vue').Ref<boolean>} options.isLeadReady Whether the lead group has settled.
  * @param {import('vue').Ref<Array>} options.items Flat item list.
  * @param {import('vue').Ref<number>} options.defaultHighlightIndex Index the highlight defaults to.
- * @param {Function} options.onActivate Called with the item to activate.
+ * @param {Function} options.onActivate Called with the item to activate,
+ *   carrying whatever the hold was armed with.
  * @return {{ arm: Function, cancel: Function, isActivationQueued: import('vue').Ref<boolean> }}
  */
 function usePendingActivation( options ) {
@@ -28,6 +29,7 @@ function usePendingActivation( options ) {
 	// keystroke and would lower them on an unrelated schedule.
 	const isActivationQueued = ref( false );
 	let armedSurface = null;
+	let armedIntent = null;
 	let timeoutId = null;
 
 	function cancel() {
@@ -36,12 +38,18 @@ function usePendingActivation( options ) {
 		}
 		isActivationQueued.value = false;
 		armedSurface = null;
+		armedIntent = null;
 		clearTimeout( timeoutId );
 		timeoutId = null;
 	}
 
-	function arm() {
+	/**
+	 * @param {Object} [intent] Flags merged onto the item once it arrives. A
+	 *   modified Enter means the same thing whether or not results had landed.
+	 */
+	function arm( intent ) {
 		armedSurface = options.surfaceKey.value;
+		armedIntent = intent || null;
 		isActivationQueued.value = true;
 		clearTimeout( timeoutId );
 		timeoutId = setTimeout( cancel, PENDING_ACTIVATION_TIMEOUT_MS );
@@ -60,7 +68,10 @@ function usePendingActivation( options ) {
 			return;
 		}
 		const index = options.defaultHighlightIndex.value;
-		const item = index >= 0 ? options.items.value[ index ] : null;
+		// Decorate before cancel(), which drops the armed intent.
+		const item = index >= 0 ?
+			Object.assign( {}, options.items.value[ index ], armedIntent ) :
+			null;
 		cancel();
 		// A group that settled empty has no activation to perform.
 		if ( item ) {

--- a/resources/skins.citizen.commandPalette/composables/useResultRouter.js
+++ b/resources/skins.citizen.commandPalette/composables/useResultRouter.js
@@ -1,6 +1,26 @@
 const { nextTick } = require( 'vue' );
 
 /**
+ * Open a URL in a new browsing context, severing the opener.
+ *
+ * The opener is cleared by hand rather than through the `noopener` feature,
+ * which makes `window.open` return null even on success and so would cost the
+ * caller its only signal that the context never opened.
+ *
+ * @param {string} url
+ * @return {boolean} False when the context could not be opened, so the caller
+ *   can fall back rather than swallow the activation.
+ */
+function openInNewTab( url ) {
+	const opened = window.open( url, '_blank' );
+	if ( !opened ) {
+		return false;
+	}
+	opened.opener = null;
+	return true;
+}
+
+/**
  * Composable that owns the palette's result-action dispatch.
  *
  * Two functions are returned: `selectResult` for row activations, and
@@ -66,10 +86,10 @@ function useResultRouter( {
 					// preview and pick another row. Plain mouse clicks are
 					// intercepted by the handler; keyboard activation
 					// synthesizes a click on the highlighted row's anchor
-					// so the handler can take over. Modifier or non-primary
-					// clicks (Ctrl, Cmd, Alt, Shift, middle) fall through
-					// to the navigate+close path so users keep their
-					// browser-level escape hatches.
+					// so the handler can take over. A modified activation --
+					// a non-primary or modifier click, or Ctrl/Cmd+Enter --
+					// falls through to the navigate+close path so users keep
+					// their browser-level escape hatches.
 					if (
 						result.previewable &&
 						preview.isAvailable() &&
@@ -89,7 +109,11 @@ function useResultRouter( {
 					// <a> tags are handled by the browser on mouse click,
 					// so we don't need to navigate.
 					if ( !result.isMouseClick ) {
-						window.location.href = action.payload;
+						// A blocked popup falls back to this tab rather than
+						// leaving the activation to do nothing at all.
+						if ( !result.newTab || !openInNewTab( action.payload ) ) {
+							window.location.href = action.payload;
+						}
 					}
 					close();
 				}

--- a/resources/skins.citizen.commandPalette/services/recentItems.js
+++ b/resources/skins.citizen.commandPalette/services/recentItems.js
@@ -2,6 +2,29 @@ const { cdxIconArticleSearch, cdxIconTrash } = require( '../icons.json' );
 const RECENT_ITEMS_KEY = 'skin-citizen-command-palette-recent-items';
 const MAX_RECENT_ITEMS = 5;
 
+// How a row was activated, not what the row is. Remembering one makes the
+// saved row replay that activation for good: `isMouseClick` tells the router
+// the browser already followed the row's <a>, so a row still carrying it
+// navigates nowhere on a later keyboard Enter.
+const ACTIVATION_FLAGS = [ 'isMouseClick', 'modifierClick' ];
+
+/**
+ * Strip the activation flags from an item.
+ *
+ * Applied on write so nothing new is stored, and on read so entries an
+ * earlier version already saved stop misbehaving without a cleared history.
+ *
+ * @param {Object} item
+ * @return {Object}
+ */
+function withoutActivationFlags( item ) {
+	const stored = Object.assign( {}, item );
+	for ( const flag of ACTIVATION_FLAGS ) {
+		delete stored[ flag ];
+	}
+	return stored;
+}
+
 /**
  * @return {Object} Recent items service
  */
@@ -19,7 +42,7 @@ function createRecentItems() {
 			recentItems.splice( existingIndex, 1 );
 		}
 		// Add to beginning
-		recentItems.unshift( item );
+		recentItems.unshift( withoutActivationFlags( item ) );
 		// Keep only MAX_RECENT_ITEMS
 		if ( recentItems.length > MAX_RECENT_ITEMS ) {
 			recentItems.pop();
@@ -63,7 +86,7 @@ function createRecentItems() {
 			}
 
 			return {
-				...item,
+				...withoutActivationFlags( item ),
 				actions
 			};
 		} );

--- a/resources/skins.citizen.commandPalette/services/recentItems.js
+++ b/resources/skins.citizen.commandPalette/services/recentItems.js
@@ -6,7 +6,7 @@ const MAX_RECENT_ITEMS = 5;
 // saved row replay that activation for good: `isMouseClick` tells the router
 // the browser already followed the row's <a>, so a row still carrying it
 // navigates nowhere on a later keyboard Enter.
-const ACTIVATION_FLAGS = [ 'isMouseClick', 'modifierClick' ];
+const ACTIVATION_FLAGS = [ 'isMouseClick', 'modifierClick', 'newTab' ];
 
 /**
  * Strip the activation flags from an item.

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -95,6 +95,7 @@
  * @property {boolean} [isMouseClick] True if the selection was triggered by a mouse click.
  * @property {boolean} [previewable] Whether the item's URL is suitable for in-place preview by an external preview gadget (e.g. Instant Diffs).
  * @property {boolean} [modifierClick] True if the click had a modifier key held (Ctrl, Cmd, Alt, Shift) or was non-primary (middle-click). Signals "I want different behavior than the row's default" — open in new tab, navigate fully past a preview, etc.
+ * @property {boolean} [newTab] True if the activation asked for a new browsing context and nothing else will open it. Set for keyboard activation only — a mouse click reaches the row's <a>, where the browser reads the modifier itself.
  */
 
 /**

--- a/tests/vitest/commandPalette/composables/useKeyboard.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboard.test.js
@@ -180,6 +180,61 @@ describe( 'useKeyboard', () => {
 
 			expect( deps.onSelect ).toHaveBeenCalledWith( deps.items.value[ 0 ] );
 		} );
+
+		it( 'should ask for a new tab on Ctrl+Enter, as Ctrl+click does', () => {
+			listNav.highlightedIndex.value = 0;
+			const event = createKeyEvent( 'Enter' );
+			event.ctrlKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onSelect ).toHaveBeenCalledWith( {
+				id: '1',
+				actions: [ { id: 'edit' } ],
+				modifierClick: true,
+				newTab: true
+			} );
+			expect( event.preventDefault ).toHaveBeenCalled();
+		} );
+
+		it( 'should leave the list item itself unflagged', () => {
+			// The row lives in the reactive result list; flagging it in place
+			// would make every later activation of that row open a new tab.
+			listNav.highlightedIndex.value = 0;
+			const event = createKeyEvent( 'Enter' );
+			event.ctrlKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.items.value[ 0 ] ).toEqual( { id: '1', actions: [ { id: 'edit' } ] } );
+		} );
+
+		it( 'should read Ctrl+Shift+Enter as the same new-tab request', () => {
+			listNav.highlightedIndex.value = 0;
+			const event = createKeyEvent( 'Enter' );
+			event.ctrlKey = true;
+			event.shiftKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onSelect ).toHaveBeenCalledWith(
+				expect.objectContaining( { newTab: true } )
+			);
+		} );
+
+		it( 'should carry the new-tab request into a held activation', () => {
+			listNav.highlightedIndex.value = -1;
+			deps.canQueueActivation.value = true;
+			const event = createKeyEvent( 'Enter' );
+			event.ctrlKey = true;
+
+			keyboard.handleKeydown( event );
+
+			expect( deps.onQueueActivation ).toHaveBeenCalledWith( {
+				modifierClick: true,
+				newTab: true
+			} );
+		} );
 	} );
 
 	describe( 'input zone — Escape', () => {

--- a/tests/vitest/commandPalette/composables/useKeyboardModifiers.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboardModifiers.test.js
@@ -31,7 +31,8 @@ const MODIFIER_SETS = {
 	meta: { metaKey: true },
 	// Windows delivers AltGr as Ctrl+Alt; several layouts type `@`, `~` and `#`
 	// — all mode triggers — that way.
-	altgr: { ctrlKey: true, altKey: true }
+	altgr: { ctrlKey: true, altKey: true },
+	ctrlShift: { ctrlKey: true, shiftKey: true }
 };
 
 describe( 'dispatcher modifier policy', () => {
@@ -154,11 +155,15 @@ describe( 'dispatcher modifier policy', () => {
 		[ 'Tab', 'none', 'input', 'onClose (claimed)' ],
 		[ ' ', 'none', 'action', 'clickFocused (claimed)' ],
 
-		// A command modifier suppresses them.
-		[ 'Enter', 'ctrl', 'input', 'ignored' ],
+		// A command modifier suppresses them, unless a binding claims it.
 		[ 'ArrowDown', 'ctrl', 'input', 'ignored' ],
 		[ 'ArrowDown', 'meta', 'input', 'ignored' ],
 		[ 'Escape', 'alt', 'input', 'ignored' ],
+
+		// Ctrl+Enter is the anchor convention for "open in a new tab", so the
+		// Enter binding claims the accelerator, with or without Shift.
+		[ 'Enter', 'ctrl', 'input', 'onSelect (claimed)' ],
+		[ 'Enter', 'ctrlShift', 'input', 'onSelect (claimed)' ],
 
 		// Shift is allowed only for printable characters, plus Tab by exception.
 		[ 'ArrowDown', 'shift', 'input', 'ignored' ],

--- a/tests/vitest/commandPalette/composables/usePendingActivation.test.js
+++ b/tests/vitest/commandPalette/composables/usePendingActivation.test.js
@@ -55,6 +55,41 @@ describe( 'usePendingActivation', () => {
 		expect( state.onActivate ).toHaveBeenCalledWith( { id: 'sunset', label: 'Sunset' } );
 	} );
 
+	it( 'carries the intent it was armed with onto the item', async () => {
+		const { state, pending } = setup();
+
+		pending.arm( { newTab: true } );
+		await settle( state, [ { id: 'sunset' } ] );
+
+		expect( state.onActivate ).toHaveBeenCalledWith( { id: 'sunset', newTab: true } );
+	} );
+
+	it( 'leaves the settled item itself unflagged', async () => {
+		// The item comes out of the live result list, so decorating it in
+		// place would make every later activation of that row inherit it.
+		const items = [ { id: 'sunset' } ];
+		const { state, pending } = setup();
+
+		pending.arm( { newTab: true } );
+		await settle( state, items );
+
+		expect( items[ 0 ] ).toEqual( { id: 'sunset' } );
+	} );
+
+	it( 'drops the intent with the hold, so the next plain Enter is plain', async () => {
+		const { state, pending } = setup();
+
+		pending.arm( { newTab: true } );
+		await settle( state, [ { id: 'sunset' } ] );
+		state.isLeadReady.value = false;
+		await nextTick();
+		pending.arm();
+		state.onActivate.mockClear();
+		await settle( state, [ { id: 'sunrise' } ] );
+
+		expect( state.onActivate ).toHaveBeenCalledWith( { id: 'sunrise' } );
+	} );
+
 	it( 'raises its own queued flag immediately', () => {
 		const { pending } = setup();
 

--- a/tests/vitest/commandPalette/composables/useResultRouter.test.js
+++ b/tests/vitest/commandPalette/composables/useResultRouter.test.js
@@ -113,6 +113,82 @@ describe( 'useResultRouter — selectResult', () => {
 		} );
 	} );
 
+	describe( 'navigate in a new tab', () => {
+		let setLocation;
+
+		beforeEach( () => {
+			setLocation = vi.fn();
+			Object.defineProperty( window, 'location', {
+				configurable: true,
+				value: { set href( v ) { setLocation( v ); } }
+			} );
+		} );
+
+		afterEach( () => {
+			vi.restoreAllMocks();
+		} );
+
+		/**
+		 * @param {Object} overrides
+		 * @return {Object}
+		 */
+		function navigatingDeps( overrides = {} ) {
+			return makeDeps( Object.assign( {
+				orchestrator: {
+					handleSelection: vi.fn().mockResolvedValue( { action: 'navigate', payload: '/wiki/Foo' } )
+				}
+			}, overrides ) );
+		}
+
+		it( 'opens a new browsing context and leaves this one alone', async () => {
+			const opened = {};
+			const open = vi.spyOn( window, 'open' ).mockReturnValue( opened );
+			const deps = navigatingDeps();
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { id: 'foo', newTab: true, modifierClick: true } );
+
+			expect( open ).toHaveBeenCalledWith( '/wiki/Foo', '_blank' );
+			expect( opened.opener ).toBeNull();
+			expect( setLocation ).not.toHaveBeenCalled();
+			expect( deps.control.close ).toHaveBeenCalled();
+		} );
+
+		it( 'falls back to this tab when the new one is blocked', async () => {
+			vi.spyOn( window, 'open' ).mockReturnValue( null );
+			const deps = navigatingDeps();
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { id: 'foo', newTab: true, modifierClick: true } );
+
+			expect( setLocation ).toHaveBeenCalledWith( '/wiki/Foo' );
+		} );
+
+		it( 'leaves a mouse click to the browser, which already read the modifier', async () => {
+			const open = vi.spyOn( window, 'open' ).mockReturnValue( {} );
+			const deps = navigatingDeps();
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { id: 'foo', isMouseClick: true, modifierClick: true } );
+
+			expect( open ).not.toHaveBeenCalled();
+			expect( setLocation ).not.toHaveBeenCalled();
+		} );
+
+		it( 'opens the new tab past a preview gadget rather than previewing in place', async () => {
+			const open = vi.spyOn( window, 'open' ).mockReturnValue( {} );
+			const deps = navigatingDeps( {
+				preview: { isAvailable: vi.fn().mockReturnValue( true ), triggerForAnchor: vi.fn() }
+			} );
+
+			const { selectResult } = useResultRouter( deps );
+			await selectResult( { previewable: true, newTab: true, modifierClick: true } );
+
+			expect( deps.preview.triggerForAnchor ).not.toHaveBeenCalled();
+			expect( open ).toHaveBeenCalledWith( '/wiki/Foo', '_blank' );
+		} );
+	} );
+
 	describe( 'navigate with preview', () => {
 		it( 'triggers the preview anchor for keyboard activation when available + previewable + non-modifier', async () => {
 			const root = document.createElement( 'div' );

--- a/tests/vitest/commandPalette/services/recentItems.test.js
+++ b/tests/vitest/commandPalette/services/recentItems.test.js
@@ -57,13 +57,15 @@ describe( 'createRecentItems', () => {
 		} );
 
 		it( 'does not remember how the item was activated', () => {
-			// A row saved from a click would otherwise replay that activation
-			// for good, navigating nowhere at all on every later plain Enter.
+			// A row saved from a Ctrl+click would otherwise replay that
+			// activation for good -- opening a new tab, or navigating
+			// nowhere at all, on every later plain Enter.
 			const item = {
 				id: 'item-1',
 				label: 'Test Page',
 				isMouseClick: true,
-				modifierClick: true
+				modifierClick: true,
+				newTab: true
 			};
 
 			service.saveRecentItem( item );

--- a/tests/vitest/commandPalette/services/recentItems.test.js
+++ b/tests/vitest/commandPalette/services/recentItems.test.js
@@ -56,6 +56,22 @@ describe( 'createRecentItems', () => {
 			expect( stored[ 2 ].id ).toBe( 'item-b' );
 		} );
 
+		it( 'does not remember how the item was activated', () => {
+			// A row saved from a click would otherwise replay that activation
+			// for good, navigating nowhere at all on every later plain Enter.
+			const item = {
+				id: 'item-1',
+				label: 'Test Page',
+				isMouseClick: true,
+				modifierClick: true
+			};
+
+			service.saveRecentItem( item );
+
+			const stored = mw.storage.getObject( 'skin-citizen-command-palette-recent-items' );
+			expect( stored[ 0 ] ).toEqual( { id: 'item-1', label: 'Test Page' } );
+		} );
+
 		it( 'enforces maximum of 5 items', () => {
 			for ( let i = 1; i <= 7; i++ ) {
 				service.saveRecentItem( { id: `item-${ i }`, label: `Page ${ i }` } );
@@ -87,6 +103,17 @@ describe( 'createRecentItems', () => {
 				expect( dismissAction ).toBeDefined();
 				expect( dismissAction.label ).toBe( 'citizen-command-palette-dismiss' );
 			}
+		} );
+
+		it( 'drops activation flags left behind by an earlier version', () => {
+			mw.storage.setObject( 'skin-citizen-command-palette-recent-items', [
+				{ id: 'item-1', label: 'Page 1', isMouseClick: true, modifierClick: false }
+			] );
+
+			const result = service.getRecentItems();
+
+			expect( result[ 0 ].isMouseClick ).toBeUndefined();
+			expect( result[ 0 ].modifierClick ).toBeUndefined();
 		} );
 
 		it( 'does not duplicate dismiss action if already present', () => {


### PR DESCRIPTION
## Problem

Command palette result rows are real links, so Ctrl+click (Cmd+click on a Mac) already opened a result in a new tab — the browser did it. The same chord on the keyboard did nothing at all: keyboard activation never reaches the row's anchor, so there was no browser default to carry the modifier, and no keybinding claimed the accelerator.

While testing this, a second, unrelated bug surfaced and is fixed in its own commit. Recent items were stored with the interaction flags the activation happened to carry, so a row saved from an ordinary mouse click kept `isMouseClick`. That flag tells the router the browser has already followed the anchor — so pressing Enter on the remembered row in a later session closed the palette and navigated nowhere. This is live on `main` today, reproduced in a browser before any of this work was applied.

## Behaviour

- **Ctrl+Enter** (**Cmd+Enter** on a Mac) opens the highlighted result in a new tab and leaves the current page where it is. **Ctrl+Shift+Enter** does the same.
- Plain **Enter** is unchanged, and so is every mouse interaction.
- A modified Enter held while results are still arriving keeps its meaning when they land, rather than falling back to a same-tab navigation.
- If the browser blocks the new tab, the result opens in the current one — an activation that appears to do nothing is worse than one that lands in the wrong place.
- Recent items no longer remember how they were opened. Histories already saved by an earlier version recover on read, so nobody has to clear theirs.

## Contract

- A previewable row (Instant Diffs and similar) still previews in place on an unmodified activation, and a modified one navigates past the preview — the same rule modifier clicks already followed.
- The palette closes on Ctrl+Enter, matching what Ctrl+click already did.
- `newTab` joins `isMouseClick` and `modifierClick` on `CommandPaletteItem`. All three describe how a row was activated, never what the row is, and are stripped before a row is remembered. **Any future flag of this kind needs adding to `ACTIVATION_FLAGS`** — nothing static catches the omission, and the symptom only appears on a later activation in a later session.
- No new interface message and no new footer hint: the chord means the same thing everywhere on the web, and a chip on every highlighted row would crowd the ones that change per row.

## Deliberately not done

- **Shift+Enter is not wired to "open in a new window."** A script cannot ask for a real browser window, only a stripped popup, which would be worse than leaving the chord alone.
- **No `noopener` feature string.** It makes `window.open` return null even on success, which would cost the blocked-popup fallback its only signal. The opener is severed by hand instead.

## Testing

- 12 new unit tests; full suite green (1457).
- Verified in a browser against the dev wiki: both chords open a new tab with the source tab untouched and the opener severed; a held Ctrl+Enter fired with no results on screen and opened its tab once they landed; plain Enter and mouse activation unaffected; the pre-existing recent-items bug reproduced before the fix and confirmed gone after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xE6Dhor1uVh3oXrJcUokQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Open highlighted command-palette results in a new browser tab using the modifier-plus-Enter shortcut.
  * Queued activations now preserve the requested new-tab behavior.
  * If a new tab cannot be opened, navigation falls back to the current tab.
* **Bug Fixes**
  * Recent items no longer retain temporary activation flags, including entries saved by earlier versions.
  * Preview and mouse-click navigation behavior remains consistent.
* **Tests**
  * Added coverage for new-tab activation, fallback navigation, queued actions, and recent-item cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->