### PR TITLE
refactor(codex): declare Codex components on the module that uses them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ To add a new skill, create `.agents/skills/<name>/SKILL.md` with frontmatter (`n
 
 - Use the Codex version bundled with MediaWiki — do not assume a specific version. The minimum is v1.14.0 (bundled with MW 1.43), but newer MW versions may provide a newer Codex.
 - Codex components requiring JS must be listed in `skin.json` under the appropriate `CodexModule`
+- A module's `codex.js` is generated at request time and has no on-disk counterpart, so Vitest resolves the components' `require( '…/codex.js' )` to `tests/vitest/mocks/codex.js`. Register stubs with `setCodexStubs()` **before** importing the component — it destructures at module-evaluation time.
 
 ### skin.json
 

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteDetailPanel.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteDetailPanel.vue
@@ -75,7 +75,7 @@
 
 <script>
 const { defineComponent, ref, computed, watch, onBeforeUnmount } = require( 'vue' );
-const { CdxButton, CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxButton, CdxIcon } = require( '../../../codex.js' );
 const { cdxIconCopy, cdxIconCheck } = require( '../icons.json' );
 const CommandPaletteImage = require( './CommandPaletteImage.vue' );
 

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteEmptyState.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteEmptyState.vue
@@ -26,7 +26,7 @@
 
 <script>
 const { defineComponent } = require( 'vue' );
-const { CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxIcon } = require( '../../../codex.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteHeader.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteHeader.vue
@@ -68,7 +68,7 @@
 
 <script>
 const { defineComponent, ref, computed } = require( 'vue' );
-const { CdxButton, CdxInfoChip, CdxTextInput, CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxButton, CdxInfoChip, CdxTextInput, CdxIcon } = require( '../../../codex.js' );
 const { cdxIconArrowPrevious, cdxIconHelp, cdxIconSearch } = require( '../icons.json' );
 
 // @vue/component

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteHelpModeSummary.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteHelpModeSummary.vue
@@ -21,7 +21,7 @@
 
 <script>
 const { defineComponent } = require( 'vue' );
-const { CdxThumbnail } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxThumbnail } = require( '../../../codex.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteImage.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteImage.vue
@@ -30,7 +30,7 @@
 
 <script>
 const { defineComponent, computed, ref, watch } = require( 'vue' );
-const { CdxIcon } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxIcon } = require( '../../../codex.js' );
 
 // Mirrors the validators in @wikimedia/codex's CdxImage so this component
 // can be swapped for CdxImage with a search-and-replace once MW LTS bundles

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemActions.vue
@@ -24,7 +24,7 @@
 
 <script>
 const { defineComponent, ref, onBeforeUpdate, nextTick } = require( 'vue' );
-const { CdxIcon, CdxButton } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxIcon, CdxButton } = require( '../../../codex.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteListItemContent.vue
@@ -95,7 +95,7 @@
 
 <script>
 const { defineComponent } = require( 'vue' );
-const { CdxIcon, CdxSearchResultTitle, CdxThumbnail } = mw.loader.require( 'skins.citizen.commandPalette.codex' );
+const { CdxIcon, CdxSearchResultTitle, CdxThumbnail } = require( '../../../codex.js' );
 
 // @vue/component
 module.exports = exports = defineComponent( {

--- a/resources/skins.citizen.notifications/components/App.vue
+++ b/resources/skins.citizen.notifications/components/App.vue
@@ -118,7 +118,7 @@
 
 <script>
 const { defineComponent, ref, computed, inject, onMounted } = require( 'vue' );
-const { CdxButton, CdxTab, CdxTabs } = mw.loader.require( 'skins.citizen.notifications.codex' );
+const { CdxButton, CdxTab, CdxTabs } = require( '../../../codex.js' );
 const NotificationList = require( './NotificationList.vue' );
 const WikiList = require( './WikiList.vue' );
 const PanelFooter = require( './PanelFooter.vue' );

--- a/resources/skins.citizen.notifications/components/PanelFooter.vue
+++ b/resources/skins.citizen.notifications/components/PanelFooter.vue
@@ -36,7 +36,7 @@
 
 <script>
 const { defineComponent, computed } = require( 'vue' );
-const { CdxButton, CdxIcon } = mw.loader.require( 'skins.citizen.notifications.codex' );
+const { CdxButton, CdxIcon } = require( '../../../codex.js' );
 const icons = require( '../icons.json' );
 
 // Links styled as normal-weight cdx buttons need the fake-button variants;

--- a/resources/skins.citizen.notifications/components/WikiList.vue
+++ b/resources/skins.citizen.notifications/components/WikiList.vue
@@ -52,7 +52,7 @@
 
 <script>
 const { defineComponent, computed, reactive, watch } = require( 'vue' );
-const { CdxIcon } = mw.loader.require( 'skins.citizen.notifications.codex' );
+const { CdxIcon } = require( '../../../codex.js' );
 const NotificationList = require( './NotificationList.vue' );
 const icons = require( '../icons.json' );
 const formatRelativeTime = require( '../relativeTime.js' );

--- a/resources/skins.citizen.preferences/App.vue
+++ b/resources/skins.citizen.preferences/App.vue
@@ -79,7 +79,7 @@
 <script>
 const { defineComponent, computed, inject, reactive, ref, watch } = require( 'vue' );
 const { NormalizedPreferencesConfig } = require( './types.js' );
-const { CdxField, CdxSelect, CdxToggleSwitch } = mw.loader.require( 'skins.citizen.preferences.codex' );
+const { CdxField, CdxSelect, CdxToggleSwitch } = require( '../../codex.js' );
 const RadioGroup = require( './RadioGroup.vue' );
 const ThemePicker = require( './ThemePicker.vue' );
 const useVisibility = require( './useVisibility.js' );

--- a/resources/skins.citizen.preferences/RadioGroup.vue
+++ b/resources/skins.citizen.preferences/RadioGroup.vue
@@ -28,7 +28,7 @@
 
 <script>
 const { defineComponent } = require( 'vue' );
-const { CdxIcon, CdxRadio } = mw.loader.require( 'skins.citizen.preferences.codex' );
+const { CdxIcon, CdxRadio } = require( '../../codex.js' );
 const { cdxIconAlignRight } = require( './icons.json' );
 
 // @vue/component

--- a/resources/skins.citizen.preferences/ThemePicker.vue
+++ b/resources/skins.citizen.preferences/ThemePicker.vue
@@ -36,7 +36,7 @@
 
 <script>
 const { defineComponent, ref, computed, watch, onMounted } = require( 'vue' );
-const { CdxRadio } = mw.loader.require( 'skins.citizen.preferences.codex' );
+const { CdxRadio } = require( '../../codex.js' );
 const { measureIdentityBaseline } = require( './themePreviewBaseline.js' );
 
 // @vue/component

--- a/resources/skins.citizen.share/App.vue
+++ b/resources/skins.citizen.share/App.vue
@@ -128,7 +128,7 @@
 
 <script>
 const { defineComponent, inject, ref, computed, onMounted, onBeforeUnmount, nextTick } = require( 'vue' );
-const { CdxButton, CdxIcon, CdxTextInput } = mw.loader.require( 'skins.citizen.share.codex' );
+const { CdxButton, CdxIcon, CdxTextInput } = require( '../../codex.js' );
 const { cdxIconArrowPrevious, cdxIconCheck, cdxIconCopy, cdxIconLink, cdxIconQrCode } = require( './icons.json' );
 const { useUrlShortener } = require( './composables/useUrlShortener.js' );
 const { useDialogResizeAnimation } = require( './composables/useDialogResizeAnimation.js' );

--- a/skin.json
+++ b/skin.json
@@ -262,7 +262,7 @@
 				"mediawiki.util"
 			]
 		},
-		"skins.citizen.preferences.codex": {
+		"skins.citizen.preferences": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
 			"codexComponents": [
 				"CdxField",
@@ -270,9 +270,7 @@
 				"CdxRadio",
 				"CdxSelect",
 				"CdxToggleSwitch"
-			]
-		},
-		"skins.citizen.preferences": {
+			],
 			"packageFiles": [
 				"resources/skins.citizen.preferences/init.js",
 				"resources/skins.citizen.preferences/App.vue",
@@ -340,7 +338,6 @@
 				"preferences"
 			],
 			"dependencies": [
-				"skins.citizen.preferences.codex",
 				"mediawiki.storage",
 				"mediawiki.util",
 				"vue"
@@ -349,15 +346,13 @@
 				"resources/skins.citizen.preferences/themePreview.less"
 			]
 		},
-		"skins.citizen.share.codex": {
+		"skins.citizen.share": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
 			"codexComponents": [
 				"CdxButton",
 				"CdxIcon",
 				"CdxTextInput"
-			]
-		},
-		"skins.citizen.share": {
+			],
 			"packageFiles": [
 				"resources/skins.citizen.share/init.js",
 				"resources/skins.citizen.share/composables/useUrlShortener.js",
@@ -395,7 +390,6 @@
 				"citizen-share-back"
 			],
 			"dependencies": [
-				"skins.citizen.share.codex",
 				"mediawiki.util",
 				"vue"
 			]
@@ -407,6 +401,14 @@
 		},
 		"skins.citizen.commandPalette": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
+			"codexComponents": [
+				"CdxButton",
+				"CdxIcon",
+				"CdxInfoChip",
+				"CdxSearchResultTitle",
+				"CdxTextInput",
+				"CdxThumbnail"
+			],
 			"dependencies": [
 				"mediawiki.api",
 				"mediawiki.jqueryMsg",
@@ -414,7 +416,6 @@
 				"mediawiki.page.ready",
 				"mediawiki.storage",
 				"mediawiki.util",
-				"skins.citizen.commandPalette.codex",
 				"vue"
 			],
 			"packageFiles": [
@@ -589,17 +590,6 @@
 				"talk"
 			]
 		},
-		"skins.citizen.commandPalette.codex": {
-			"class": "MediaWiki\\ResourceLoader\\CodexModule",
-			"codexComponents": [
-				"CdxButton",
-				"CdxIcon",
-				"CdxInfoChip",
-				"CdxSearchResultTitle",
-				"CdxTextInput",
-				"CdxThumbnail"
-			]
-		},
 		"skins.citizen.commandPalette.smw": {
 			"packageFiles": [
 				"resources/skins.citizen.commandPalette.smw/init.js",
@@ -643,11 +633,16 @@
 		},
 		"skins.citizen.notifications": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
+			"codexComponents": [
+				"CdxButton",
+				"CdxIcon",
+				"CdxTab",
+				"CdxTabs"
+			],
 			"dependencies": [
 				"mediawiki.api",
 				"mediawiki.ForeignApi",
 				"mediawiki.util",
-				"skins.citizen.notifications.codex",
 				"vue"
 			],
 			"packageFiles": [
@@ -686,15 +681,6 @@
 				"citizen-notifications-retry",
 				"citizen-notifications-see-all",
 				"citizen-notifications-preferences"
-			]
-		},
-		"skins.citizen.notifications.codex": {
-			"class": "MediaWiki\\ResourceLoader\\CodexModule",
-			"codexComponents": [
-				"CdxButton",
-				"CdxIcon",
-				"CdxTab",
-				"CdxTabs"
 			]
 		},
 		"skins.citizen.icons": {

--- a/tests/vitest/commandPalette/components/CommandPaletteGallery.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteGallery.test.js
@@ -2,15 +2,16 @@
 
 const { mount } = require( '@vue/test-utils' );
 const mw = require( '../../mocks/mw.js' );
+const { setCodexStubs } = require( '../../mocks/codex.js' );
 globalThis.mw = mw;
 
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxThumbnail: {
 		name: 'CdxThumbnail',
 		template: '<div class="cdx-thumbnail-stub"></div>',
 		props: [ 'thumbnail', 'placeholderIcon' ]
 	}
-} ) );
+} );
 
 let CommandPaletteGallery;
 

--- a/tests/vitest/commandPalette/components/CommandPaletteGalleryItem.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteGalleryItem.test.js
@@ -2,18 +2,19 @@
 
 const { mount } = require( '@vue/test-utils' );
 const mw = require( '../../mocks/mw.js' );
+const { setCodexStubs } = require( '../../mocks/codex.js' );
 globalThis.mw = mw;
 
-// CommandPaletteImage (the gallery tile's child) imports CdxIcon via
-// `mw.loader.require` at module load — stub it so the component tree
-// renders without a real Codex bundle.
-mw.loader.require = vi.fn( () => ( {
+// CommandPaletteImage (the gallery tile's child) destructures CdxIcon from
+// the module's generated codex.js at module load — stub it so the component
+// tree renders without a real Codex bundle.
+setCodexStubs( {
 	CdxIcon: {
 		name: 'CdxIcon',
 		template: '<span class="cdx-icon-stub"></span>',
 		props: [ 'icon' ]
 	}
-} ) );
+} );
 
 let CommandPaletteGalleryItem;
 

--- a/tests/vitest/commandPalette/components/CommandPaletteHeader.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteHeader.test.js
@@ -2,12 +2,13 @@
 
 const { mount } = require( '@vue/test-utils' );
 const mw = require( '../../mocks/mw.js' );
+const { setCodexStubs } = require( '../../mocks/codex.js' );
 globalThis.mw = mw;
 
 // CdxTextInput sets `inheritAttrs: false` so that ARIA attributes land on the
 // real <input> rather than the wrapper. The stub has to do the same, or these
 // tests would pass against markup a screen reader never sees.
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxButton: {
 		name: 'CdxButton',
 		template: '<button><slot></slot></button>'
@@ -27,7 +28,7 @@ mw.loader.require = vi.fn( () => ( {
 		props: [ 'modelValue', 'inputType', 'clearable', 'placeholder' ],
 		template: '<div class="cdx-text-input-stub"><input v-bind="$attrs"></div>'
 	}
-} ) );
+} );
 
 let CommandPaletteHeader;
 

--- a/tests/vitest/commandPalette/components/CommandPaletteImage.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteImage.test.js
@@ -2,15 +2,16 @@
 
 const { mount } = require( '@vue/test-utils' );
 const mw = require( '../../mocks/mw.js' );
+const { setCodexStubs } = require( '../../mocks/codex.js' );
 globalThis.mw = mw;
 
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxIcon: {
 		name: 'CdxIcon',
 		template: '<span class="cdx-icon-stub"></span>',
 		props: [ 'icon' ]
 	}
-} ) );
+} );
 
 let CommandPaletteImage;
 

--- a/tests/vitest/commandPalette/components/CommandPaletteListItemContent.test.js
+++ b/tests/vitest/commandPalette/components/CommandPaletteListItemContent.test.js
@@ -2,9 +2,10 @@
 
 const { mount } = require( '@vue/test-utils' );
 const mw = require( '../../mocks/mw.js' );
+const { setCodexStubs } = require( '../../mocks/codex.js' );
 globalThis.mw = mw;
 
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxIcon: {
 		name: 'CdxIcon',
 		template: '<span class="cdx-icon"></span>',
@@ -20,7 +21,7 @@ mw.loader.require = vi.fn( () => ( {
 		template: '<div class="cdx-thumbnail"></div>',
 		props: [ 'thumbnail', 'placeholderIcon' ]
 	}
-} ) );
+} );
 
 let CommandPaletteListItemContent;
 

--- a/tests/vitest/mocks/codex.js
+++ b/tests/vitest/mocks/codex.js
@@ -1,0 +1,32 @@
+/**
+ * Stand-in for the `codex.js` that ResourceLoader synthesises inside a
+ * CodexModule from its `codexComponents` list. The real file is generated at
+ * request time and has no on-disk counterpart, so `tests/vitest/setup.js`
+ * resolves the components' `require( '…/codex.js' )` here instead.
+ *
+ * Components destructure this at module-evaluation time, so a test must call
+ * `setCodexStubs()` before it imports the component under test.
+ */
+
+const stubs = {};
+
+/**
+ * Replace the registered stubs.
+ *
+ * Consumers destructure this module as they evaluate, so re-registering only
+ * reaches components imported afterwards — never one that is already loaded.
+ *
+ * @param {Object} components Map of Codex component name to Vue stub
+ */
+function setCodexStubs( components ) {
+	for ( const key of Object.keys( stubs ) ) {
+		if ( key !== 'setCodexStubs' ) {
+			delete stubs[ key ];
+		}
+	}
+	Object.assign( stubs, components );
+}
+
+stubs.setCodexStubs = setCodexStubs;
+
+module.exports = stubs;

--- a/tests/vitest/setup.js
+++ b/tests/vitest/setup.js
@@ -88,5 +88,12 @@ Module._resolveFilename = function ( request, parent, ...rest ) {
 			return path.resolve( __dirname, 'mocks/AppStub.js' );
 		}
 	}
+	// ResourceLoader synthesises `codex.js` inside a CodexModule from its
+	// `codexComponents` list; it has no on-disk counterpart for Node to find.
+	if ( parent && parent.filename &&
+		parent.filename.includes( 'resources/skins.citizen.' ) &&
+		request.endsWith( '/codex.js' ) ) {
+		return path.resolve( __dirname, 'mocks/codex.js' );
+	}
 	return originalResolveFilename.call( this, request, parent, ...rest );
 };

--- a/tests/vitest/skins.citizen.notifications/App.test.js
+++ b/tests/vitest/skins.citizen.notifications/App.test.js
@@ -5,10 +5,11 @@ const { mount, flushPromises } = require( '@vue/test-utils' );
 // Vue instance — otherwise @vue/test-utils' mount throws `app.onUnmount`.
 require( 'vue' );
 const mw = require( '../mocks/mw.js' );
+const { setCodexStubs } = require( '../mocks/codex.js' );
 globalThis.mw = mw;
 
-// Stub the Codex components the panel pulls via mw.loader.require.
-mw.loader.require = vi.fn( () => ( {
+// Stub the Codex components the panel pulls from the module's codex.js.
+setCodexStubs( {
 	CdxButton: {
 		name: 'CdxButton',
 		template: '<button class="cdx-button" :disabled="disabled" @click="$emit( \'click\', $event )"><slot /></button>',
@@ -31,7 +32,7 @@ mw.loader.require = vi.fn( () => ( {
 		template: '<div class="cdx-tab" :data-tab="name"><slot /></div>',
 		props: [ 'name', 'label' ]
 	},
-} ) );
+} );
 
 let App;
 

--- a/tests/vitest/skins.citizen.notifications/PanelFooter.test.js
+++ b/tests/vitest/skins.citizen.notifications/PanelFooter.test.js
@@ -5,10 +5,11 @@ const { mount } = require( '@vue/test-utils' );
 // Vue instance — otherwise @vue/test-utils' mount throws `app.onUnmount`.
 require( 'vue' );
 const mw = require( '../mocks/mw.js' );
+const { setCodexStubs } = require( '../mocks/codex.js' );
 globalThis.mw = mw;
 
-// Stub the Codex components the footer pulls via mw.loader.require.
-mw.loader.require = vi.fn( () => ( {
+// Stub the Codex components the footer pulls from the module's codex.js.
+setCodexStubs( {
 	CdxButton: {
 		name: 'CdxButton',
 		template: '<button class="cdx-button" :disabled="disabled" @click="$emit( \'click\', $event )"><slot /></button>',
@@ -20,7 +21,7 @@ mw.loader.require = vi.fn( () => ( {
 		template: '<span class="cdx-icon"></span>',
 		props: [ 'icon' ]
 	}
-} ) );
+} );
 
 let PanelFooter;
 

--- a/tests/vitest/skins.citizen.notifications/WikiList.test.js
+++ b/tests/vitest/skins.citizen.notifications/WikiList.test.js
@@ -5,15 +5,16 @@ const { mount, flushPromises } = require( '@vue/test-utils' );
 // Vue instance — otherwise @vue/test-utils' mount throws `app.onUnmount`.
 require( 'vue' );
 const mw = require( '../mocks/mw.js' );
+const { setCodexStubs } = require( '../mocks/codex.js' );
 globalThis.mw = mw;
 
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxIcon: {
 		name: 'CdxIcon',
 		template: '<span class="cdx-icon"></span>',
 		props: [ 'icon' ]
 	}
-} ) );
+} );
 
 let WikiList;
 

--- a/tests/vitest/skins.citizen.preferences/App.test.js
+++ b/tests/vitest/skins.citizen.preferences/App.test.js
@@ -3,10 +3,11 @@
 const { mount, shallowMount, flushPromises } = require( '@vue/test-utils' );
 const { reactive } = require( 'vue' );
 const mw = require( '../mocks/mw.js' );
+const { setCodexStubs } = require( '../mocks/codex.js' );
 globalThis.mw = mw;
 
 // Stub Codex components before loading App.vue
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxField: {
 		name: 'CdxField',
 		template: '<fieldset :id="id" class="cdx-field citizen-preferences-group"><div class="cdx-label"><slot name="label" /></div><div class="cdx-label__description"><slot name="description" /></div><slot /></fieldset>',
@@ -30,7 +31,7 @@ mw.loader.require = vi.fn( () => ( {
 		props: [ 'id', 'modelValue' ],
 		emits: [ 'update:modelValue' ]
 	}
-} ) );
+} );
 
 // Mock getComputedStyle to return fake CSS custom property values and a
 // resolved color-scheme (which useVisibility's dark-theme condition reads).

--- a/tests/vitest/skins.citizen.preferences/RadioGroup.test.js
+++ b/tests/vitest/skins.citizen.preferences/RadioGroup.test.js
@@ -2,10 +2,11 @@
 
 const { mount } = require( '@vue/test-utils' );
 const mw = require( '../mocks/mw.js' );
+const { setCodexStubs } = require( '../mocks/codex.js' );
 globalThis.mw = mw;
 
 // Mock Codex components before loading the component
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxIcon: {
 		name: 'CdxIcon',
 		template: '<span class="cdx-icon"></span>',
@@ -17,7 +18,7 @@ mw.loader.require = vi.fn( () => ( {
 		props: [ 'modelValue', 'inputValue', 'name' ],
 		emits: [ 'update:modelValue' ]
 	}
-} ) );
+} );
 
 // .vue files are processed by Vite as ESM; use dynamic import() in beforeAll
 // rather than require(), and access the component via mod.default.

--- a/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
+++ b/tests/vitest/skins.citizen.preferences/ThemePicker.test.js
@@ -2,16 +2,17 @@
 
 const { mount } = require( '@vue/test-utils' );
 const mw = require( '../mocks/mw.js' );
+const { setCodexStubs } = require( '../mocks/codex.js' );
 globalThis.mw = mw;
 
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxRadio: {
 		name: 'CdxRadio',
 		template: '<div class="cdx-radio"><input type="radio" /><slot /></div>',
 		props: [ 'modelValue', 'inputValue', 'name' ],
 		emits: [ 'update:modelValue' ]
 	}
-} ) );
+} );
 
 // Knob values served to the baseline measurement (themePreviewBaseline.js).
 // The module caches its one getComputedStyle read at module level, so the

--- a/tests/vitest/skins.citizen.share/App.test.js
+++ b/tests/vitest/skins.citizen.share/App.test.js
@@ -2,10 +2,11 @@
 
 const { mount, flushPromises } = require( '@vue/test-utils' );
 const mw = require( '../mocks/mw.js' );
+const { setCodexStubs } = require( '../mocks/codex.js' );
 globalThis.mw = mw;
 
 // Stub Codex components used by App.vue
-mw.loader.require = vi.fn( () => ( {
+setCodexStubs( {
 	CdxButton: {
 		name: 'CdxButton',
 		template: '<button :aria-label="ariaLabel" :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
@@ -21,7 +22,7 @@ mw.loader.require = vi.fn( () => ( {
 		template: '<input :value.attr="modelValue" />',
 		props: [ 'modelValue', 'readonly' ]
 	}
-} ) );
+} );
 
 const PAGE_URL_ATTR = 'https://wiki.example/wiki/Page';
 const SHORT_URL = 'https://w.example/s/3';


### PR DESCRIPTION
## Problem

Each Vue panel kept its Codex components in a separate sibling module — `skins.citizen.preferences.codex` and three others — which the panel reached through a cross-module `mw.loader.require()`. That is not how MediaWiki expects Codex to be used: `CodexModule` appends the generated component files to a module's own `packageFiles`, so a single module can hold both the components and the `.vue` files that consume them. MediaWiki's Codex documentation gives that combined form as its canonical example, and both `CodexExample` (the reference extension) and `SimpleBatchUpload` ship it.

The split was never a deliberate migration — the pair appears fully formed in the commit that first added each panel, so there was never a combined state that got broken apart.

## Behaviour after this change

Four fewer ResourceLoader modules are registered. Every registered module adds bytes to the startup manifest that every visitor downloads, which is why the Codex documentation explicitly discourages registering many modules.

Panel bundle sizes are unchanged, because the same components are bundled either way:

| module | bytes |
| --- | --- |
| `skins.citizen.commandPalette` | 229,037 |
| `skins.citizen.preferences` | 183,659 |
| `skins.citizen.notifications` | 75,907 |
| `skins.citizen.share` | 64,522 |

## Contract

- No user-visible change. The same components render in the same panels.
- No change to how panels are loaded — the lazy-load and intent-prefetch behaviour is untouched.
- Nothing about server-rendered markup changes, so no compat slice is required.
- One trade-off worth naming: the two largest panels can no longer be held in `mw.loader.store`, whose per-module limit they now exceed when combined. That limit is not a budget anyone designs around — MediaWiki's own `ext.visualEditor.core` is nine times over it, and the modules that exceed it carry the majority of all module bytes — but it is a real difference and reviewers should know it was a considered choice rather than an oversight.

## Testing

The components previously received their Codex components through `mw.loader.require()`, which tests could intercept. They now destructure a file ResourceLoader generates at request time, which has no on-disk counterpart, so Vitest resolves it to a mock.

That mock is a mutable registry rather than a fixed set of stubs. Each test registers exactly the components it was already stubbing, so every stub and every assertion is unchanged — only the channel differs. `tests/vitest/setup.js` already resolved other generated files (`icons.json`, `config.json`) the same way.

- 1466 tests pass; all lint checks clean.
- All four panels driven through their real triggers in a browser, including notifications with a logged-in Echo user. No console errors.

`AGENTS.md` notes how the generated `codex.js` is stubbed in Vitest, since that is Citizen-specific and the failure it causes is otherwise opaque. Declaring `codexComponents` alongside the consuming files is the upstream convention and is left undocumented here — the code now demonstrates it.

## Note for reviewers

`tests/vitest/skins.citizen.share/App.test.js > serves from cache on a second click` is intermittently flaky under full-suite load. It is **pre-existing and unrelated**: it depends on a real `setTimeout` in the component with no fake timers, and this branch changes only three header lines in that file. Measured on unmodified `main` it fails 2 in 10 full-suite runs, versus 1 in 9 here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex components are now bundled directly with related interface modules, improving component loading consistency across preferences, sharing, notifications, and command palette features.

* **Bug Fixes**
  * Updated component loading to use the bundled Codex implementation, preventing reliance on runtime loader resolution.

* **Tests**
  * Standardized Codex component stubs across the test suite for more reliable and consistent test execution.
  * Added guidance for configuring Codex stubs before component imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->