### PR TITLE
fix(commandPalette): survive a handler with malformed triggers

### DIFF
--- a/resources/skins.citizen.commandPalette/services/paletteRegistry.js
+++ b/resources/skins.citizen.commandPalette/services/paletteRegistry.js
@@ -6,6 +6,20 @@ const { cdxIconCode } = require( '../icons.json' );
  *
  * @return {Object} Palette registry service
  */
+/**
+ * A handler's triggers, or an empty list when it has none usable.
+ *
+ * `register` warns about a malformed `triggers` but still stores the handler,
+ * and third parties register through a public hook, so neither its presence nor
+ * its type can be assumed here.
+ *
+ * @param {import('../types.js').PaletteHandler} handler
+ * @return {string[]}
+ */
+function triggersOf( handler ) {
+	return Array.isArray( handler?.triggers ) ? handler.triggers : [];
+}
+
 function createPaletteRegistry() {
 	/** @type {Map<string, import('../types.js').PaletteHandler>} */
 	const handlers = new Map();
@@ -20,7 +34,7 @@ function createPaletteRegistry() {
 	 */
 	function rebuildTriggerList() {
 		flatTriggerList = Array.from( handlers.entries() ).flatMap(
-			( [ id, handler ] ) => ( handler?.triggers ?? [] ).map(
+			( [ id, handler ] ) => triggersOf( handler ).map(
 				( trigger ) => ( { trigger, id, lowerTrigger: trigger.toLowerCase() } )
 			)
 		);
@@ -145,24 +159,25 @@ function createPaletteRegistry() {
 			entries = Array.from( handlers.entries() );
 		}
 
-		try {
-			return entries.map( ( [ id, handler ] ) => ( {
+		return entries.flatMap( ( [ id, handler ] ) => {
+			const triggers = triggersOf( handler );
+			if ( !triggers.length ) {
+				return [];
+			}
+			return [ {
 				id: `citizen-command-palette-item-command-${ id }`,
 				type: 'command',
-				label: handler.triggers[ 0 ],
+				label: triggers[ 0 ],
 				description: handler.description,
 				thumbnailIcon: cdxIconCode,
-				value: handler.triggers[ 0 ],
-				metadata: handler.triggers.length > 1 ?
-					handler.triggers.slice( 1 ).map( ( trigger ) => ( { label: trigger } ) ) :
+				value: triggers[ 0 ],
+				metadata: triggers.length > 1 ?
+					triggers.slice( 1 ).map( ( trigger ) => ( { label: trigger } ) ) :
 					undefined,
 				source: `command:${ id }`,
 				highlightQuery: true
-			} ) );
-		} catch ( error ) {
-			mw.log.error( '[paletteRegistry|getCommandListItems] Error during mapping:', error );
-			return [];
-		}
+			} ];
+		} );
 	}
 
 	/**

--- a/tests/vitest/commandPalette/services/paletteRegistry.test.js
+++ b/tests/vitest/commandPalette/services/paletteRegistry.test.js
@@ -245,6 +245,57 @@ describe( 'createPaletteRegistry', () => {
 
 			expect( items[ 0 ].metadata ).toEqual( [ { label: '@' } ] );
 		} );
+
+		it( 'skips a triggerless handler instead of emptying the list', () => {
+			registry.register( makeHandler( { id: 'valid', triggers: [ '/valid:' ] } ) );
+			// `register` warns about this but still accepts it, and third parties
+			// register through a public hook.
+			registry.register( makeHandler( { id: 'broken', triggers: [] } ) );
+
+			const items = registry.getCommandListItems();
+
+			expect( items ).toHaveLength( 1 );
+			expect( items[ 0 ].value ).toBe( '/valid:' );
+		} );
+
+		it( 'skips a handler whose triggers is not an array', () => {
+			registry.register( makeHandler( { id: 'valid', triggers: [ '/valid:' ] } ) );
+			// A single string instead of a list of them is an easy mistake for a
+			// third party calling `register` directly rather than via defineMode.
+			registry.register( makeHandler( { id: 'stringy', triggers: '/oops:' } ) );
+
+			const items = registry.getCommandListItems();
+
+			expect( items ).toHaveLength( 1 );
+			expect( items[ 0 ].value ).toBe( '/valid:' );
+		} );
+
+		it( 'skips a handler whose triggers property is missing entirely', () => {
+			registry.register( makeHandler( { id: 'valid', triggers: [ '/valid:' ] } ) );
+			const broken = makeHandler( { id: 'broken' } );
+			delete broken.triggers;
+			registry.register( broken );
+
+			const items = registry.getCommandListItems();
+
+			expect( items ).toHaveLength( 1 );
+			expect( items[ 0 ].value ).toBe( '/valid:' );
+		} );
+	} );
+
+	describe( 'register with a malformed handler', () => {
+		it( 'does not throw, and later registrations still work', () => {
+			expect( () => registry.register( makeHandler( { id: 'stringy', triggers: '/oops:' } ) ) )
+				.not.toThrow();
+
+			expect( () => registry.register( makeHandler( { id: 'good', triggers: [ '/good:' ] } ) ) )
+				.not.toThrow();
+
+			const items = registry.getCommandListItems();
+
+			expect( items ).toHaveLength( 1 );
+			expect( items[ 0 ].value ).toBe( '/good:' );
+		} );
 	} );
 
 	describe( 'getHandler', () => {


### PR DESCRIPTION
Closes #1816.

## Problem

`getCommandListItems` read `handler.triggers[ 0 ]` with no guard, inside a `try` whose `catch` returned `[]` for the whole list. One handler without triggers threw on the row it reached and took every command with it — and the help catalog, which `init.js` builds from the same call.

`rebuildTriggerList` had the same gap and a worse consequence. It runs inside `register`, after the handler is stored, so a `triggers` that is not an array threw out of `register` itself and left the bad entry in the map. Because it rescans every handler on each call, **every later `register` threw too**, and so did `getCommandListItems` — one malformed handler permanently stopped any further registration.

`register` only warns before accepting such a handler, and third parties register through `citizen.commandPalette.register`, which exposes `register` directly rather than the stricter `defineMode`/`defineCommand`. Passing a single string where a list belongs is an easy mistake to make there.

Measured through that hook in a browser:

| gadget registers | before | after |
| --- | --- | --- |
| `{ id, description }`, no triggers | command list drops to **0** | skipped; 10 rows remain |
| `triggers: '/oops:'`, then a well-formed gadget | both `register` calls throw; palette unusable | malformed one skipped, the later one works; 11 rows |

## Change

Both sites read triggers through one helper that returns an empty list unless the value really is an array, so a malformed handler costs its own row and nothing else.

With that guard nothing in the mapping can throw, so the blanket `catch` goes rather than remain as a construct that turns any future error into a silently empty palette.

Four regression tests: empty `triggers`, missing `triggers`, non-array `triggers`, and that `register` survives a malformed handler and keeps working afterwards. All fail without the change.

## Deliberately not changed

`register` still warns and accepts rather than rejecting. Refusing a malformed handler outright would also work, but it changes what third-party registration accepts, and that is a separate decision. With both readers tolerant, such a handler is inert rather than harmful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command palette stability when command handlers have missing, empty, or invalid trigger configurations.
  * Invalid handlers are now skipped without preventing valid commands from appearing or being registered.

* **Tests**
  * Added coverage for malformed handlers and verified that valid command registration continues to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->