### PR TITLE
fix(WikiLove): 🐛 fix missing heart icon for the button

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -707,6 +707,7 @@
 				"editLock",
 				"ellipsis",
 				"eye",
+				"heart",
 				"help",
 				"history",
 				"home",


### PR DESCRIPTION
Heart icon was missing causing WikiLove links to display a blank box, this _should_ fix it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a heart icon to the available icon set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->