### PR TITLE
perf: load Vue once and reuse it across every menu that needs it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,15 +446,15 @@ Breaking changes never ship unguarded — they ride the preview channel until th
 
 Vue and per-module bundles are not part of the initial page load — they're loaded on intent via `mw.loader`. Any control that mounts a Vue app needs:
 
-- **Intent prefetch** via `bindIntentPrefetch()` on the trigger so hover/focus/touch starts the network round-trip before the click. Its optional `onReady` callback fires when the module is ready and can be used to also pre-mount the app during idle time, so the eventual click only pays for the first render — see `createCommandPalette` for the reference implementation (it skips `touchstart` intents, where the tap follows too closely for an idle mount to win).
-- **Lazy load on activation** via `mw.loader.using()` on the actual click/toggle event.
+- **Intent prefetch** via `bindIntentPrefetch()` on the trigger so hover/focus/touch starts the network round-trip before the click. Pass `{ vue: true }` so Vue is claimed as its own request. Its optional `onReady` callback fires when the module is ready and can be used to also pre-mount the app during idle time, so the eventual click only pays for the first render — see `createCommandPalette` for the reference implementation (it skips `touchstart` intents, where the tap follows too closely for an idle mount to win).
+- **Lazy load on activation** via `usingWithVue()` from `vueBatch.js` on the actual click/toggle event — never `mw.loader.using()` directly. `mw.loader` batches a module with every dependency still in state `registered`, so a bare `using()` welds a private copy of Vue into that panel's `load.php` URL. Vue is past `mw.loader.store`'s 100 kB cap, so such a copy is reusable by neither the module store nor the browser's URL-keyed HTTP cache, and every panel re-downloads Vue. `vueBatch.js` documents the ordering invariant that keeps the split free.
 - **Server-rendered skeleton** inside the mount target for in-place panels (Preferences, Share). Vue's `mount()` replaces it on success. The skeleton must be server-rendered because the JS that would render it isn't there yet.
 - **A failure path** sized to the UI's tolerance for staying broken. Pick what fits:
   - Retry the load in place (Preferences renders a retry button beside the skeleton).
   - Degrade to a non-Vue path that achieves the same goal (Share closes the panel and triggers the browser's native share sheet).
   - Surface a toast and dismiss the UI (Command palette uses `mw.notify`; the overlay sits empty during the load and disappears on failure).
 
-See `createPreferences`, `createShare`, and `createCommandPalette` for the patterns.
+See `createPreferences`, `createShare`, and `createCommandPalette` for the patterns, and `vueBatch.js` for why Vue is requested separately.
 
 ### i18n
 

--- a/resources/skins.citizen.scripts/commandPalette.js
+++ b/resources/skins.citizen.scripts/commandPalette.js
@@ -1,6 +1,7 @@
 const MODULE = 'skins.citizen.commandPalette';
 const LOAD_TIMEOUT_MS = 10000;
 const { bindIntentPrefetch } = require( './intentPrefetch.js' );
+const { usingWithVue } = require( './vueBatch.js' );
 
 /**
  * Create the command palette trigger orchestrator.
@@ -129,7 +130,7 @@ function createCommandPalette( { document, mw } ) {
 			timeoutId = setTimeout( () => reject( new Error( 'timeout' ) ), LOAD_TIMEOUT_MS );
 		} );
 
-		Promise.race( [ mw.loader.using( MODULE ), timeoutPromise ] ).then(
+		Promise.race( [ usingWithVue( MODULE, mw ), timeoutPromise ] ).then(
 			( req ) => {
 				clearTimeout( timeoutId );
 				mountApp( req );
@@ -229,6 +230,7 @@ function createCommandPalette( { document, mw } ) {
 		// Touch is excluded: touchstart precedes the tap's click by too
 		// little for an idle mount to win the race.
 		cancelPrefetch = bindIntentPrefetch( summary, MODULE, mw, {
+			vue: true,
 			onReady: ( req, eventType ) => {
 				if ( eventType === 'touchstart' ) {
 					return;

--- a/resources/skins.citizen.scripts/intentPrefetch.js
+++ b/resources/skins.citizen.scripts/intentPrefetch.js
@@ -1,3 +1,5 @@
+const { claimVueBatch } = require( './vueBatch.js' );
+
 const INTENT_EVENTS = [ 'pointerenter', 'focus', 'touchstart' ];
 
 /**
@@ -21,11 +23,14 @@ const INTENT_EVENTS = [ 'pointerenter', 'focus', 'touchstart' ];
  * @param {string} moduleName ResourceLoader module name
  * @param {Object} mw MediaWiki global
  * @param {Object} [options]
+ * @param {boolean} [options.vue] Module is Vue-backed, so claim Vue's own
+ *   ResourceLoader batch alongside it — see `vueBatch.js` for why
  * @param {Function} [options.onReady] Called with `( require, eventType )` when the module is ready
  * @return {Function} cancel
  */
 function bindIntentPrefetch( trigger, moduleName, mw, options ) {
 	const onReady = options && options.onReady;
+	const vue = !!( options && options.vue );
 	let fired = false;
 	let suppressOnReady = false;
 
@@ -34,6 +39,9 @@ function bindIntentPrefetch( trigger, moduleName, mw, options ) {
 			return;
 		}
 		fired = true;
+		if ( vue ) {
+			claimVueBatch( mw );
+		}
 		if ( !onReady ) {
 			mw.loader.load( moduleName );
 			return;

--- a/resources/skins.citizen.scripts/notifications.js
+++ b/resources/skins.citizen.scripts/notifications.js
@@ -1,5 +1,6 @@
 const MODULE = 'skins.citizen.notifications';
 const { bindIntentPrefetch } = require( './intentPrefetch.js' );
+const { usingWithVue } = require( './vueBatch.js' );
 
 /**
  * Trigger orchestrator for the notifications dropdown.
@@ -129,6 +130,7 @@ function createNotifications( { document, mw } ) {
 		// touchstart too closely for an idle callback to win, and the mount is
 		// cheap enough to run inline.
 		cancelPrefetch = bindIntentPrefetch( summary, MODULE, mw, {
+			vue: true,
 			onReady: ( req, eventType ) => {
 				const mount = () => {
 					// A click may have beaten this callback — the load path owns
@@ -169,7 +171,7 @@ function createNotifications( { document, mw } ) {
 			loading = true;
 			showPreview();
 
-			mw.loader.using( MODULE ).then(
+			usingWithVue( MODULE, mw ).then(
 				( req ) => {
 					// A throw here (module shape, Vue mount) is not caught by
 					// the rejection handler below, so guard it explicitly —

--- a/resources/skins.citizen.scripts/preferences.js
+++ b/resources/skins.citizen.scripts/preferences.js
@@ -1,5 +1,6 @@
 const MODULE = 'skins.citizen.preferences';
 const { bindIntentPrefetch } = require( './intentPrefetch.js' );
+const { usingWithVue } = require( './vueBatch.js' );
 
 /**
  * @param {Object} deps
@@ -57,7 +58,7 @@ function createPreferences( { document, mw } ) {
 			}
 		}
 
-		const cancelPrefetch = bindIntentPrefetch( summary, MODULE, mw );
+		const cancelPrefetch = bindIntentPrefetch( summary, MODULE, mw, { vue: true } );
 
 		function load() {
 			if ( mounted || loading ) {
@@ -66,7 +67,7 @@ function createPreferences( { document, mw } ) {
 			loading = true;
 			showSkeleton();
 
-			mw.loader.using( MODULE ).then(
+			usingWithVue( MODULE, mw ).then(
 				() => {
 					mounted = true;
 					loading = false;

--- a/resources/skins.citizen.scripts/share.js
+++ b/resources/skins.citizen.scripts/share.js
@@ -1,5 +1,6 @@
 const MODULE = 'skins.citizen.share';
 const { bindIntentPrefetch } = require( './intentPrefetch.js' );
+const { usingWithVue } = require( './vueBatch.js' );
 const { triggerNativeShare } = require( './triggerNativeShare.js' );
 
 /**
@@ -92,7 +93,7 @@ function createShare( { document, window, mw, navigator, mode = 'auto' } ) {
  */
 function createPanel( { trigger, nativeDialog, mountPoint, mw, window } ) {
 	let state = 'idle'; // 'idle' | 'loading' | 'mounted'
-	const cancelPrefetch = bindIntentPrefetch( trigger, MODULE, mw );
+	const cancelPrefetch = bindIntentPrefetch( trigger, MODULE, mw, { vue: true } );
 
 	function closeNativeDialog() {
 		if ( nativeDialog.open ) {
@@ -102,7 +103,7 @@ function createPanel( { trigger, nativeDialog, mountPoint, mw, window } ) {
 
 	function load() {
 		state = 'loading';
-		mw.loader.using( MODULE ).then(
+		usingWithVue( MODULE, mw ).then(
 			( req ) => {
 				const mod = req( MODULE );
 				mod.initApp( mountPoint );

--- a/resources/skins.citizen.scripts/vueBatch.js
+++ b/resources/skins.citizen.scripts/vueBatch.js
@@ -1,0 +1,44 @@
+const VUE_MODULE = 'vue';
+
+/**
+ * Request Vue as its own ResourceLoader batch.
+ *
+ * `mw.loader` batches a module together with every dependency still in state
+ * `registered`, so a bare `using( panel )` mints a load.php URL carrying its
+ * own copy of Vue. The browser caches by full URL, and Vue's serialised form is
+ * far past `mw.loader.store`'s 100 kB per-module cap, so those copies are
+ * reusable by neither cache: each Vue-backed panel re-downloads Vue on every
+ * page view that opens it first. Claiming Vue separately moves it to `loading`,
+ * which excludes it from the panel's batch and leaves `modules=vue` as a single
+ * URL shared by every panel and stable across releases.
+ *
+ * Two constraints keep this free, and both are load-bearing:
+ * Vue must be requested *before* the panel, and it must not be awaited —
+ * `mw.loader.work()` runs synchronously inside `using()`, so the two requests
+ * are issued back to back and travel in parallel. Awaiting would serialise them
+ * and cost a round trip.
+ *
+ * When Vue is already loading or ready — an earlier panel, or an extension that
+ * pulled it in — this is a no-op and issues no request.
+ *
+ * @param {Object} mw MediaWiki global
+ */
+function claimVueBatch( mw ) {
+	// Speculative, so failure stays silent: the caller's own load owns error
+	// surfacing, and an unhandled rejection here would surface twice.
+	mw.loader.using( VUE_MODULE ).catch( () => {} );
+}
+
+/**
+ * `mw.loader.using` for a Vue-backed module, keeping Vue in its own request.
+ *
+ * @param {string} moduleName
+ * @param {Object} mw MediaWiki global
+ * @return {jQuery.Promise} With a `require` function
+ */
+function usingWithVue( moduleName, mw ) {
+	claimVueBatch( mw );
+	return mw.loader.using( moduleName );
+}
+
+module.exports = { claimVueBatch, usingWithVue };

--- a/skin.json
+++ b/skin.json
@@ -220,7 +220,8 @@
 				"resources/skins.citizen.scripts/share.js",
 				"resources/skins.citizen.scripts/triggerNativeShare.js",
 				"resources/skins.citizen.scripts/speculationRules.js",
-				"resources/skins.citizen.scripts/stickyHeader.js"
+				"resources/skins.citizen.scripts/stickyHeader.js",
+				"resources/skins.citizen.scripts/vueBatch.js"
 			],
 			"messages": [
 				"citizen-command-palette-load-error",

--- a/tests/vitest/skins.citizen.scripts/intentPrefetch.test.js
+++ b/tests/vitest/skins.citizen.scripts/intentPrefetch.test.js
@@ -15,6 +15,40 @@ describe( 'bindIntentPrefetch', () => {
 		return document.getElementById( 'trigger' );
 	}
 
+	describe( 'vue option', () => {
+		beforeEach( () => {
+			mw.loader.using.mockClear();
+		} );
+
+		it( 'claims the vue batch before the module on the load path', () => {
+			const trigger = makeTrigger();
+
+			bindIntentPrefetch( trigger, 'foo.module', mw, { vue: true } );
+			trigger.dispatchEvent( new Event( 'pointerenter' ) );
+
+			expect( mw.loader.using ).toHaveBeenCalledWith( 'vue' );
+			expect( mw.loader.load ).toHaveBeenCalledWith( 'foo.module' );
+		} );
+
+		it( 'claims the vue batch before the module on the onReady path', () => {
+			const trigger = makeTrigger();
+
+			bindIntentPrefetch( trigger, 'foo.module', mw, { vue: true, onReady: () => {} } );
+			trigger.dispatchEvent( new Event( 'pointerenter' ) );
+
+			expect( mw.loader.using.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [ 'vue', 'foo.module' ] );
+		} );
+
+		it( 'does not touch vue when the option is absent', () => {
+			const trigger = makeTrigger();
+
+			bindIntentPrefetch( trigger, 'foo.module', mw );
+			trigger.dispatchEvent( new Event( 'pointerenter' ) );
+
+			expect( mw.loader.using ).not.toHaveBeenCalledWith( 'vue' );
+		} );
+	} );
+
 	it( 'fires mw.loader.load once on pointerenter', () => {
 		const trigger = makeTrigger();
 

--- a/tests/vitest/skins.citizen.scripts/notifications.test.js
+++ b/tests/vitest/skins.citizen.scripts/notifications.test.js
@@ -171,7 +171,7 @@ describe( 'notifications trigger', () => {
 		await tick();
 		await setOpen( true );
 
-		expect( mw.loader.using ).toHaveBeenCalledTimes( 1 );
+		expect( mw.loader.using.mock.calls.filter( ( [ name ] ) => name !== 'vue' ) ).toHaveLength( 1 );
 		expect( mockRefresh ).toHaveBeenCalledTimes( 1 );
 	} );
 
@@ -261,12 +261,12 @@ describe( 'notifications trigger', () => {
 		await setOpen( true );
 		resolveLoad();
 		await tick();
-		expect( mw.loader.using ).toHaveBeenCalledTimes( 1 );
+		expect( mw.loader.using.mock.calls.filter( ( [ name ] ) => name !== 'vue' ) ).toHaveLength( 1 );
 
 		await setOpen( false );
 		await setOpen( true );
 
-		expect( mw.loader.using ).toHaveBeenCalledTimes( 1 );
+		expect( mw.loader.using.mock.calls.filter( ( [ name ] ) => name !== 'vue' ) ).toHaveLength( 1 );
 		expect( mockRefresh ).toHaveBeenCalledTimes( 1 );
 		expect( mockMarkSeen ).toHaveBeenCalledTimes( 2 );
 	} );
@@ -299,7 +299,7 @@ describe( 'notifications trigger', () => {
 
 		// Retry re-attempts the load.
 		document.querySelector( '.citizen-notifications__retry' ).click();
-		expect( mw.loader.using ).toHaveBeenCalledTimes( 2 );
+		expect( mw.loader.using.mock.calls.filter( ( [ name ] ) => name !== 'vue' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'keeps the footer links reachable when the module fails to load', async () => {
@@ -354,6 +354,6 @@ describe( 'notifications trigger', () => {
 		await setOpen( false );
 		await setOpen( true );
 
-		expect( mw.loader.using ).toHaveBeenCalledTimes( 2 );
+		expect( mw.loader.using.mock.calls.filter( ( [ name ] ) => name !== 'vue' ) ).toHaveLength( 2 );
 	} );
 } );

--- a/tests/vitest/skins.citizen.scripts/preferences.test.js
+++ b/tests/vitest/skins.citizen.scripts/preferences.test.js
@@ -166,7 +166,7 @@ describe( 'createPreferences', () => {
 			Object.defineProperty( details, 'open', { value: true, configurable: true } );
 			details.dispatchEvent( new Event( 'toggle' ) );
 
-			expect( mw.loader.using ).toHaveBeenCalledTimes( 1 );
+			expect( mw.loader.using.mock.calls.filter( ( [ name ] ) => name !== 'vue' ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -195,7 +195,7 @@ describe( 'createPreferences', () => {
 			const retryBtn = document.querySelector( '.citizen-preferences-error__retry' );
 			retryBtn.click();
 
-			expect( mw.loader.using ).toHaveBeenCalledTimes( 1 );
+			expect( mw.loader.using.mock.calls.filter( ( [ name ] ) => name !== 'vue' ) ).toHaveLength( 1 );
 			const skeletonEl = document.querySelector( '.citizen-preferences-skeleton' );
 			const errorEl = document.querySelector( '.citizen-preferences-error' );
 			expect( skeletonEl.hidden ).toBe( false );

--- a/tests/vitest/skins.citizen.scripts/vueBatch.test.js
+++ b/tests/vitest/skins.citizen.scripts/vueBatch.test.js
@@ -1,0 +1,62 @@
+const { claimVueBatch, usingWithVue } = require( '../../../resources/skins.citizen.scripts/vueBatch.js' );
+
+const MODULE = 'skins.citizen.commandPalette';
+
+let mw;
+
+beforeEach( () => {
+	mw = { loader: { using: vi.fn( () => Promise.resolve() ) } };
+} );
+
+describe( 'claimVueBatch', () => {
+	it( 'requests vue on its own so the panel batch excludes it', () => {
+		claimVueBatch( mw );
+
+		expect( mw.loader.using ).toHaveBeenCalledTimes( 1 );
+		expect( mw.loader.using ).toHaveBeenCalledWith( 'vue' );
+	} );
+
+	it( 'swallows a failed vue load so the caller owns error surfacing', async () => {
+		mw.loader.using = vi.fn( () => Promise.reject( new Error( 'network' ) ) );
+
+		expect( () => claimVueBatch( mw ) ).not.toThrow();
+		await Promise.resolve();
+	} );
+} );
+
+describe( 'usingWithVue', () => {
+	it( 'requests vue before the module', () => {
+		usingWithVue( MODULE, mw );
+
+		expect( mw.loader.using.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [ 'vue', MODULE ] );
+	} );
+
+	it( 'does not await vue, so both requests are in flight together', () => {
+		let resolveVue;
+		mw.loader.using = vi.fn( ( name ) => name === 'vue' ?
+			new Promise( ( resolve ) => {
+				resolveVue = resolve;
+			} ) :
+			Promise.resolve() );
+
+		usingWithVue( MODULE, mw );
+
+		expect( mw.loader.using ).toHaveBeenCalledWith( MODULE );
+		expect( resolveVue ).toBeTypeOf( 'function' );
+	} );
+
+	it( 'resolves with the module require function', async () => {
+		const req = vi.fn();
+		mw.loader.using = vi.fn( ( name ) => Promise.resolve( name === 'vue' ? undefined : req ) );
+
+		await expect( usingWithVue( MODULE, mw ) ).resolves.toBe( req );
+	} );
+
+	it( 'rejects when the module fails, regardless of vue', async () => {
+		mw.loader.using = vi.fn( ( name ) => name === 'vue' ?
+			Promise.resolve() :
+			Promise.reject( new Error( 'module failed' ) ) );
+
+		await expect( usingWithVue( MODULE, mw ) ).rejects.toThrow( 'module failed' );
+	} );
+} );


### PR DESCRIPTION
## Problem

Citizen has four lazy-loaded Vue-backed menus: the command palette, preferences, share and notifications. Each one downloaded its own private copy of Vue, and none of those copies could be reused by the others.

Two caches were supposed to prevent this and neither does:

- **The browser HTTP cache** keys on the full URL. Because ResourceLoader batches a module together with every dependency that isn't loaded yet, each menu produced a different `modules=` list with Vue welded inside it — four URLs, four copies.
- **`mw.loader.store`** (localStorage) refuses any module over 100 kB. Vue is roughly 152 kB in production, so it is never stored, in any wiki, ever.

The module store actually made things worse. As smaller modules moved into localStorage they dropped out of the batch, which reshaped the URL and minted yet another Vue-bearing entry. A five-page-view session on the dev wiki produced **five differently-shaped URLs and five full Vue downloads**.

This also meant every Citizen release that touched any of those four bundles invalidated Vue's bytes along with them, because the URL's version hash covers the whole batch.

## Behaviour after this change

Vue is requested as its own `load.php` entry, so all four menus share one cached copy that stays valid across releases.

Measured on the dev wiki at Slow 4G with 4× CPU throttling, time from load to module ready:

| | Before | After |
| --- | --- | --- |
| Cold first open | 1484 ms | 1502 ms (unchanged) |
| Second menu | 2750 ms | 2143 ms |
| Third menu | 1283 ms | 701 ms |

The second menu drops from 135,930 to 41,174 bytes, with Vue served from cache.

The cold first open is deliberately unchanged — that is the case the existing intent-prefetch was built to mask, and this must not regress it. The two requests are issued back to back and travel in parallel, so the split costs no extra round trip.

## Contract

- **Readers are unaffected.** No Vue-backed module ships on initial page load, so someone who never opens a menu downloads zero Vue before and after.
- **No-op when Vue is already present.** If an extension loaded Vue first, the extra request is never issued — measured at 0 ms and 0 requests.
- **No behaviour change to the menus themselves**: intent prefetch, idle mount, error, timeout and retry paths are untouched.
- **No caching implication for PHP-rendered HTML.** Nothing about the markup changes, so no compat slice is needed.

`AGENTS.md` previously told contributors to load these modules the old way. Following that wording when adding a fifth menu would have quietly recreated the problem, so it now documents the shared-Vue requirement.

## Testing

- 1466 unit tests pass; 9 are new, covering the ordering requirement, the already-loaded no-op, and the promise contract.
- All four menus driven end-to-end in a real browser through their actual triggers, including notifications with a logged-in Echo user. Cross-menu reuse confirmed: opening notifications on one page view, then the command palette on the next, served Vue from cache.
- No console errors.

## Follow-ups, deliberately not in scope

- **The four Codex modules still overlap.** `CdxIcon` appears in all four, `CdxButton` in three, and `share`'s Codex payload is a strict subset of the command palette's. Merging them is a genuine trade-off — anyone who opens a single menu would pay for the union — so it wants its own measurement.
- **A hover on the search button still costs a full menu download** even if the user never opens it. That is a question about prefetch policy rather than caching, and it trades directly against the first-open latency this prefetch exists to hide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved loading behavior for Vue-powered features, including the command palette, notifications, preferences, and sharing panels.
  - Vue resources are now prepared more efficiently during user interactions, helping related features appear more reliably and responsively.
  - Added resilient handling for Vue loading failures so individual feature loads can continue gracefully.

- **Documentation**
  - Updated guidance for integrating lazy-loaded Vue modules and linked to the relevant loading reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->