### PR TITLE
fix(templates): separate icon button link attributes

### DIFF
--- a/templates/IconButtonLink.mustache
+++ b/templates/IconButtonLink.mustache
@@ -1,5 +1,5 @@
 <a role="button"
-    {{#array-attributes}}{{key}}="{{value}}"{{/array-attributes}}
+    {{#array-attributes}} {{key}}="{{value}}"{{/array-attributes}}
     class="cdx-button cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet{{#icon}} cdx-button--icon-only{{/icon}}{{#class}} {{.}}{{/class}}">
     {{#icon}}{{>Icon}}{{/icon}}<span>{{ text }}</span>
 </a>


### PR DESCRIPTION
## Problem

`IconButtonLink.mustache` renders each attribute in its `array-attributes` loop with no separator between iterations, so a link carrying two or more attributes serialises them joined together:

```html
<a role="button"
    href="/w/index.php?title=Akita&amp;action=edit&amp;section=1"title="Edit section's source code: First topic"
```

That is invalid HTML. Browsers recover from it — the tokenizer treats the run after the closing quote as a new attribute name — so nothing was visibly broken, but the skin has been emitting malformed markup.

## Behaviour

The template is used in exactly one place, `SectionLinks.mustache`, so this affects section edit links.

It has been largely invisible because on ordinary content pages `CitizenComponentBodyContent` parses the body HTML into a DOM and re-serialises it, which silently repaired the spacing before it reached the client. That repair does not happen wherever `SkinCitizen::shouldMakeSections()` returns false — the main page, non-content namespaces, non-wikitext content, mobile view under MobileFrontend, or `$wgCitizenEnableCollapsibleSections = false`. Those pages ship the malformed markup today.

Measured on the dev wiki before and after, counting joined attribute pairs in the served HTML:

| page | before | after |
| --- | --- | --- |
| article (sectioning runs) | 0 | 0 |
| talk page | 2 | 0 |
| main page | 2 | 0 |

Section edit links are otherwise unchanged — same `href`, same `title`, same `section=N`.

## Contract

Output-only, and whitespace inside a start tag. No class or ID is renamed, removed or restructured, so this is not cache-breaking and needs no compat slice.

`Button.mustache` and `Link.mustache` already write `{{#array-attributes}} {{key}}="{{value}}"…` with the leading space; this brings the third template in line with them.

## Follow-ups

None required. Worth noting for anyone working on the body-content pipeline: the DOM round-trip there acts as an incidental repair pass for malformed markup, so any change that removes it will expose defects of this shape elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnGAcsnNzmFdPDWkhAGjmB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spacing between rendered attributes in icon button links for more consistent markup output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->