### PR TITLE
fix(pwa): stop refetching the logos on every manifest request

### DIFF
--- a/includes/Api/ApiWebappManifest.php
+++ b/includes/Api/ApiWebappManifest.php
@@ -15,6 +15,7 @@ use MediaWiki\MainConfigNames;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\Title\Title;
 use MediaWiki\Utils\UrlUtils;
+use Wikimedia\ObjectCache\WANObjectCache;
 
 /**
  * Based on the MobileFrontend extension
@@ -38,6 +39,23 @@ class ApiWebappManifest extends ApiBase {
 	 */
 	private const LOGO_FETCH_TIMEOUT = 3;
 	private const LOGO_FETCH_CONNECT_TIMEOUT = 1;
+
+	/**
+	 * How long a measured icon list is kept, and how long one that came out
+	 * short is kept before the logos are measured again.
+	 *
+	 * Measuring a logo means fetching it from the wiki's own web server, so a
+	 * list that lost one to a failure is worth retrying long before a complete
+	 * one is.
+	 */
+	private const ICON_CACHE_TTL = WANObjectCache::TTL_DAY;
+	private const ICON_CACHE_INCOMPLETE_TTL = 5 * WANObjectCache::TTL_MINUTE;
+
+	/** Bumped when the shape of a cached icon list changes. */
+	private const ICON_CACHE_VERSION = 1;
+
+	/** The $wgLogos entries the manifest can carry, in the order it emits them. */
+	private const LOGO_KEYS = [ '1x', '1.5x', '2x', 'icon', 'svg' ];
 
 	/** Icon fields taken from config, per the manifest spec. */
 	private const ICON_KEYS = [ 'src', 'sizes', 'type', 'purpose' ];
@@ -65,6 +83,7 @@ class ApiWebappManifest extends ApiBase {
 		private readonly Language $contentLanguage,
 		private readonly HttpRequestFactory $httpRequestFactory,
 		private readonly UrlUtils $urlUtils,
+		private readonly WANObjectCache $wanCache,
 	) {
 		parent::__construct( $main, $moduleName );
 		$this->config = $this->getConfig();
@@ -153,39 +172,91 @@ class ApiWebappManifest extends ApiBase {
 
 	/**
 	 * Get icons from wgLogos
+	 *
+	 * The key hashes the logos the list was built from, so a $wgLogos edit
+	 * misses the old entry rather than needing a purge.
 	 */
 	private function getIconsFromLogos(): array {
-		$urlUtils = $this->urlUtils;
-		$httpRequestFactory = $this->httpRequestFactory;
+		$logos = $this->getConfiguredLogos();
+		if ( $logos === [] ) {
+			return [];
+		}
+
+		$cache = $this->wanCache;
+
+		return $cache->getWithSetCallback(
+			$cache->makeKey(
+				'citizen-manifest-icons',
+				self::ICON_CACHE_VERSION,
+				hash( 'sha256', serialize( $logos ) )
+			),
+			self::ICON_CACHE_TTL,
+			function ( $oldValue, &$ttl, array &$setOpts ) use ( $logos ) {
+				// No replica read here, so no lag to declare. Left unsaid,
+				// WANObjectCache reads how long the fetches took as staleness
+				// and keeps the list for thirty seconds.
+				$setOpts['since'] = INF;
+
+				$icons = $this->buildIcons( $logos );
+				if ( count( $icons ) < count( $logos ) ) {
+					$ttl = self::ICON_CACHE_INCOMPLETE_TTL;
+				}
+				return $icons;
+			}
+		);
+	}
+
+	/**
+	 * The logos the manifest can carry, in the order it emits them.
+	 *
+	 * @return string[]
+	 */
+	private function getConfiguredLogos(): array {
+		$logos = $this->config->get( MainConfigNames::Logos );
+		if ( !is_array( $logos ) ) {
+			return [];
+		}
+
+		$configured = [];
+		foreach ( self::LOGO_KEYS as $logoKey ) {
+			// $wgLogos also carries array-shaped entries such as wordmark.
+			if ( isset( $logos[$logoKey] ) && is_string( $logos[$logoKey] ) ) {
+				$configured[$logoKey] = $logos[$logoKey];
+			}
+		}
+		return $configured;
+	}
+
+	/**
+	 * Turn configured logos into manifest icon entries.
+	 *
+	 * A logo yields one entry or none, so a list shorter than the logos it was
+	 * built from means something could not be measured.
+	 *
+	 * @param string[] $logos
+	 * @return array[]
+	 */
+	private function buildIcons( array $logos ): array {
 		$logger = LoggerFactory::getInstance( 'Citizen' );
 
 		$icons = [];
-		$logos = $this->config->get( MainConfigNames::Logos );
 
-		if ( !$logos ) {
-			return $icons;
-		}
-
-		$logoKeys = [
-			'1x',
-			'1.5x',
-			'2x',
-			'icon',
-			'svg'
-		];
-
-		foreach ( $logoKeys as $logoKey ) {
-			// Avoid undefined index
-			if ( !isset( $logos[$logoKey] ) ) {
+		foreach ( $logos as $logoPath ) {
+			if ( self::isSvgPath( $logoPath ) ) {
+				// An SVG fits any size, and getimagesizefromstring() cannot
+				// read one anyway, so fetching it would discard the bytes.
+				$icons[] = [
+					'src' => $logoPath,
+					'sizes' => 'any',
+					'type' => 'image/svg+xml',
+				];
 				continue;
 			}
 
-			$logoPath = (string)$logos[$logoKey];
-
 			$logoUrl = '';
 			try {
-				$logoUrl = $urlUtils->expand( $logoPath, PROTO_CURRENT ) ?? '';
-				$request = $httpRequestFactory->create( $logoUrl, [
+				$logoUrl = $this->urlUtils->expand( $logoPath, PROTO_CURRENT ) ?? '';
+				$request = $this->httpRequestFactory->create( $logoUrl, [
 					'timeout' => self::LOGO_FETCH_TIMEOUT,
 					'connectTimeout' => self::LOGO_FETCH_CONNECT_TIMEOUT,
 				], __METHOD__ );
@@ -194,9 +265,6 @@ class ApiWebappManifest extends ApiBase {
 					$logoContent = $request->getContent();
 				} else {
 					$logoContent = '';
-					// The manifest is cached for a week, so a logo the server
-					// could not reach is missing from it for a week with
-					// nothing else to show for it.
 					$logger->warning(
 						'Could not fetch logo {logo} for the webapp manifest, HTTP {code}',
 						[ 'logo' => $logoUrl, 'code' => $request->getStatus() ]
@@ -210,36 +278,29 @@ class ApiWebappManifest extends ApiBase {
 				);
 			}
 
-			if ( $logoContent !== '' ) {
-				$logoSize = getimagesizefromstring( $logoContent );
-			} else {
-				$logoSize = false;
-			}
-
-			$icon = [
-				'src' => $logoPath
-			];
-
-			if ( $logoSize !== false ) {
-				$icon['sizes'] = $logoSize[0] . 'x' . $logoSize[1];
-				$icon['type'] = $logoSize['mime'];
-			}
-
-			// Set sizes to any if it is a SVG
-			if ( str_ends_with( $logoPath, 'svg' ) ) {
-				$icon['sizes'] = 'any';
-				$icon['type'] = 'image/svg+xml';
-			}
-
-			// Exit if not sizes are detected
-			if ( !isset( $icon['sizes'] ) ) {
+			$logoSize = $logoContent !== '' ? getimagesizefromstring( $logoContent ) : false;
+			// Nothing measurable, so there are no sizes to declare.
+			if ( $logoSize === false ) {
 				continue;
 			}
 
-			$icons[] = $icon;
+			$icons[] = [
+				'src' => $logoPath,
+				'sizes' => $logoSize[0] . 'x' . $logoSize[1],
+				'type' => $logoSize['mime'],
+			];
 		}
 
 		return $icons;
+	}
+
+	/**
+	 * Whether a logo path points at an SVG.
+	 */
+	private static function isSvgPath( string $logoPath ): bool {
+		// A query string or fragment is not part of the extension.
+		$path = substr( $logoPath, 0, strcspn( $logoPath, '?#' ) );
+		return str_ends_with( strtolower( $path ), '.svg' );
 	}
 
 	/**

--- a/skin.json
+++ b/skin.json
@@ -127,7 +127,8 @@
 			"services": [
 				"ContentLanguage",
 				"HttpRequestFactory",
-				"UrlUtils"
+				"UrlUtils",
+				"MainWANObjectCache"
 			]
 		}
 	},

--- a/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/Unit/Api/ApiWebappManifestTest.php
@@ -15,7 +15,10 @@ use MediaWiki\Utils\UrlUtils;
 use MediaWikiUnitTestCase;
 use MWHttpRequest;
 use ReflectionMethod;
+use RuntimeException;
 use StatusValue;
+use Wikimedia\ObjectCache\HashBagOStuff;
+use Wikimedia\ObjectCache\WANObjectCache;
 
 /**
  * The default shortcuts resolve special page titles through the service
@@ -40,6 +43,7 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 			$this->createMock( Language::class ),
 			$this->createMock( HttpRequestFactory::class ),
 			$this->createMock( UrlUtils::class ),
+			self::createCache(),
 		);
 	}
 
@@ -255,10 +259,30 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 	}
 
 	/**
+	 * A real cache over an in-memory store: getWithSetCallback() is final, so
+	 * a mock cannot stand in for it.
+	 *
+	 * The no-op asyncHandler drops WANObjectCache's pre-emptive refresh of a
+	 * popular key. Without one it regenerates in line instead, which lands as
+	 * an unexpected call on a request mock about once in 800 reads.
+	 */
+	private static function createCache(): WANObjectCache {
+		return new WANObjectCache( [
+			'cache' => new HashBagOStuff(),
+			'asyncHandler' => static function ( callable $callback ): void {
+			},
+		] );
+	}
+
+	/**
 	 * Build an API whose only icon source is $wgLogos, fetched through the
 	 * given factory.
 	 */
-	private function createApiWithLogos( array $logos, HttpRequestFactory $httpRequestFactory ): ApiWebappManifest {
+	private function createApiWithLogos(
+		array $logos,
+		HttpRequestFactory $httpRequestFactory,
+		?WANObjectCache $cache = null
+	): ApiWebappManifest {
 		$contextMock = $this->createMock( IContextSource::class );
 		$contextMock->method( 'getConfig' )->willReturn( new HashConfig( [
 			'CitizenManifestOptions' => [ 'icons' => [] ],
@@ -277,6 +301,14 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 			$this->createMock( Language::class ),
 			$httpRequestFactory,
 			$urlUtils,
+			$cache ?? self::createCache(),
+		);
+	}
+
+	/** A 1x1 PNG, so getimagesizefromstring() has something real to measure. */
+	private static function onePixelPng(): string {
+		return (string)base64_decode(
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
 		);
 	}
 
@@ -323,21 +355,275 @@ class ApiWebappManifestTest extends MediaWikiUnitTestCase {
 	}
 
 	/**
-	 * An SVG needs no measuring, so it survives a fetch the server could not
-	 * make — the browser fetches it on its own account, and a server that
-	 * cannot reach its own URL is not evidence the browser cannot either.
+	 * @return iterable<string, array{string}>
 	 */
-	public function testGetIconsFromLogosKeepsAnSvgItCannotFetch(): void {
+	public static function provideSvgLogoPaths(): iterable {
+		yield 'plain' => [ '/logo.svg' ];
+		// Extensions are not case sensitive, and a logo path may carry a
+		// cache-busting query string or a fragment.
+		yield 'uppercase extension' => [ '/logo.SVG' ];
+		yield 'query string' => [ '/logo.svg?ver=2' ];
+		yield 'fragment' => [ '/logo.svg#icon' ];
+	}
+
+	/**
+	 * Nothing about an SVG has to be measured, so fetching one is pure cost.
+	 *
+	 * @dataProvider provideSvgLogoPaths
+	 */
+	public function testGetIconsFromLogosDoesNotFetchAnSvg( string $logoPath ): void {
 		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
-		$httpRequestFactory->method( 'create' )->willReturn( $this->createLogoRequest( false ) );
-		$api = $this->createApiWithLogos( [ 'svg' => '/logo.svg' ], $httpRequestFactory );
+		$httpRequestFactory->expects( $this->never() )->method( 'create' );
+		$api = $this->createApiWithLogos( [ 'svg' => $logoPath ], $httpRequestFactory );
 
 		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
 
 		$this->assertSame(
-			[ [ 'src' => '/logo.svg', 'sizes' => 'any', 'type' => 'image/svg+xml' ] ],
+			[ [ 'src' => $logoPath, 'sizes' => 'any', 'type' => 'image/svg+xml' ] ],
 			$method->invoke( $api )
 		);
+	}
+
+	/**
+	 * The extension is what marks an SVG, not the last three characters of the
+	 * path — otherwise a raster logo would be advertised as a scalable one.
+	 */
+	public function testGetIconsFromLogosMeasuresAPathMerelyEndingInSvg(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->willReturn( $this->createLogoRequest( true, self::onePixelPng() ) );
+		$api = $this->createApiWithLogos( [ '1x' => '/logosvg' ], $httpRequestFactory );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$this->assertSame(
+			[ [ 'src' => '/logosvg', 'sizes' => '1x1', 'type' => 'image/png' ] ],
+			$method->invoke( $api )
+		);
+	}
+
+	/**
+	 * Measuring a logo means fetching it from the wiki's own web server, so an
+	 * uncached manifest response must not pay for the list a second time.
+	 */
+	public function testGetIconsFromLogosMeasuresEachLogoOnce(): void {
+		$clock = 1000.0;
+		$cache = self::createCache();
+		$cache->setMockTime( $clock );
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->willReturn( $this->createLogoRequest( true, self::onePixelPng() ) );
+		$api = $this->createApiWithLogos( [ '1x' => '/logo.png' ], $httpRequestFactory, $cache );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+		$first = $method->invoke( $api );
+		$clock += 3600;
+
+		$this->assertSame( $first, $method->invoke( $api ) );
+	}
+
+	/**
+	 * A logo the server could not reach is missing from the manifest until the
+	 * cached list expires, so a list that came out short must be measured again
+	 * long before a complete one would be.
+	 */
+	public function testGetIconsFromLogosRetriesAnIncompleteListSooner(): void {
+		$clock = 1000.0;
+		$cache = self::createCache();
+		$cache->setMockTime( $clock );
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->exactly( 2 ) )
+			->method( 'create' )
+			->willReturn( $this->createLogoRequest( false ) );
+		$api = $this->createApiWithLogos( [ '1x' => '/logo.png' ], $httpRequestFactory, $cache );
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$method->invoke( $api );
+		$clock += 3600;
+
+		$this->assertSame( [], $method->invoke( $api ) );
+	}
+
+	/**
+	 * The short retry must still be a cached window, not a bypass: an
+	 * unreachable logo that is measured again on every request is the defect
+	 * this memo exists to remove.
+	 */
+	public function testGetIconsFromLogosCachesAnIncompleteListBriefly(): void {
+		$clock = 1000.0;
+		$cache = self::createCache();
+		$cache->setMockTime( $clock );
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->willReturn( $this->createLogoRequest( false ) );
+		$api = $this->createApiWithLogos( [ '1x' => '/logo.png' ], $httpRequestFactory, $cache );
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$method->invoke( $api );
+		$clock += 60;
+
+		$this->assertSame( [], $method->invoke( $api ) );
+	}
+
+	/**
+	 * A server slow to answer for its own logos is the one that can least
+	 * afford to measure them again, so how long measuring took must not shorten
+	 * how long the result is kept.
+	 */
+	public function testGetIconsFromLogosKeepsASlowlyMeasuredList(): void {
+		$clock = 1000.0;
+		$cache = self::createCache();
+		$cache->setMockTime( $clock );
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->willReturnCallback( function () use ( &$clock ): MWHttpRequest {
+				// Over WANObjectCache's MAX_READ_LAG of 7s, past which it cuts
+				// the entry to TTL_LAGGED (30s).
+				$clock += 10;
+				return $this->createLogoRequest( true, self::onePixelPng() );
+			} );
+		$api = $this->createApiWithLogos( [ '1x' => '/logo.png' ], $httpRequestFactory, $cache );
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$first = $method->invoke( $api );
+		$clock += 3600;
+
+		$this->assertSame( $first, $method->invoke( $api ) );
+	}
+
+	/**
+	 * The cached list is keyed on the logos it was built from, so editing
+	 * $wgLogos takes effect without a purge.
+	 */
+	public function testGetIconsFromLogosRemeasuresWhenTheLogosChange(): void {
+		$cache = self::createCache();
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->exactly( 2 ) )
+			->method( 'create' )
+			->willReturn( $this->createLogoRequest( true, self::onePixelPng() ) );
+
+		foreach ( [ '/old.png', '/new.png' ] as $logoPath ) {
+			$api = $this->createApiWithLogos( [ '1x' => $logoPath ], $httpRequestFactory, $cache );
+			$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+			$this->assertSame(
+				[ [ 'src' => $logoPath, 'sizes' => '1x1', 'type' => 'image/png' ] ],
+				$method->invoke( $api )
+			);
+		}
+	}
+
+	/**
+	 * $wgLogos carries entries the manifest has no use for, and 'wordmark' is
+	 * an array rather than a path — neither may reach the fetch loop.
+	 */
+	public function testGetIconsFromLogosIgnoresLogosItCannotUse(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->never() )->method( 'create' );
+		$api = $this->createApiWithLogos( [
+			'1x' => '/logo.svg',
+			'wordmark' => [ 'src' => '/wordmark.svg', 'width' => 135, 'height' => 20 ],
+			'icon' => '/icon.svg',
+		], $httpRequestFactory );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$this->assertSame( [
+			[ 'src' => '/logo.svg', 'sizes' => 'any', 'type' => 'image/svg+xml' ],
+			[ 'src' => '/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml' ],
+		], $method->invoke( $api ) );
+	}
+
+	/**
+	 * A malformed URL or a misconfigured proxy throws rather than answering,
+	 * which must leave the rest of the list intact.
+	 */
+	public function testGetIconsFromLogosDropsALogoWhoseFetchThrows(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->method( 'create' )
+			->willThrowException( new RuntimeException( 'Invalid reverseProxy configured' ) );
+		$api = $this->createApiWithLogos(
+			[ '1x' => '/logo.png', 'icon' => '/icon.svg' ],
+			$httpRequestFactory
+		);
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$this->assertSame(
+			[ [ 'src' => '/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml' ] ],
+			$method->invoke( $api )
+		);
+	}
+
+	/**
+	 * $wgLogos is site config, so a value of the wrong shape under a key the
+	 * manifest does use must be skipped rather than stringified into a src.
+	 */
+	public function testGetIconsFromLogosSkipsALogoThatIsNotAPath(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->never() )->method( 'create' );
+		$api = $this->createApiWithLogos( [
+			'1x' => [ 'src' => '/logo.svg', 'width' => 135, 'height' => 20 ],
+			'icon' => '/icon.svg',
+		], $httpRequestFactory );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$this->assertSame(
+			[ [ 'src' => '/icon.svg', 'sizes' => 'any', 'type' => 'image/svg+xml' ] ],
+			$method->invoke( $api )
+		);
+	}
+
+	/**
+	 * The manifest's icon order is Citizen's, not whatever order $wgLogos
+	 * happens to declare its keys in.
+	 */
+	public function testGetIconsFromLogosEmitsAFixedOrder(): void {
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->never() )->method( 'create' );
+		$api = $this->createApiWithLogos( [
+			'icon' => '/icon.svg',
+			'svg' => '/scalable.svg',
+			'1x' => '/one.svg',
+		], $httpRequestFactory );
+
+		$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+		$this->assertSame(
+			[ '/one.svg', '/icon.svg', '/scalable.svg' ],
+			array_column( $method->invoke( $api ), 'src' )
+		);
+	}
+
+	/**
+	 * The key covers only the logos the manifest can carry, so editing one it
+	 * cannot use must not throw the measured list away.
+	 */
+	public function testGetIconsFromLogosKeepsTheListWhenAnUnusedLogoChanges(): void {
+		$cache = self::createCache();
+		$httpRequestFactory = $this->createMock( HttpRequestFactory::class );
+		$httpRequestFactory->expects( $this->once() )
+			->method( 'create' )
+			->willReturn( $this->createLogoRequest( true, self::onePixelPng() ) );
+
+		$logoSets = [
+			[ '1x' => '/logo.png' ],
+			[ '1x' => '/logo.png', 'wordmark' => [ 'src' => '/wordmark.svg', 'width' => 135, 'height' => 20 ] ],
+		];
+		foreach ( $logoSets as $logos ) {
+			$api = $this->createApiWithLogos( $logos, $httpRequestFactory, $cache );
+			$method = new ReflectionMethod( $api, 'getIconsFromLogos' );
+
+			$this->assertSame(
+				[ [ 'src' => '/logo.png', 'sizes' => '1x1', 'type' => 'image/png' ] ],
+				$method->invoke( $api )
+			);
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/SkinJsonServiceWiringTest.php
+++ b/tests/phpunit/Unit/SkinJsonServiceWiringTest.php
@@ -4,21 +4,22 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Skins\Citizen\Tests\Unit;
 
+use MediaWiki\Skins\Citizen\Api\ApiWebappManifest;
 use MediaWiki\Skins\Citizen\SkinCitizen;
 use MediaWikiUnitTestCase;
 use ReflectionClass;
 use ReflectionNamedType;
 
 /**
- * Guards the positional contract between skin.json's service list and
- * SkinCitizen's constructor. ObjectFactory passes services by position, so
+ * Guards the positional contract between skin.json's service lists and the
+ * constructors they feed. ObjectFactory passes services by position, so
  * inserting a name anywhere but the end — or adding a constructor parameter
  * without its service — hands the wrong object to the wrong parameter. Every
  * service parameter is typed, so that throws a TypeError at construction; but
- * nothing else in the suite constructs the skin through skin.json, so the
- * TypeError would first surface on a real page view — Special:Preferences
- * among them, which instantiates every registered skin and so goes down with
- * it.
+ * nothing else in the suite constructs these through skin.json, so the
+ * TypeError would first surface on a real request — a page view for the skin
+ * (Special:Preferences among them, which instantiates every registered skin
+ * and so goes down with it), or ?action=appmanifest for the API module.
  *
  * @group Citizen
  * @coversNothing
@@ -30,27 +31,34 @@ class SkinJsonServiceWiringTest extends MediaWikiUnitTestCase {
 	 */
 	private const SERVICE_CLASS_ALIASES = [
 		'MobileFrontend.Context' => 'MobileContext',
+		'ContentLanguage' => 'Language',
+		'MainWANObjectCache' => 'WANObjectCache',
 	];
 
-	private function getSkinSpec(): array {
-		$skinJson = json_decode(
+	/**
+	 * ApiModuleManager hands ObjectFactory the parent ApiMain and the module
+	 * name as extraArgs, so an API module's declared services start at the
+	 * third constructor parameter.
+	 */
+	private const API_MODULE_EXTRA_ARGS = 2;
+
+	private function readSkinJson(): array {
+		return json_decode(
 			file_get_contents( dirname( __DIR__, 3 ) . '/skin.json' ),
 			true,
 			512,
 			JSON_THROW_ON_ERROR
 		);
-
-		return $skinJson['ValidSkinNames']['citizen'];
 	}
 
 	/**
 	 * @return string[] Constructor parameter type short names, in order
 	 */
-	private function getConstructorParameterTypes(): array {
-		$constructor = ( new ReflectionClass( SkinCitizen::class ) )->getConstructor();
+	private function getConstructorParameterTypes( string $class, int $skip = 0 ): array {
+		$constructor = ( new ReflectionClass( $class ) )->getConstructor();
 		$types = [];
 
-		foreach ( $constructor->getParameters() as $parameter ) {
+		foreach ( array_slice( $constructor->getParameters(), $skip ) as $parameter ) {
 			$type = $parameter->getType();
 			if ( !( $type instanceof ReflectionNamedType ) || $type->isBuiltin() ) {
 				// The trailing $options array; services stop here.
@@ -63,19 +71,37 @@ class SkinJsonServiceWiringTest extends MediaWikiUnitTestCase {
 		return $types;
 	}
 
-	public function testServiceOrderMatchesConstructorParameterOrder(): void {
-		$spec = $this->getSkinSpec();
-		$declared = array_merge( $spec['services'], $spec['optional_services'] ?? [] );
-
-		$expected = array_map(
+	/**
+	 * @param string[] $declared
+	 * @return string[]
+	 */
+	private function toClassShortNames( array $declared ): array {
+		return array_map(
 			static fn ( string $service ): string => self::SERVICE_CLASS_ALIASES[$service] ?? $service,
 			$declared
 		);
+	}
+
+	public function testServiceOrderMatchesConstructorParameterOrder(): void {
+		$spec = $this->readSkinJson()['ValidSkinNames']['citizen'];
+		$declared = array_merge( $spec['services'], $spec['optional_services'] ?? [] );
 
 		$this->assertSame(
-			$expected,
-			$this->getConstructorParameterTypes(),
+			$this->toClassShortNames( $declared ),
+			$this->getConstructorParameterTypes( SkinCitizen::class ),
 			'skin.json service order must match SkinCitizen constructor parameter order'
+		);
+	}
+
+	public function testApiModuleServiceOrderMatchesConstructorParameterOrder(): void {
+		$spec = $this->readSkinJson()['APIModules']['appmanifest'];
+
+		$declared = array_merge( $spec['services'], $spec['optional_services'] ?? [] );
+
+		$this->assertSame(
+			$this->toClassShortNames( $declared ),
+			$this->getConstructorParameterTypes( ApiWebappManifest::class, self::API_MODULE_EXTRA_ARGS ),
+			'skin.json service order must match ApiWebappManifest constructor parameter order'
 		);
 	}
 }

--- a/tests/phpunit/integration/Api/ApiWebappManifestTest.php
+++ b/tests/phpunit/integration/Api/ApiWebappManifestTest.php
@@ -39,6 +39,7 @@ class ApiWebappManifestTest extends MediaWikiIntegrationTestCase {
 			$services->getContentLanguage(),
 			$services->getHttpRequestFactory(),
 			$services->getUrlUtils(),
+			$services->getMainWANObjectCache(),
 		);
 	}
 
@@ -114,6 +115,7 @@ class ApiWebappManifestTest extends MediaWikiIntegrationTestCase {
 			$services->getContentLanguage(),
 			$services->getHttpRequestFactory(),
 			$services->getUrlUtils(),
+			$services->getMainWANObjectCache(),
 		);
 
 		$api->execute();


### PR DESCRIPTION
Closes #1833.

## Problem

A wiki that leaves `$wgCitizenManifestOptions['icons']` unset has its manifest icons derived from `$wgLogos`. To describe each logo, the endpoint fetched it over HTTP — expanded against `$wgServer`, so the server made a request to its own public hostname, out and back over whatever route that resolves to.

Nothing remembered the answer. The manifest's week-long `Cache-Control` is a per-response directive, not a server-side memo: MediaWiki downgrades it to `private` for anything with a session, adds `Vary: Cookie`, and rewrites it to `max-age=0` whenever the response sets a cookie. So a wiki with ordinary traffic repeated the whole loop several times a minute. The reporter watched their server GET its own two logos every twenty seconds.

For an SVG that work was entirely wasted — PHP cannot measure SVG at all, and the endpoint discarded the response and filled in the answer from the file extension regardless. Every logo the reporter had was an SVG, and so are MediaWiki's own defaults.

## Behaviour after this change

- **An SVG is described from its path and never fetched.** For the reporting wiki, and for any wiki on MediaWiki's default logos, the endpoint now makes no outbound requests at all. This holds regardless of how the wiki is configured.
- **Anything that does have to be measured is measured once**, and the result is held in the wiki's main object cache for a day. It is keyed on the logos it was built from, so editing `$wgLogos` takes effect without a purge.
- **A logo that could not be measured is retried within five minutes** rather than leaving the manifest short for a day.
- **Three logo paths that used to be dropped from the manifest now work**: an uppercase `.SVG`, and an SVG carrying a cache-busting query string or a fragment. Each was previously fetched, failed to measure, and vanished from the output.
- The emitted manifest is otherwise byte-identical.

Wikis that set `$wgCitizenManifestOptions['icons']` explicitly are unaffected — that path never measured anything.

## What this does not cover

- A wiki left on MediaWiki's default `$wgMainCacheType = CACHE_NONE` has no store behind the memo, so its **non-SVG** logos are still measured per response. That is why the SVG skip, rather than the memo, is what fixes the default configuration.
- The measurement still leaves the server, so an operator whose wiki cannot reach its own `$wgServer` URLs still loses those icons. `$wgLocalVirtualHosts` and `$wgLocalHTTPProxy` route such requests inside the network; setting `icons` explicitly avoids them entirely.
- The key tracks the logo paths, not their bytes, so a logo file replaced in place shows up within a day. The manifest's own browser cache is a week, so this is not the binding constraint.

## Notes for review

The `sizes` and `type` fields are optional in the manifest spec, so "just stop measuring" looks like the obvious simplification. It is not safe: Chromium builds icon candidates only from an icon's *declared* sizes, and the same selector backs its installability check — a raster logo declaring nothing would take a wiki from installable to not. That failure would be invisible on an all-SVG wiki, so it is worth stating explicitly rather than leaving to a future cleanup.

The first commit is independent: `APIModules.appmanifest` already declared its services positionally and nothing guarded that contract, so a misordered name would first surface as a `TypeError` on a live request.

## Follow-ups, not in scope

- A wiki that sets only the legacy `$wgLogo` gets **zero** manifest icons, and per-language logo variants are ignored, because the endpoint reads `$wgLogos` directly instead of going through core's accessor.
- A degraded icon list is still emitted with the full week-long `max-age`, so a client that catches a bad window keeps it well past the server-side retry.
- A logo that answers but is not a measurable image is dropped without a log line; only an unreachable one warns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Web app manifest icons are now generated more efficiently through caching.
  * SVG logos are handled without unnecessary downloads and retain flexible sizing.
  * Raster logos are measured before being included, preventing unusable icons from appearing.
  * Logo updates automatically refresh cached manifest results.
  * Temporary failures are retried sooner, while complete results remain cached longer.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->