### PR TITLE
chore(commandPalette): enable the strict flags that already pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ Auto-fix commands: `composer fix` (PHP), `npm run lint:fix:js` (JS), `npm run li
 
 **Type checking**: `npm run lint:types` runs `tsc --checkJs` over the JSDoc annotations; CI runs it via the shared lint workflow's `lint-types` input. Note that workflow invokes each `lint:*` script individually and never `npm run lint`, so adding a new lint script to the `lint` chain does not put it in CI — it needs an input on the shared workflow as well.
 
-`tsconfig.json`'s `include` names every checked path explicitly rather than relying on imports to pull files in, so coverage does not shrink silently when an import is removed. Vue SFC script bodies are not covered — those need `vue-tsc`. `strict` is off for this first pass, so `strictNullChecks` in particular is not enforced; tightening it is a deliberate follow-up, not an oversight.
+`tsconfig.json`'s `include` names every checked path explicitly rather than relying on imports to pull files in, so coverage does not shrink silently when an import is removed. Vue SFC script bodies are not covered — those need `vue-tsc`.
+
+`strict` is enabled a flag at a time rather than as a bundle, because its members cost very different amounts here. `strictFunctionTypes`, `strictBindCallApply`, `noImplicitThis` and `alwaysStrict` are on — the code already satisfied them, so they cost nothing and now prevent regressions. Still off, with what they would currently cost: `useUnknownInCatchVariables` (8 diagnostics), `strictNullChecks` (42, and the ones worth fixing), `noImplicitAny` (524, mostly missing parameter annotations rather than defects). Do not switch on bare `strict` — it turns all of them on at once.
 
 **Preflight**: Run `npm run preflight` to execute all Node-based lints and JS tests in one command. Run `composer preflight` from within a MediaWiki installation to execute all PHP lints, style checks, Phan static analysis, and PHPUnit tests.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
 		"checkJs": true,
 		"noEmit": true,
 		"skipLibCheck": true,
-		"strict": false
+		"strictFunctionTypes": true,
+		"strictBindCallApply": true,
+		"noImplicitThis": true,
+		"alwaysStrict": true
 	},
 	"include": [
 		"resources/skins.citizen.commandPalette/**/*.js",


### PR DESCRIPTION
## Problem

`strict` is a bundle of eight checks, and their cost against this codebase differs by two orders of magnitude. Enabling it wholesale is 571 diagnostics; leaving it off entirely means declining checks that cost nothing.

Measured per flag:

| flag | diagnostics |
| --- | --- |
| `strictFunctionTypes` | 0 |
| `strictBindCallApply` | 0 |
| `noImplicitThis` | 0 |
| `alwaysStrict` | 0 |
| `useUnknownInCatchVariables` | 8 |
| `strictNullChecks` | 42 |
| `noImplicitAny` | 524 |

## Change

Enables the four that already report zero. Nothing changes today; they prevent the corresponding mistakes being introduced later.

No source changes — `tsconfig.json` and the `AGENTS.md` note recording what each remaining flag would cost, so the next person can pick one off without re-measuring.

## Scope

The three still off, in the order they are worth doing:

- `useUnknownInCatchVariables` (8) and `strictNullChecks` (42) are where the real findings are. 34 of those 50 are in `useProviderOrchestration`, and 13 are the single `deps` parameter — documented `@param {Object} [deps]` but used unguarded in 13 places against 2 guarded. The only production caller always passes it, so the signature advertises a contract the body does not honour.
- `noImplicitAny` (524) is missing parameter annotations rather than defects, and is the entire reason bare `strict` looks expensive.
