### PR TITLE
fix(commandPalette): say what the mode callback arrays contain

### DIFF
--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -133,13 +133,13 @@
  * @property {boolean} [compactResults=false] Render results in a denser layout — small icon instead of thumbnail, description inline. Use for command-style modes whose items lack real thumbnails. Ignored in gallery layout.
  * @property {KeyBinding[]} [keybindings] Optional mode-contributed keyboard bindings. Prepended onto the core binding list at dispatch time, so mode bindings win on key collisions within their own zone.
  * @property {StateContent} [emptyState] Content shown when the mode is active with no query. Falls back to default search messaging.
- * @property {( query: string, tokens?: Array ) => StateContent} [noResults] Returns content shown when query produces no results. Receives the query string and optional tokens array. Falls back to default no-results messaging.
+ * @property {( query: string, tokens?: CommandPaletteToken[] ) => StateContent} [noResults] Returns content shown when query produces no results. Receives the query string and optional tokens array. Falls back to default no-results messaging.
  * @property {TokenPattern|TokenPattern[]} [tokenPattern] Optional token detection pattern(s) for auto-tokenization.
  * @property {PaletteHelp} [help] Optional content surfaced by the help overlay when this mode is active.
- * @property {( query: string, signal?: AbortSignal, tokens?: Array, modeContext?: Array ) => Promise<CommandPaletteItem[]>} getResults Returns result items for the given sub-query. Optional signal for abort, optional tokens array, optional mode context array (only meaningful for modes that opt in to drill-down state). The signal is honoured by mw.Api on MediaWiki 1.44+ and ignored on 1.43.
+ * @property {( query: string, signal?: AbortSignal, tokens?: CommandPaletteToken[], modeContext?: Object[] ) => Promise<CommandPaletteItem[]>} getResults Returns result items for the given sub-query. Optional signal for abort, optional tokens array, optional mode context array (only meaningful for modes that opt in to drill-down state). The signal is honoured by mw.Api on MediaWiki 1.44+ and ignored on 1.43.
  * @property {( item: CommandPaletteItem, signal?: AbortSignal ) => Promise<Object>} [getItemDetail] Lazy detail-pane data for the highlighted item, resolving to `{ description, pairs }` — each field is merged into the item's `detail` when present. Use when the data is too heavy to compute for every item upfront. Same signal caveat as `getResults`.
  * @property {( item: CommandPaletteItem ) => (CommandPaletteActionResult|Promise<CommandPaletteActionResult>)} [onResultSelect] Handles selection of a result item.
- * @property {( modeContext: Array ) => string} [headerLabel] Optional breadcrumb label rendered in the header. Receives the current modeContext stack. Falls back to the input placeholder when absent.
+ * @property {( modeContext: Object[] ) => string} [headerLabel] Optional breadcrumb label rendered in the header. Receives the current modeContext stack. Falls back to the input placeholder when absent.
  */
 
 /**


### PR DESCRIPTION
## Problem

`types.js` documents three mode callbacks with a bare `Array` parameter:

```js
@property {( query: string, tokens?: Array ) => StateContent} [noResults]
@property {( query: string, signal?: AbortSignal, tokens?: Array, modeContext?: Array ) => …} getResults
@property {( modeContext: Array ) => string} [headerLabel]
```

An array of what? This is the file third-party mode and provider authors work from, so "an array" is close to no documentation at all — the same failure #1775 was filed about.

## Change

The token arrays are `CommandPaletteToken[]`; the mode-context stack is `Object[]`.

These were the last four places in `types.js` needing a type argument, so the API reference is now clean under `noImplicitAny` — even though the flag stays off for the implementation, where the remaining ~519 diagnostics are mostly `{Object}` parameters in internal files no external author reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved command palette type documentation with more precise parameter annotations for tokens and mode context data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->