### PR TITLE
chore(commandPalette): check for null and unknown catch values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,9 @@ Auto-fix commands: `composer fix` (PHP), `npm run lint:fix:js` (JS), `npm run li
 
 `tsconfig.json`'s `include` names every checked path explicitly rather than relying on imports to pull files in, so coverage does not shrink silently when an import is removed. Vue SFC script bodies are not covered — those need `vue-tsc`.
 
-`strict` is enabled a flag at a time rather than as a bundle, because its members cost very different amounts here. `strictFunctionTypes`, `strictBindCallApply`, `noImplicitThis` and `alwaysStrict` are on — the code already satisfied them, so they cost nothing and now prevent regressions. Still off, with what they would currently cost: `useUnknownInCatchVariables` (8 diagnostics), `strictNullChecks` (42, and the ones worth fixing), `noImplicitAny` (524, mostly missing parameter annotations rather than defects). Do not switch on bare `strict` — it turns all of them on at once.
+`strict` is enabled a flag at a time rather than as a bundle, because its members cost very different amounts here. All are on except `noImplicitAny`, which is 524 diagnostics of missing parameter annotations rather than defects. Do not switch on bare `strict` — it turns that one on too.
+
+Two idioms the checker cannot follow, both of which appear in this codebase: a parameter defaulted with `x = x || {}` in the body does not stay narrowed inside a closure, so use a default parameter; and a `typeof obj.method === 'function'` guard does not survive into a callback, so bind the method to a local first.
 
 **Preflight**: Run `npm run preflight` to execute all Node-based lints and JS tests in one command. Run `composer preflight` from within a MediaWiki installation to execute all PHP lints, style checks, Phan static analysis, and PHPUnit tests.
 

--- a/resources/skins.citizen.commandPalette/composables/useOperationLifecycle.js
+++ b/resources/skins.citizen.commandPalette/composables/useOperationLifecycle.js
@@ -21,6 +21,8 @@
  * @param {number} [options.pendingDelayMs=300] Delay before `showPending` flips on, so brief operations don't flash a spinner.
  * @return {{ reset: Function, runDebouncedAbortable: Function }}
  */
+const isAbortError = require( '../utils/isAbortError.js' );
+
 function useOperationLifecycle( { isPending, showPending, pendingDelayMs = 300 } ) {
 	let debounceTimeout = null;
 	let pendingDelayTimeout = null;
@@ -100,7 +102,7 @@ function useOperationLifecycle( { isPending, showPending, pendingDelayMs = 300 }
 					onResult( result );
 				}
 			} catch ( error ) {
-				if ( error && error.name !== 'AbortError' ) {
+				if ( !isAbortError( error ) ) {
 					onError( error );
 				}
 			} finally {

--- a/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
+++ b/resources/skins.citizen.commandPalette/composables/useProviderOrchestration.js
@@ -50,7 +50,7 @@ function normalizeProviderResult( result ) {
  * @param {{leadActions: ( query: string ) => Array<Object>, trailActions: ( query: string ) => Array<Object>}} resultDecorator
  *   `createAppendQueryActions()`'s return. Only its two attached action
  *   builders are used here; the decorator itself is applied by the caller.
- * @param {Object} [deps] Optional dependencies for presults.
+ * @param {Object} [deps={}] Optional dependencies for presults.
  * @param {Object} [deps.recentItemsProvider] Provider for recent items (presults).
  * @param {Object} [deps.relatedArticlesProvider] Provider for related articles (presults).
  * @param {Object} [deps.recentItemsService] Service for dismissing recent items.
@@ -58,13 +58,14 @@ function normalizeProviderResult( result ) {
  * @param {Function} [deps.getHelpCatalogItems] Returns the list of registered modes/commands shown in the help overlay's mode catalog at root.
  * @return {Object} Orchestration state and methods.
  */
-function useProviderOrchestration( providers, resultDecorator, deps ) {
-	deps = deps || {};
+function useProviderOrchestration( providers, resultDecorator, deps = {} ) {
 
 	const query = ref( '' );
 	const isPending = ref( false );
 	const showPending = ref( false );
+	/** @type {import('vue').ShallowRef<import('../types.js').PaletteMode|null>} */
 	const activeMode = shallowRef( null );
+	/** @type {import('vue').Ref<Object[]>} */
 	const activeModeContext = ref( [] );
 	const helpVisible = ref( false );
 
@@ -80,9 +81,13 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	// Every surface has at most one asynchronous group. `forSurface` is the
 	// staleness test: items are stale until a landing stamps them with the
 	// surface that is current when they arrive.
+	/** @type {import('vue').Ref<{ items: import('../types.js').CommandPaletteItem[], forSurface: string|null, providerId: string|null }>} */
 	const content = ref( { items: [], forSurface: null, providerId: null } );
+	/** @type {import('vue').Ref<{ items: import('../types.js').CommandPaletteItem[], settled: boolean }>} */
 	const related = ref( { items: [], settled: false } );
+	/** @type {import('vue').Ref<import('../types.js').CommandPaletteItem[]>} */
 	const recents = ref( [] );
+	/** @type {import('vue').Ref<import('../types.js').CommandPaletteItem[]>} */
 	const helpItems = ref( [] );
 
 	const isPresultsSurface = computed(
@@ -226,7 +231,8 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 	 *
 	 * @param {Array} items Items from the content provider.
 	 * @param {string} dispatchSurface surfaceKey captured when the request was issued.
-	 * @param {string} [providerId] Id of the provider that produced the items.
+	 * @param {string|null} [providerId] Id of the provider that produced the items,
+	 *   or null when none did.
 	 */
 	function applyContent( items, dispatchSurface, providerId ) {
 		if ( surfaceKey.value !== dispatchSurface ) {
@@ -612,12 +618,15 @@ function useProviderOrchestration( providers, resultDecorator, deps ) {
 			return;
 		}
 		const capturedItem = item;
+		// Captured after the guard above; the narrowing does not survive into the
+		// closure that runs it.
+		const getItemDetail = mode.getItemDetail;
 		const isStale = () => activeMode.value !== mode ||
 			!flatItems.value.includes( capturedItem );
 		detailLifecycle.runDebouncedAbortable( {
 			debounceMs: DETAIL_DEBOUNCE_MS,
 			isStale,
-			run: ( signal ) => mode.getItemDetail( capturedItem, signal ),
+			run: ( signal ) => getItemDetail( capturedItem, signal ),
 			onResult: ( result ) => {
 				if ( !result || !capturedItem.detail ) {
 					return;

--- a/resources/skins.citizen.commandPalette/composables/useTokenizedInput.js
+++ b/resources/skins.citizen.commandPalette/composables/useTokenizedInput.js
@@ -12,6 +12,7 @@ const { ref, computed } = require( 'vue' );
  */
 function useTokenizedInput( getTokenPatterns, activeMode ) {
 	let tokenCounter = 0;
+	/** @type {import('vue').Ref<import('../types.js').CommandPaletteToken[]>} */
 	const tokens = ref( [] );
 	const freeText = ref( '' );
 	const selectedIndex = ref( -1 );

--- a/resources/skins.citizen.commandPalette/modes/category.js
+++ b/resources/skins.citizen.commandPalette/modes/category.js
@@ -11,6 +11,7 @@
  *    case-insensitive title startsWith.
  */
 const { cdxIconTag, cdxIconArticle, cdxIconEdit } = require( '../icons.json' );
+const isAbortError = require( '../utils/isAbortError.js' );
 const config = require( '../config.json' );
 const { defineMode } = require( '../services/defineMode.js' );
 
@@ -142,7 +143,7 @@ function createCategoryMode( ApiConstructor ) {
 			const hits = data?.query?.prefixsearch || [];
 			return hits.map( ( hit ) => adaptCategoryItem( stripPrefix( hit.title ) ) );
 		} catch ( error ) {
-			if ( error && error.name === 'AbortError' ) {
+			if ( isAbortError( error ) ) {
 				return [];
 			}
 			mw.log.error( '[commandPalette] Category prefixsearch failed:', error );
@@ -176,7 +177,7 @@ function createCategoryMode( ApiConstructor ) {
 			} );
 			return subcats.concat( pages );
 		} catch ( error ) {
-			if ( error && error.name === 'AbortError' ) {
+			if ( isAbortError( error ) ) {
 				return [];
 			}
 			mw.log.error( '[commandPalette] Category members fetch failed:', error );

--- a/resources/skins.citizen.commandPalette/modes/file.js
+++ b/resources/skins.citizen.commandPalette/modes/file.js
@@ -25,6 +25,7 @@ const {
 	cdxIconPlay
 } = require( '../icons.json' );
 const config = require( '../config.json' );
+const isAbortError = require( '../utils/isAbortError.js' );
 const { defineMode } = require( '../services/defineMode.js' );
 
 const FILE_NAMESPACE = 6;
@@ -423,7 +424,7 @@ function createFileMode( ApiConstructor ) {
 			return Object.values( pages )
 				.sort( ( a, b ) => ( a.index || 0 ) - ( b.index || 0 ) );
 		} catch ( error ) {
-			if ( error && error.name !== 'AbortError' ) {
+			if ( !isAbortError( error ) ) {
 				mw.log.error( '[commandPalette] File search failed:', error );
 			}
 			return [];

--- a/resources/skins.citizen.commandPalette/modes/help.js
+++ b/resources/skins.citizen.commandPalette/modes/help.js
@@ -8,7 +8,7 @@ const { defineCommand } = require( '../services/defineMode.js' );
  * a transient layer rendered on top of the active mode — opening or closing
  * it does not modify the active mode, query, or mode-context stack.
  *
- * @type {import('../types.js').PaletteCommand}
+ * @type {import('../types.js').PaletteCommand|null}
  */
 module.exports = defineCommand( {
 	id: 'help',

--- a/resources/skins.citizen.commandPalette/modes/history.js
+++ b/resources/skins.citizen.commandPalette/modes/history.js
@@ -11,6 +11,7 @@
  *   the 50-rev window," which may still have a real parent outside it).
  */
 const { cdxIconHistory } = require( '../icons.json' );
+const isAbortError = require( '../utils/isAbortError.js' );
 const config = require( '../config.json' );
 const { defineMode } = require( '../services/defineMode.js' );
 
@@ -262,7 +263,7 @@ function createHistoryMode( ApiConstructor ) {
 			}, { signal } );
 			return extractRevisions( data );
 		} catch ( error ) {
-			if ( error && error.name !== 'AbortError' ) {
+			if ( !isAbortError( error ) ) {
 				mw.log.error( '[commandPalette] History fetch failed:', error );
 			}
 			return [];
@@ -294,7 +295,7 @@ function createHistoryMode( ApiConstructor ) {
 			tagDisplayNames = map;
 			return map;
 		} catch ( error ) {
-			if ( error && error.name !== 'AbortError' ) {
+			if ( !isAbortError( error ) ) {
 				mw.log.error( '[commandPalette] Tag display-name fetch failed:', error );
 			}
 			return new Map();

--- a/resources/skins.citizen.commandPalette/modes/namespace.js
+++ b/resources/skins.citizen.commandPalette/modes/namespace.js
@@ -187,7 +187,7 @@ function matchNamespacePrefix( text ) {
 	return { label: name ? `${ name }:` : raw, raw };
 }
 
-/** @type {import('../types.js').PaletteMode} */
+/** @type {import('../types.js').PaletteMode|null} */
 module.exports = defineMode( {
 	id: 'namespace',
 	triggers: [ '/ns:', ':' ],

--- a/resources/skins.citizen.commandPalette/providers/PaletteCommandProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/PaletteCommandProvider.js
@@ -1,4 +1,5 @@
 const createProvider = require( './createProvider.js' );
+const isAbortError = require( '../utils/isAbortError.js' );
 
 const MAX_COMMAND_RESULTS = 10;
 
@@ -41,7 +42,7 @@ async function getMatchedCommandResults( paletteRegistry, match, query, signal )
 		// A cancelled request is not a failure. Rethrowing lets the
 		// orchestration's lifecycle swallow it, so an aborted keystroke
 		// neither logs an error nor renders an empty list.
-		if ( err && err.name === 'AbortError' ) {
+		if ( isAbortError( err ) ) {
 			throw err;
 		}
 		mw.log.error(

--- a/resources/skins.citizen.commandPalette/providers/SearchProvider.js
+++ b/resources/skins.citizen.commandPalette/providers/SearchProvider.js
@@ -1,5 +1,6 @@
 const createProvider = require( './createProvider.js' );
 const { getNavigationAction } = require( '../utils/providerActions.js' );
+const isAbortError = require( '../utils/isAbortError.js' );
 
 /**
  * Creates a search provider with the given search client.
@@ -19,7 +20,7 @@ function createSearchProvider( searchClient ) {
 				const results = response.results ?? [];
 				return { items: results.map( ( item ) => ( { ...item, source: 'search' } ) ) };
 			} catch ( error ) {
-				if ( error.name === 'AbortError' ) {
+				if ( isAbortError( error ) ) {
 					return { items: [] };
 				}
 				throw error;

--- a/resources/skins.citizen.commandPalette/services/searchClient.js
+++ b/resources/skins.citizen.commandPalette/services/searchClient.js
@@ -104,24 +104,27 @@ function createRestSearchClient( scriptPath ) {
 			query,
 			results: response.pages.map( ( page ) => {
 				const thumbnail = page.thumbnail;
-				const showRedirect = !!page.matched_title &&
-					isRedirectUseful( page.title, page.matched_title );
+				// Bound to a local so the null check narrows for the metadata
+				// label below; `showRedirect` alone is just a boolean.
+				const matchedTitle = page.matched_title;
+				const showRedirect = !!matchedTitle &&
+					isRedirectUseful( page.title, matchedTitle );
 				return {
 					id: `citizen-command-palette-item-page-${ page.key }`,
 					type: 'page',
 					label: page.title,
 					description: showDescription ? page.description : undefined,
-					url: mw.util.getUrl( page.matched_title ?? page.title ),
+					url: mw.util.getUrl( matchedTitle ?? page.title ),
 					thumbnail: thumbnail ? {
 						url: thumbnail.url,
 						width: thumbnail.width ?? undefined,
 						height: thumbnail.height ?? undefined
 					} : undefined,
 					thumbnailIcon: cdxIconArticle,
-					metadata: showRedirect ? [
+					metadata: showRedirect && matchedTitle ? [
 						{
 							icon: cdxIconArticleRedirect,
-							label: page.matched_title,
+							label: matchedTitle,
 							highlightQuery: true
 						}
 					] : undefined,

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -236,12 +236,25 @@
  */
 
 /**
+ * A token chip in the input. A mode contributes one through a `tokenPattern`
+ * match or an `addToken` action; `id` is assigned when the token is stored.
+ *
+ * @typedef {Object} CommandPaletteToken
+ * @property {string} id Unique identifier for the chip.
+ * @property {string} label Text shown in the chip.
+ * @property {string} raw Source text the token was matched from.
+ * @property {string} modeId Mode that produced the token.
+ * @property {string} position Where the token may appear. Defaults to 'any'.
+ * @property {string} [variant] Optional visual variant for the chip.
+ */
+
+/**
  * Action to append a token chip to the input and clear the free text,
  * without leaving the current mode.
  *
  * @typedef {Object} CommandPaletteAddTokenAction
  * @property {'addToken'} action
- * @property {{label: string, raw: string, modeId: string, position: string, variant: (string|undefined)}} payload The token to append — the shape TokenPattern matchers produce, plus its owning mode.
+ * @property {Omit<CommandPaletteToken, 'id'>} payload The token to append — the shape TokenPattern matchers produce, plus its owning mode.
  */
 
 /**

--- a/resources/skins.citizen.commandPalette/utils/isAbortError.js
+++ b/resources/skins.citizen.commandPalette/utils/isAbortError.js
@@ -1,0 +1,19 @@
+/**
+ * Whether a caught value is an abort signal firing rather than a real failure.
+ *
+ * Catch bindings are `unknown`: a rejected promise can carry anything, so the
+ * value is not necessarily an object and reading `.name` off it directly can
+ * throw. Callers abort in-flight requests on every keystroke, so this runs on
+ * the common path.
+ *
+ * @param {unknown} error
+ * @return {boolean}
+ */
+function isAbortError( error ) {
+	if ( typeof error !== 'object' || error === null ) {
+		return false;
+	}
+	return /** @type {{ name?: unknown }} */ ( error ).name === 'AbortError';
+}
+
+module.exports = isAbortError;

--- a/skin.json
+++ b/skin.json
@@ -434,6 +434,7 @@
 				"resources/skins.citizen.commandPalette/composables/useResultRouter.js",
 				"resources/skins.citizen.commandPalette/composables/useTokenizedInput.js",
 				"resources/skins.citizen.commandPalette/utils/fetch.js",
+				"resources/skins.citizen.commandPalette/utils/isAbortError.js",
 				"resources/skins.citizen.commandPalette/utils/providerActions.js",
 				"resources/skins.citizen.commandPalette/utils/appendQueryActions.js",
 				"resources/skins.citizen.commandPalette/services/instantDiffs.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
 		"strictFunctionTypes": true,
 		"strictBindCallApply": true,
 		"noImplicitThis": true,
-		"alwaysStrict": true
+		"alwaysStrict": true,
+		"useUnknownInCatchVariables": true,
+		"strictNullChecks": true
 	},
 	"include": [
 		"resources/skins.citizen.commandPalette/**/*.js",


### PR DESCRIPTION
## Problem

`strictNullChecks` and `useUnknownInCatchVariables` were the two strict flags left worth having — 50 diagnostics between them, against 524 for `noImplicitAny`, which stays off. Without them, every `ref( null )` and `ref( [] )` in the palette was effectively untyped and every catch binding was `any`.

## Change

Both flags are on and the palette is at zero diagnostics.

**Catch bindings.** Eight `error.name === 'AbortError'` tests now go through one `isAbortError` helper. Seven already guarded against a falsy error and `SearchProvider` did not, so a rejected promise carrying a non-object no longer throws a second error on the way out.

**Untyped refs — 24 of the 50.** `shallowRef( null )` infers `Ref<null>` and `ref( [] )` infers `Ref<never[]>`, so reads through `activeMode`, `content`, `related`, `recents`, `helpItems` and `tokens` were unchecked. Annotating them gives those refs real types for the first time. Extracting `CommandPaletteToken` in the process removes an inline duplicate of the token shape from `CommandPaletteAddTokenAction`.

**Two wrong annotations.** `help` and `namespace` declared their exports non-null, but `defineCommand` and `defineMode` return null on validation failure — and `paletteRegistry` already warns and refuses such a handler, so null was always a real outcome.

## Notes for reviewers

Thirteen diagnostics were `deps` in `useProviderOrchestration`, already defaulted by `deps = deps || {}`. That narrowing does not reach the closures that use it, so a default parameter does the same job in a form the checker can follow. It differs only if a caller passes `null` explicitly, which none do. The same pattern explains the `getItemDetail` change: it is guarded at the top of the function and invoked inside a closure, so the method is bound to a local. Its only implementation is a plain function with no `this` use.

In `searchClient`, `matched_title` is bound to a local so the null check narrows for the metadata label. `showRedirect` alone is a boolean and carries no type information.

## Verification

1466 tests, all lints clean, and the palette driven in a browser through rapid typing (which aborts a request per keystroke, exercising `isAbortError` on the common path), the command list, namespace mode and help mode.

The redirect-badge branch could not be exercised here: this wiki's only redirect is `FooRedirect` → `Foo`, and `isRedirectUseful` correctly rejects it because the titles contain one another. The `url` line on that path was confirmed — the result links to `/wiki/FooRedirect`.

## Follow-ups

`noImplicitAny` remains off. #1816 is still open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command palette search, history, category, file, and provider behavior when requests are cancelled.
  * Prevented invalid or incomplete redirect information from appearing in search results.
  * Improved reliability when loading command details and handling optional palette modes.

* **Refactor**
  * Consolidated cancellation handling across command palette features for more consistent behavior.

* **Documentation**
  * Clarified TypeScript guidance and command palette type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->