### PR TITLE
chore(commandPalette): type-check the JSDoc annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,10 @@ jobs:
               - .github/workflows/ci.yml
             script:
               - resources/**/*.js
+              - resources/**/*.d.ts
               - tests/vitest/**
               - vitest.config.js
+              - tsconfig.json
               - package.json
               - package-lock.json
               - .eslintrc.json
@@ -90,6 +92,7 @@ jobs:
       lint-styles: ${{ needs.changes.outputs.stylesheet == 'true' || github.event_name == 'schedule' }}
       lint-i18n: ${{ needs.changes.outputs.i18n == 'true' || github.event_name == 'schedule' }}
       lint-md: ${{ needs.changes.outputs.markdown == 'true' || github.event_name == 'schedule' }}
+      lint-types: ${{ needs.changes.outputs.script == 'true' || github.event_name == 'schedule' }}
       runner: ubuntu-24.04-arm
 
   # Deliberately not gated on `changes`: a compat slice expires when skin.json's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,16 @@ Run only what's relevant to the files you changed.
 | Files changed | Command |
 | --- | --- |
 | `*.php` | `composer preflight` (lint, style, Phan, and PHPUnit) |
-| `*.js`, `*.vue` | `npm run lint:js` then `npm test` |
+| `*.js`, `*.vue` | `npm run lint:js`, `npm run lint:types`, then `npm test` |
 | `*.less`, `*.css`, `*.vue` | `npm run lint:styles` |
 | `i18n/` | `npm run lint:i18n` |
 | `*.md` | `npm run lint:md` |
 
 Auto-fix commands: `composer fix` (PHP), `npm run lint:fix:js` (JS), `npm run lint:fix:styles` (styles), `npm run lint:fix:md` (markdown).
+
+**Type checking**: `npm run lint:types` runs `tsc --checkJs` over the JSDoc annotations; CI runs it via the shared lint workflow's `lint-types` input. Note that workflow invokes each `lint:*` script individually and never `npm run lint`, so adding a new lint script to the `lint` chain does not put it in CI — it needs an input on the shared workflow as well.
+
+`tsconfig.json`'s `include` names every checked path explicitly rather than relying on imports to pull files in, so coverage does not shrink silently when an import is removed. Vue SFC script bodies are not covered — those need `vue-tsc`. `strict` is off for this first pass, so `strictNullChecks` in particular is not enforced; tightening it is a deliberate follow-up, not an oversight.
 
 **Preflight**: Run `npm run preflight` to execute all Node-based lints and JS tests in one command. Run `composer preflight` from within a MediaWiki installation to execute all PHP lints, style checks, Phan static analysis, and PHPUnit tests.
 
@@ -93,6 +97,7 @@ To add a new skill, create `.agents/skills/<name>/SKILL.md` with frontmatter (`n
 `skin.json` is the source of truth for how the skin is wired — ResourceLoader modules, hooks, config variables, and extension skin styles are all declared here.
 
 - When adding or removing files under `resources/`, update the corresponding `packageFiles` or `styles` list in `skin.json`
+- ResourceLoader replaces `config.json` and `icons.json` per request, so the checked-in copies are dev stubs and the real shape lives in the `.json.d.ts` beside each. Changing a `callbackParam` icon list or a config callback means updating that declaration too — nothing checks it for you.
 - When a new i18n message key is read by JS via `mw.message()`, also add it to the relevant ResourceLoader module's `messages` array in `skin.json` — adding the key only to `i18n/en.json` and `i18n/qqq.json` is not enough; messages not listed in the module render as `⧼key⧽` in the UI
 - When adding support for a new extension, add a LESS file under `skinStyles/` and register it in `skin.json` under `ResourceModuleSkinStyles`
 - Config variables are declared under `config` in `skin.json` (prefixed `wgCitizen`). In PHP they are accessed via `$this->getConfig()->get( 'CitizenFoo' )`, and can be injected into JS via `ResourceLoaderHooks`

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"stylelint-order": "^7.0.1",
 				"stylelint-plugin-use-baseline": "^1.4.5",
 				"types-mediawiki": "2.1.0",
+				"typescript": "5.9.3",
 				"vitest": "^4.1.10",
 				"vue": "3.4.27"
 			}
@@ -9565,12 +9566,11 @@
 			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
 	"name": "Citizen",
 	"private": true,
 	"scripts": {
-		"lint": "npm -s run lint:js && npm -s run lint:styles && npm -s run lint:i18n && npm -s run lint:md && npm -s run lint:compat",
+		"lint": "npm -s run lint:js && npm -s run lint:types && npm -s run lint:styles && npm -s run lint:i18n && npm -s run lint:md && npm -s run lint:compat",
 		"lint:compat": "node scripts/compat-lint.mjs",
 		"lint:fix:js": "npm -s run lint:js -- --fix",
 		"lint:fix:md": "npm -s run lint:md -- --fix",
 		"lint:fix:styles": "npm -s run lint:styles -- --fix",
 		"lint:js": "eslint --cache .",
 		"lint:md": "markdownlint \"*.md\"",
+		"lint:types": "tsc -p tsconfig.json",
 		"lint:styles": "stylelint \"**/*.{less,css,vue}\"",
 		"lint:i18n": "banana-checker --requireLowerCase=0 i18n/",
 		"docs:install": "cd docs && npm install",
@@ -44,6 +45,7 @@
 		"stylelint-order": "^7.0.1",
 		"stylelint-plugin-use-baseline": "^1.4.5",
 		"types-mediawiki": "2.1.0",
+		"typescript": "5.9.3",
 		"vitest": "^4.1.10",
 		"vue": "3.4.27"
 	},

--- a/resources/.eslintrc.json
+++ b/resources/.eslintrc.json
@@ -10,6 +10,11 @@
 	"globals": {
 		"exports": true
 	},
+	"settings": {
+		"jsdoc": {
+			"mode": "typescript"
+		}
+	},
 	"rules": {
 		"no-implicit-globals": "warn",
 		"es-x/no-object-fromentries": "warn",
@@ -24,7 +29,16 @@
 		"es-x/no-array-prototype-flat": "off",
 		"compat/compat": "warn",
 		"mediawiki/class-doc": "off",
-		"mediawiki/no-nodelist-unsupported-methods": "off"
+		"mediawiki/no-nodelist-unsupported-methods": "off",
+		"jsdoc/no-undefined-types": [
+			"warn",
+			{
+				"definedTypes": [
+					"JQuery",
+					"RequestInit"
+				]
+			}
+		]
 	},
 	"parserOptions": {
 		"ecmaVersion": 11,

--- a/resources/skins.citizen.commandPalette/composables/useListNavigation.js
+++ b/resources/skins.citizen.commandPalette/composables/useListNavigation.js
@@ -45,7 +45,7 @@ function useListNavigation( itemsRef, options ) {
 	/**
 	 * Scrolls the currently highlighted item into view.
 	 *
-	 * @param {import('vue').Ref<Map<number, HTMLElement|null>>} itemRefs Reactive reference to the Map of DOM elements.
+	 * @param {import('vue').Ref<Map<number, Object>>} itemRefs Map of row index → row component instance.
 	 */
 	function scrollToHighlighted( itemRefs ) {
 		const itemElement = itemRefs.value?.get( highlightedIndex.value );

--- a/resources/skins.citizen.commandPalette/composables/usePendingActivation.js
+++ b/resources/skins.citizen.commandPalette/composables/usePendingActivation.js
@@ -82,5 +82,4 @@ function usePendingActivation( options ) {
 	return { arm, cancel, isActivationQueued };
 }
 
-module.exports = usePendingActivation;
-module.exports.PENDING_ACTIVATION_TIMEOUT_MS = PENDING_ACTIVATION_TIMEOUT_MS;
+module.exports = Object.assign( usePendingActivation, { PENDING_ACTIVATION_TIMEOUT_MS } );

--- a/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
+++ b/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
@@ -47,7 +47,9 @@ function normalizeProviderResult( result ) {
  * Replaces the Pinia searchStore.
  *
  * @param {Array<Object>} providers Array of validated provider objects.
- * @param {Function} resultDecorator Function (items, query) => decoratedItems.
+ * @param {{leadActions: ( query: string ) => Array<Object>, trailActions: ( query: string ) => Array<Object>}} resultDecorator
+ *   `createAppendQueryActions()`'s return. Only its two attached action
+ *   builders are used here; the decorator itself is applied by the caller.
  * @param {Object} [deps] Optional dependencies for presults.
  * @param {Object} [deps.recentItemsProvider] Provider for recent items (presults).
  * @param {Object} [deps.relatedArticlesProvider] Provider for related articles (presults).

--- a/resources/skins.citizen.commandPalette/composables/useResultRouter.js
+++ b/resources/skins.citizen.commandPalette/composables/useResultRouter.js
@@ -49,8 +49,8 @@ function openInNewTab( url ) {
  * @param {Object} options.navigation
  * @param {Function} options.navigation.findModeByQuery
  * @param {Object} options.control
- * @param {Function} options.control.focusInput
- * @param {Function} options.control.close
+ * @param {() => void} options.control.focusInput
+ * @param {() => void} options.control.close
  * @param {import('vue').Ref<HTMLElement|null>} options.control.paletteRoot
  * @param {Object} options.preview
  * @param {Function} options.preview.isAvailable

--- a/resources/skins.citizen.commandPalette/config.json.d.ts
+++ b/resources/skins.citizen.commandPalette/config.json.d.ts
@@ -1,0 +1,9 @@
+// The checked-in config.json is a development stub; ResourceLoader replaces it
+// per request from ResourceLoaderHooks::getCitizenCommandPaletteResourceLoaderConfig.
+// This declaration describes what that callback returns, not the stub.
+declare const config: {
+	isSemanticMediaWikiEnabled: boolean;
+	wgSearchSuggestCacheExpiry: number;
+};
+
+export = config;

--- a/resources/skins.citizen.commandPalette/icons.json.d.ts
+++ b/resources/skins.citizen.commandPalette/icons.json.d.ts
@@ -1,0 +1,32 @@
+// The checked-in icons.json is a development stub; ResourceLoader replaces it
+// per request from CodexModule::getIcons. Keep these keys in step with the
+// `callbackParam` list for icons.json in skin.json.
+declare const icons: {
+	cdxIconArrowPrevious: string;
+	cdxIconArticle: string;
+	cdxIconArticles: string;
+	cdxIconArticleNotFound: string;
+	cdxIconArticleRedirect: string;
+	cdxIconArticleSearch: string;
+	cdxIconArticlesSearch: string;
+	cdxIconAttachment: string;
+	cdxIconCheck: string;
+	cdxIconCode: string;
+	cdxIconCopy: string;
+	cdxIconEdit: string;
+	cdxIconHelp: string;
+	cdxIconHistory: string;
+	cdxIconImage: string;
+	cdxIconImageGallery: string;
+	cdxIconSearch: string;
+	cdxIconTrash: string;
+	cdxIconSpecialPages: string;
+	cdxIconTag: string;
+	cdxIconPlay: string;
+	cdxIconUserAvatar: string;
+	cdxIconUserContributions: string;
+	cdxIconUserTalk: string;
+	cdxIconVolumeUp: string;
+};
+
+export = icons;

--- a/resources/skins.citizen.commandPalette/init.js
+++ b/resources/skins.citizen.commandPalette/init.js
@@ -96,7 +96,7 @@ function initApp( overlayEl, options ) {
 
 	const appendQueryActions = createAppendQueryActions();
 
-	const app = Vue.createMwApp( App, {}, config );
+	const app = Vue.createMwApp( App );
 	app.provide( 'providers', providers );
 	app.provide( 'recentItemsService', recentItemsService );
 	app.provide( 'resultDecorator', appendQueryActions );

--- a/resources/skins.citizen.commandPalette/modes/action.js
+++ b/resources/skins.citizen.commandPalette/modes/action.js
@@ -7,7 +7,7 @@ const { defineMode } = require( '../services/defineMode.js' );
  * Creates the action command handler.
  *
  * @param {Document} documentRef The document object for DOM queries.
- * @param {Function} ApiConstructor The mw.Api constructor.
+ * @param {typeof mw.Api} ApiConstructor The mw.Api constructor.
  * @return {Object} The command handler.
  */
 function createActionCommand( documentRef, ApiConstructor ) {

--- a/resources/skins.citizen.commandPalette/modes/category.js
+++ b/resources/skins.citizen.commandPalette/modes/category.js
@@ -121,7 +121,7 @@ function getCurrentPageCategoryItems() {
 /**
  * Factory for the category mode.
  *
- * @param {Function} ApiConstructor mw.Api constructor.
+ * @param {typeof mw.Api} ApiConstructor mw.Api constructor.
  * @return {Object}
  */
 function createCategoryMode( ApiConstructor ) {

--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -362,7 +362,7 @@ function adaptListItem( page ) {
 /**
  * Factory for the file/media mode.
  *
- * @param {Function} ApiConstructor mw.Api constructor.
+ * @param {typeof mw.Api} ApiConstructor mw.Api constructor.
  * @return {Object} Mode descriptor.
  */
 function createFileMode( ApiConstructor ) {

--- a/resources/skins.citizen.commandPalette/modes/history.js
+++ b/resources/skins.citizen.commandPalette/modes/history.js
@@ -236,7 +236,7 @@ function filterRevisions( revisions, subQuery ) {
 /**
  * Factory for the revision history mode.
  *
- * @param {Function} ApiConstructor mw.Api constructor.
+ * @param {typeof mw.Api} ApiConstructor mw.Api constructor.
  * @return {Object}
  */
 function createHistoryMode( ApiConstructor ) {

--- a/resources/skins.citizen.commandPalette/modes/namespace.js
+++ b/resources/skins.citizen.commandPalette/modes/namespace.js
@@ -93,7 +93,7 @@ function adaptNamespaceResult( nsResult ) {
 		value: `${ nsResult.label }:`,
 		metadata: [
 			{
-				label: nsResult.value
+				label: String( nsResult.value )
 			}
 		],
 		highlightQuery: true

--- a/resources/skins.citizen.commandPalette/modes/user.js
+++ b/resources/skins.citizen.commandPalette/modes/user.js
@@ -6,7 +6,7 @@ const { defineMode } = require( '../services/defineMode.js' );
 /**
  * Creates the user command handler.
  *
- * @param {Function} ApiConstructor The mw.Api constructor.
+ * @param {typeof mw.Api} ApiConstructor The mw.Api constructor.
  * @return {Object} The command handler.
  */
 function createUserCommand( ApiConstructor ) {

--- a/resources/skins.citizen.commandPalette/providers/RelatedArticlesProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/RelatedArticlesProvider.js
@@ -36,9 +36,9 @@ function createRelatedArticlesProvider( loader ) {
 
 			cachedArticleId = currentArticleId;
 			fetchPromise = new Promise( ( resolve ) => {
-				const onSuccess = async ( require ) => {
+				const onSuccess = async ( req ) => {
 					try {
-						const gateway = require( 'ext.relatedArticles.readMore' ).test.relatedPages;
+						const gateway = req( 'ext.relatedArticles.readMore' ).test.relatedPages;
 						const relatedPages = await gateway.getForCurrentPage( 3 );
 
 						if ( relatedPages.length === 0 ) {

--- a/resources/skins.citizen.commandPalette/providers/createProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/createProvider.js
@@ -52,5 +52,4 @@ function createProvider( id, handler, config ) {
 	} );
 }
 
-module.exports = createProvider;
-module.exports.DEFAULT_DEBOUNCE_MS = DEFAULT_DEBOUNCE_MS;
+module.exports = Object.assign( createProvider, { DEFAULT_DEBOUNCE_MS } );

--- a/resources/skins.citizen.commandPalette/services/instantDiffs.js
+++ b/resources/skins.citizen.commandPalette/services/instantDiffs.js
@@ -23,7 +23,7 @@ function isAvailable() {
  * Ask the gadget to scan a container for unprocessed diff/revision links
  * and attach its click handlers. No-op when the gadget is unavailable.
  *
- * @param {HTMLElement|jQuery} container DOM element or jQuery collection.
+ * @param {HTMLElement|JQuery} container DOM element or jQuery collection.
  */
 function processContext( container ) {
 	if ( !isAvailable() ) {
@@ -31,7 +31,7 @@ function processContext( container ) {
 	}
 	// The gadget's process hook calls $container.find() internally, so the
 	// payload must be a jQuery object. Wrap raw DOM elements before firing.
-	const $container = container && container.jquery ? container : $( container );
+	const $container = container && 'jquery' in container ? container : $( container );
 	mw.hook( 'instantDiffs.process' ).fire( $container );
 }
 
@@ -59,7 +59,7 @@ function triggerForAnchor( anchor ) {
  * the late-load case where the gadget initializes after a consumer has
  * already rendered its anchors. No-op-on-call if the hook never fires.
  *
- * @param {Function} callback
+ * @param {( ...args: any[] ) => any} callback
  */
 function onReady( callback ) {
 	mw.hook( 'instantDiffs.ready' ).add( callback );

--- a/resources/skins.citizen.commandPalette/services/paletteRegistry.js
+++ b/resources/skins.citizen.commandPalette/services/paletteRegistry.js
@@ -7,7 +7,7 @@ const { cdxIconCode } = require( '../icons.json' );
  * @return {Object} Palette registry service
  */
 function createPaletteRegistry() {
-	/** @type {Map<string, import('../types.js').PaletteMode|import('../types.js').PaletteCommand>} */
+	/** @type {Map<string, import('../types.js').PaletteHandler>} */
 	const handlers = new Map();
 
 	/** @type {Array<{trigger: string, id: string, lowerTrigger: string}>} */
@@ -29,7 +29,7 @@ function createPaletteRegistry() {
 	/**
 	 * Registers a new handler.
 	 *
-	 * @param {import('../types.js').PaletteMode|import('../types.js').PaletteCommand} handler The handler object (must include an 'id' property)
+	 * @param {Object} handler Unvalidated handler object; the body checks its shape.
 	 * @return {boolean} True if registration was successful, false otherwise.
 	 */
 	function register( handler ) {
@@ -139,7 +139,7 @@ function createPaletteRegistry() {
 			);
 			const uniqueIds = [ ...new Set( filteredTriggers.map( ( { id } ) => id ) ) ];
 			entries = uniqueIds
-				.map( ( id ) => [ id, handlers.get( id ) ] )
+				.map( ( id ) => /** @type {[string, import('../types.js').PaletteHandler]} */ ( [ id, handlers.get( id ) ] ) )
 				.filter( ( entry ) => entry[ 1 ] );
 		} else {
 			entries = Array.from( handlers.entries() );
@@ -200,7 +200,7 @@ function createPaletteRegistry() {
 		for ( const entry of flatTriggerList ) {
 			if ( entry.lowerTrigger === lowerKey ) {
 				const handler = handlers.get( entry.id );
-				if ( handler && typeof handler.getResults === 'function' ) {
+				if ( handler && 'getResults' in handler && typeof handler.getResults === 'function' ) {
 					return handler;
 				}
 			}
@@ -217,7 +217,7 @@ function createPaletteRegistry() {
 	 */
 	function findModeByQuery( query ) {
 		const match = findMatchingCommand( query );
-		if ( match && typeof match.handler.getResults === 'function' ) {
+		if ( match && 'getResults' in match.handler && typeof match.handler.getResults === 'function' ) {
 			return { mode: match.handler, trigger: match.trigger };
 		}
 		return null;
@@ -231,7 +231,7 @@ function createPaletteRegistry() {
 	function getTokenPatterns() {
 		const patterns = [];
 		for ( const handler of handlers.values() ) {
-			if ( handler.tokenPattern ) {
+			if ( 'tokenPattern' in handler && handler.tokenPattern ) {
 				if ( Array.isArray( handler.tokenPattern ) ) {
 					patterns.push( ...handler.tokenPattern );
 				} else {

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -133,13 +133,13 @@
  * @property {boolean} [compactResults=false] Render results in a denser layout — small icon instead of thumbnail, description inline. Use for command-style modes whose items lack real thumbnails. Ignored in gallery layout.
  * @property {KeyBinding[]} [keybindings] Optional mode-contributed keyboard bindings. Prepended onto the core binding list at dispatch time, so mode bindings win on key collisions within their own zone.
  * @property {StateContent} [emptyState] Content shown when the mode is active with no query. Falls back to default search messaging.
- * @property {function(string, Array?): StateContent} [noResults] Returns content shown when query produces no results. Receives the query string and optional tokens array. Falls back to default no-results messaging.
+ * @property {( query: string, tokens?: Array ) => StateContent} [noResults] Returns content shown when query produces no results. Receives the query string and optional tokens array. Falls back to default no-results messaging.
  * @property {TokenPattern|TokenPattern[]} [tokenPattern] Optional token detection pattern(s) for auto-tokenization.
  * @property {PaletteHelp} [help] Optional content surfaced by the help overlay when this mode is active.
- * @property {function(string, AbortSignal?, Array?, Array?): Promise<CommandPaletteItem[]>} getResults Returns result items for the given sub-query. Optional signal for abort, optional tokens array, optional mode context array (only meaningful for modes that opt in to drill-down state). The signal is honoured by mw.Api on MediaWiki 1.44+ and ignored on 1.43.
- * @property {function(CommandPaletteItem, AbortSignal?): Promise<Object>} [getItemDetail] Lazy detail-pane data for the highlighted item, resolving to `{ description, pairs }` — each field is merged into the item's `detail` when present. Use when the data is too heavy to compute for every item upfront. Same signal caveat as `getResults`.
- * @property {function(CommandPaletteItem): (CommandPaletteActionResult|Promise<CommandPaletteActionResult>)} [onResultSelect] Handles selection of a result item.
- * @property {function(Array): string} [headerLabel] Optional breadcrumb label rendered in the header. Receives the current modeContext stack. Falls back to the input placeholder when absent.
+ * @property {( query: string, signal?: AbortSignal, tokens?: Array, modeContext?: Array ) => Promise<CommandPaletteItem[]>} getResults Returns result items for the given sub-query. Optional signal for abort, optional tokens array, optional mode context array (only meaningful for modes that opt in to drill-down state). The signal is honoured by mw.Api on MediaWiki 1.44+ and ignored on 1.43.
+ * @property {( item: CommandPaletteItem, signal?: AbortSignal ) => Promise<Object>} [getItemDetail] Lazy detail-pane data for the highlighted item, resolving to `{ description, pairs }` — each field is merged into the item's `detail` when present. Use when the data is too heavy to compute for every item upfront. Same signal caveat as `getResults`.
+ * @property {( item: CommandPaletteItem ) => (CommandPaletteActionResult|Promise<CommandPaletteActionResult>)} [onResultSelect] Handles selection of a result item.
+ * @property {( modeContext: Array ) => string} [headerLabel] Optional breadcrumb label rendered in the header. Receives the current modeContext stack. Falls back to the input placeholder when absent.
  */
 
 /**
@@ -149,9 +149,16 @@
  * @property {string} modeId Which mode produced this pattern.
  * @property {'prefix'|'any'} position Where the token must appear in the query.
  * @property {'root'|string} activeIn Controls when pattern is eligible: 'root' = only when no mode active, a mode id string = only when that mode is active.
- * @property {function(string): {label: string, raw: string}|null} match Tests text and returns token data or null.
- * @property {function(string): {label: string, raw: string}|null} [eagerMatch] Optional lenient matcher used after the standard pass matched at least one token (e.g. paste). Allows end-of-string as a valid terminator.
+ * @property {( text: string ) => {label: string, raw: string}|null} match Tests text and returns token data or null.
+ * @property {( text: string ) => {label: string, raw: string}|null} [eagerMatch] Optional lenient matcher used after the standard pass matched at least one token (e.g. paste). Allows end-of-string as a valid terminator.
  * @property {string} [variant] Optional visual variant for the chip (e.g. 'outlined').
+ */
+
+/**
+ * Either kind of registry entry. Both carry `id` and `triggers`; only a mode
+ * produces results, and only a command handles selection.
+ *
+ * @typedef {PaletteMode|PaletteCommand} PaletteHandler
  */
 
 /**
@@ -163,7 +170,7 @@
  * @property {string} [label] Display label for this command in the command list.
  * @property {string} [description] Short explanation shown in the command list.
  * @property {PaletteHelp} [help] Optional content surfaced by the help overlay.
- * @property {function(CommandPaletteItem): (CommandPaletteActionResult|Promise<CommandPaletteActionResult>)} [onResultSelect] Handles selection — executes the command action.
+ * @property {( item: CommandPaletteItem ) => (CommandPaletteActionResult|Promise<CommandPaletteActionResult>)} [onResultSelect] Handles selection — executes the command action.
  */
 
 /**
@@ -189,8 +196,8 @@
  * @property {'input'|'action'} zone Which focus zone the binding applies to.
  * @property {string[]} keys Event `key` values that fire `handle`. An empty array marks the binding as hint-only. Declare 'ArrowLeft'/'ArrowRight' logically (previous/next): the palette mirrors the physical arrow on RTL interface languages before resolving.
  * @property {string|string[]} [modifiers='none'] Which modifier state the binding claims, from 'none', 'shift', 'accel' (Ctrl, or Command on a Mac), 'accel+shift', or 'any'. An array accepts several. A character composed with AltGr, and a capital typed with Shift, count as 'none' — they are typed text, not chords. Anything not named here stays with the browser.
- * @property {function(Object): boolean} when Predicate over the dispatch state — false suppresses both the handler and the hint.
- * @property {function(Object, KeyboardEvent)} handle Called when a `keys` entry matches and `when` passes. Should call `event.preventDefault()` to claim the keystroke.
+ * @property {( state: Object ) => boolean} when Predicate over the dispatch state — false suppresses both the handler and the hint.
+ * @property {( state: Object, event: KeyboardEvent ) => void} handle Called when a `keys` entry matches and `when` passes. Should call `event.preventDefault()` to claim the keystroke.
  * @property {boolean} [worksDuringHelp] When true, the binding fires even with the help overlay open. Defaults to false.
  * @property {KeyBindingHint|null} [hint] Footer hint to surface, or null to omit one.
  */
@@ -273,7 +280,7 @@
 
 /**
  * @typedef {Object} CitizenCommandPaletteSearchClient
- * @property {function(string): Promise<CommandPaletteSearchResponse>} fetchByQuery
+ * @property {( query: string ) => Promise<CommandPaletteSearchResponse>} fetchByQuery
  */
 
 /**
@@ -289,9 +296,9 @@
  * @property {string} id - Unique identifier for the provider.
  * @property {number} debounceMs - Debounce in milliseconds; 0 fetches immediately on every keystroke.
  * @property {boolean} keepStaleResults - Whether the previous results stay on screen while fresh ones load.
- * @property {function(string): boolean} canProvide - Method to check if the provider can handle the query.
- * @property {function(string): Array<CommandPaletteItem>|Promise<Array<CommandPaletteItem>>} getResults - Method to fetch results.
- * @property {?function(CommandPaletteItem): CommandPaletteActionResult|Promise<CommandPaletteActionResult>} onResultSelect - Optional method to handle result selection.
+ * @property {( query: string ) => boolean} canProvide - Method to check if the provider can handle the query.
+ * @property {( query: string ) => Array<CommandPaletteItem>|Promise<Array<CommandPaletteItem>>} getResults - Method to fetch results.
+ * @property {?( item: CommandPaletteItem ) => CommandPaletteActionResult|Promise<CommandPaletteActionResult>} onResultSelect - Optional method to handle result selection.
  */
 
 /**

--- a/resources/types/ambient.d.ts
+++ b/resources/types/ambient.d.ts
@@ -1,0 +1,13 @@
+// Globals the skin reads that no upstream package declares.
+
+interface Window {
+	// Provided by the InstantDiffs gadget when installed; absent otherwise, so
+	// every read is guarded.
+	instantDiffs?: { isReady?: boolean };
+}
+
+interface Navigator {
+	// User-Agent Client Hints. Not in lib.dom yet and unsupported in Firefox and
+	// Safari, so every read is guarded.
+	userAgentData?: { platform?: string };
+}

--- a/resources/types/globals.d.ts
+++ b/resources/types/globals.d.ts
@@ -1,0 +1,3 @@
+// Ambient MediaWiki globals. `types-mediawiki` pulls in @types/jquery and
+// @types/oojs-ui, so `$`, `jQuery` and `OO` resolve from the same install.
+import 'types-mediawiki';

--- a/resources/types/vue-sfc.d.ts
+++ b/resources/types/vue-sfc.d.ts
@@ -1,0 +1,8 @@
+// Kept apart from globals.d.ts on purpose: a top-level `import` would turn this
+// file into a module, and `declare module '*.vue'` inside a module is a module
+// augmentation, which never matches the wildcard.
+declare module '*.vue' {
+	import type { DefineComponent } from 'vue';
+	const component: DefineComponent;
+	export default component;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "es2020",
+		"module": "node16",
+		"moduleResolution": "node16",
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"strict": false
+	},
+	"include": [
+		"resources/skins.citizen.commandPalette/**/*.js",
+		"resources/skins.citizen.scripts/keyboardLayout.js",
+		"resources/types/**/*.d.ts"
+	]
+}


### PR DESCRIPTION
Closes part of #1775.

## Problem

The command palette's `types.js` is the API reference third-party mode and provider authors work from, but nothing validated it. There was no `tsconfig.json`, no `typescript` dependency and no type-check step, so the annotations were prose that happened to use type syntax. #1772 had to hand-correct six accumulated discrepancies; nothing prevented the next six, and an external author had no way to tell a stale annotation from a live one.

## Change

`npm run lint:types` runs `tsc --checkJs` over the palette, and CI runs it as a `lint-types` job. The first run reported 236 diagnostics; it is at zero.

Most of the diagnostics were configuration rather than defects — 149 came from `mw` being undeclared, fixed by wiring `types-mediawiki`, which was already an unused devDependency. The rest were annotations that had drifted from the code, such as `useListNavigation` declaring `Ref<Map<number, HTMLElement|null>>` for a map that holds row component instances and is read via `.$el`.

It also caught one live defect: `init.js` passed a third argument to `Vue.createMwApp`, which spreads into `createApp( rootComponent, rootProps )`. The argument never reached Vue. Nothing injects `'config'` and the module already reads it directly, so it is removed.

## Notes for reviewers

Four decisions that would otherwise look arbitrary:

- **Type checking is wired through the shared lint workflow's `lint-types` input, not the `lint` chain.** That workflow invokes each `lint:*` script individually and never `npm run lint`, so chaining the script alone would not reach CI. The input was added in StarCitizenTools/mediawiki-ci-workflows#21.
- **`config.json` and `icons.json` get `.d.ts` sidecars rather than `resolveJsonModule`.** ResourceLoader replaces both per request from PHP callbacks, so the checked-in copies are development stubs and resolving them would type against the wrong shape. `icons.json.d.ts` mirrors `skin.json`'s `callbackParam` list and must be updated with it; `AGENTS.md` says so.
- **`types-mediawiki` rather than `@wikimedia/types-wikimedia`,** which Vector and RelatedArticles use. The latter is missing `mw.log.error`, `mw.storage.getObject`/`setObject`, `mw.language` and `mw.util.escapeIdForAttribute`, and its `util` gap cannot be closed by declaration merging.
- **TypeScript is pinned below 6.** `eslint-config-wikimedia` depends on `@typescript-eslint` 8.x, which peers `typescript: ">=4.8.4 <6.0.0"`; installing 7 makes npm drop `@typescript-eslint/eslint-plugin` and `lint:js` stops running. The code is ready for the bump anyway — `tsconfig` uses `node16` rather than the `node10` that 7 removes, `types.js` no longer uses the Closure `function(A, B?): C` form 7 cannot parse, and two export sites use `Object.assign`. `tsc 7.0.2` reports zero, so the eventual bump is a version change.

`jsdoc/valid-types` was also reporting against valid TypeScript-flavoured JSDoc, because `eslint-config-wikimedia` sets jsdoc mode to classic and `resources/.eslintrc.json` is a root config. Switching it there takes that rule from 63 warnings to 10, all genuine, and clears two `no-undefined-types`. It surfaces six `check-param-names` warnings in `useResultRouter` that the parse errors had hidden — the plugin cannot follow a property documented two levels inside a destructured parameter. Those predate this change and appear identically on the unmodified file.

## Scope

Vue SFC script bodies need `vue-tsc` and are not covered. `strict` is off — enabling it is 571 diagnostics, mostly implicit-any parameters and property-does-not-exist, since the palette was written with nothing checking. Vector and RelatedArticles both run `strict`, but were written under it.

## Follow-ups

- #1816 — narrowing the handler union surfaced a behaviour bug: one triggerless handler empties the command list and help catalog.
- `types.js` still ships as a runtime module nothing imports (#1775 point 2).
- Enabling `strict`; extending coverage to Vue SFCs; bumping TypeScript once the linter allows it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-wide JavaScript type checking to the lint workflow.
  * Added type definitions for configuration, icons, Vue components, browser APIs, and MediaWiki globals.
* **Documentation**
  * Clarified development verification steps and configuration declaration requirements.
  * Improved inline API and callback documentation.
* **Refactor**
  * Improved palette registry validation and namespace label handling without changing expected behavior.
* **Chores**
  * Updated CI checks to include relevant TypeScript declarations and configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->