### PR TITLE
fix(dropdown): stop one Escape closing both a select and the dropdown

### DIFF
--- a/resources/skins.citizen.scripts/dropdown.js
+++ b/resources/skins.citizen.scripts/dropdown.js
@@ -37,12 +37,24 @@ class Dropdown {
 	/**
 	 * Dismiss the target when ESCAPE is pressed.
 	 *
-	 * @param {Event} event
+	 * Must stay bound on capture: a nested control stops Escape on keydown, and
+	 * by keyup has already collapsed, so the expanded state this reads is only
+	 * available before it runs. `role="combobox"` is what marks a control that
+	 * owns Escape — the table of contents and notification toggles carry
+	 * aria-expanded without handling any key.
+	 *
+	 * @param {KeyboardEvent} event
 	 */
 	dismissOnEscape( event ) {
-		if ( event.key === 'Escape' ) {
-			this.dismiss();
+		if ( event.key !== 'Escape' ) {
+			return;
 		}
+		const target = event.target;
+		if ( target && typeof target.closest === 'function' &&
+			target.closest( '[role="combobox"][aria-expanded="true"]' ) ) {
+			return;
+		}
+		this.dismiss();
 	}
 
 	/**
@@ -76,7 +88,7 @@ class Dropdown {
 		this.window.removeEventListener( 'mousedown', this.dismissIfExternalEventTarget );
 		this.window.removeEventListener( 'touchstart', this.dismissIfExternalEventTarget );
 		this.window.removeEventListener( 'focusin', this.dismissIfExternalEventTarget );
-		this.window.removeEventListener( 'keyup', this.dismissOnEscape );
+		this.window.removeEventListener( 'keydown', this.dismissOnEscape, true );
 	}
 
 	/**
@@ -87,7 +99,7 @@ class Dropdown {
 		this.window.addEventListener( 'mousedown', this.dismissIfExternalEventTarget );
 		this.window.addEventListener( 'touchstart', this.dismissIfExternalEventTarget, { passive: true } );
 		this.window.addEventListener( 'focusin', this.dismissIfExternalEventTarget );
-		this.window.addEventListener( 'keyup', this.dismissOnEscape );
+		this.window.addEventListener( 'keydown', this.dismissOnEscape, true );
 	}
 
 	/**

--- a/tests/vitest/skins.citizen.scripts/dropdown.test.js
+++ b/tests/vitest/skins.citizen.scripts/dropdown.test.js
@@ -111,9 +111,72 @@ describe( 'Dropdown', () => {
 				.find( ( call ) => call[ 0 ] === 'toggle' )[ 1 ];
 			toggleHandler();
 
-			const keyupHandler = win.addEventListener.mock.calls
-				.find( ( call ) => call[ 0 ] === 'keyup' )[ 1 ];
-			keyupHandler( { key: 'Escape' } );
+			const keydownHandler = win.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'keydown' )[ 1 ];
+			keydownHandler( { key: 'Escape', target: null } );
+
+			expect( details.open ).toBe( false );
+		} );
+
+		it( 'should not dismiss when a nested control has something expanded', () => {
+			const dropdown = create();
+			dropdown.init();
+			details.open = true;
+
+			const toggleHandler = details.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'toggle' )[ 1 ];
+			toggleHandler();
+
+			// A Codex select handle whose menu is open. The capture-phase
+			// listener sees this before the control collapses it.
+			const handle = { closest: vi.fn( () => ( {} ) ) };
+
+			const keydownHandler = win.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'keydown' )[ 1 ];
+			keydownHandler( { key: 'Escape', target: handle } );
+
+			expect( handle.closest ).toHaveBeenCalledWith(
+				'[role="combobox"][aria-expanded="true"]'
+			);
+			expect( details.open ).toBe( true );
+		} );
+
+		it( 'should dismiss when the expanded element is not a combobox', () => {
+			const dropdown = create();
+			dropdown.init();
+			details.open = true;
+
+			const toggleHandler = details.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'toggle' )[ 1 ];
+			toggleHandler();
+
+			// A table-of-contents section toggle: carries aria-expanded but
+			// handles no keys, so Escape still belongs to the dropdown.
+			const tocToggle = {
+				closest: vi.fn( ( selector ) => selector.includes( 'combobox' ) ? null : {} )
+			};
+
+			const keydownHandler = win.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'keydown' )[ 1 ];
+			keydownHandler( { key: 'Escape', target: tocToggle } );
+
+			expect( details.open ).toBe( false );
+		} );
+
+		it( 'should dismiss when a nested control is collapsed', () => {
+			const dropdown = create();
+			dropdown.init();
+			details.open = true;
+
+			const toggleHandler = details.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'toggle' )[ 1 ];
+			toggleHandler();
+
+			const handle = { closest: vi.fn( () => null ) };
+
+			const keydownHandler = win.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'keydown' )[ 1 ];
+			keydownHandler( { key: 'Escape', target: handle } );
 
 			expect( details.open ).toBe( false );
 		} );
@@ -127,9 +190,9 @@ describe( 'Dropdown', () => {
 				.find( ( call ) => call[ 0 ] === 'toggle' )[ 1 ];
 			toggleHandler();
 
-			const keyupHandler = win.addEventListener.mock.calls
-				.find( ( call ) => call[ 0 ] === 'keyup' )[ 1 ];
-			keyupHandler( { key: 'Enter' } );
+			const keydownHandler = win.addEventListener.mock.calls
+				.find( ( call ) => call[ 0 ] === 'keydown' )[ 1 ];
+			keydownHandler( { key: 'Enter', target: null } );
 
 			expect( details.open ).toBe( true );
 		} );
@@ -243,7 +306,7 @@ describe( 'Dropdown', () => {
 				'mousedown', expect.any( Function )
 			);
 			expect( win.addEventListener ).toHaveBeenCalledWith(
-				'keyup', expect.any( Function )
+				'keydown', expect.any( Function ), true
 			);
 		} );
 
@@ -267,7 +330,7 @@ describe( 'Dropdown', () => {
 				'mousedown', expect.any( Function )
 			);
 			expect( win.removeEventListener ).toHaveBeenCalledWith(
-				'keyup', expect.any( Function )
+				'keydown', expect.any( Function ), true
 			);
 		} );
 	} );
@@ -298,7 +361,7 @@ describe( 'Dropdown', () => {
 			dropdown.destroy();
 
 			expect( win.removeEventListener ).toHaveBeenCalledWith(
-				'keyup', expect.any( Function )
+				'keydown', expect.any( Function ), true
 			);
 			expect( target.removeEventListener ).toHaveBeenCalledWith(
 				'click', expect.any( Function )


### PR DESCRIPTION
Closes #1740.

## Problem

Dropdowns dismissed on `keyup`. A Codex select handles Escape on `keydown` and stops the event there, so the keydown never reached the window listener — but the keyup is a separate event Codex does not touch, and it arrived unconditionally. One Escape aimed at the Font size menu closed the menu *and* the whole preferences panel, losing the settings context mid-adjustment.

## Why not simply move to keydown

That fixes the reported case, because Codex stops the event before it bubbles. But `CdxSelect` calls `preventDefault()` and `stopPropagation()` on Escape **whether or not its menu is open** — confirmed in `codex.js`, where the `Escape` branch calls `maybePrevent()` unconditionally and `CdxSelect` does not pass `prevent: false`. Verified in a browser: with a select merely focused and collapsed, the keydown still never reaches window.

So a bubble-phase listener would trade one bug for another — Escape would do nothing at all while a select had focus, until the user moved focus elsewhere. No guard helps there, because the event never arrives.

## Change

Bind in the **capture** phase, which runs before the focused control, and skip dismissal only when the event target sits inside something currently expanded.

At capture time the select's menu is still open, and that is what distinguishes "the user closed a menu" from "the user closed this dropdown". By keyup the state is gone, which is why no guard on the old listener could have told them apart.

The issue suggested a `defaultPrevented` check and noted capture would defeat it. That is true of `defaultPrevented`, which always reads false in capture — but not of a DOM-state check, which is why this reads `aria-expanded` instead.

Verified in a browser against the real panel:

| | menu | panel |
| --- | --- | --- |
| before, one Escape with the menu open | closed | **closed** |
| after, one Escape with the menu open | closed | **open** |
| after, Escape with the select focused but collapsed | — | closed |
| after, Escape with an expanded table-of-contents toggle focused | — | closed |

The guard matches `role="combobox"`, not `aria-expanded` alone. Both `CdxSelect`'s handle and the command palette's input carry that role; the table of contents section toggles and the notification wiki toggles are plain buttons that carry `aria-expanded` while handling no keys. The table of contents is itself a `.citizen-dropdown`, so matching `aria-expanded` on its own stopped Escape closing it whenever one of those toggles had focus.

The command palette does not close on Escape from this listener, which is pre-existing and unrelated — it runs its own Escape ladder — confirmed against `main`.

Three regression tests cover the expanded, collapsed and non-combobox cases, and the selector string itself is asserted, so broadening it back fails the suite, and the existing tests move from `keyup` to capture-phase `keydown`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown Escape-key handling for faster and more reliable dismissal.
  * Dropdowns now remain open when Escape is used within an expanded combobox.
  * Escape continues to close dropdowns when used with other controls or collapsed elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->