### PR TITLE
feat(sections): hide the edit buttons when a section is collapsed

### DIFF
--- a/resources/skins.citizen.styles/components/Sections.less
+++ b/resources/skins.citizen.styles/components/Sections.less
@@ -105,6 +105,12 @@ section[ data-mw-section-id ] > .mw-heading,
 		// margin instead of merging with it.
 		margin-block-end: 0;
 
+		// Hide edit section buttons when section is collapsed,
+		// since user no longer needs the section.
+		.mw-editsection {
+			display: none;
+		}
+
 		&::before,
 		> .citizen-section-toggle::before {
 			transform: rotate3d( 1, 0, 0, 180deg );


### PR DESCRIPTION
## Problem

A collapsed section keeps its edit links in the heading row. They act on a body the reader has just put away, so the row goes on offering controls for content that is no longer on screen.

## Behaviour

Collapsing a section now hides its own edit links along with the body; expanding brings them back. Subsections nested inside the collapsed section already went with the body, so only the collapsed section's own heading row changes.

The collapse toggle does not move. The links are taken out of flow rather than dimmed, and the section title is the heading row's only growing item, so the chevron keeps its place at the trailing edge and the row keeps its height.

## Contract

- CSS only — no markup change, so cached HTML is unaffected. Cache status **clean**, no compat slice needed.
- DiscussionTools' subscribe control is deliberately untouched: collapsible sections are gated on `Title::isContentPage()`, so the two controls never share a heading.

## Testing

Verified in a browser against the dev wiki, on both a plain section and one with nested subsections:

- Toggle geometry is byte-identical across expand → collapse → expand (32x32 at the same x), and the heading row height is unchanged.
- The edit links round-trip between `display: flex` and `display: none`; `aria-expanded` on the toggle is unaffected.
- No new console errors.

`npm run lint:styles` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2pXCSQ7VaPATCHFtqhpNr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Edit controls are now hidden when a section is collapsed, creating a cleaner and less cluttered interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->