### PR TITLE
feat(keyboardHint): draw shortcut keys as keycaps

### DIFF
--- a/resources/skins.citizen.commandPalette/components/CommandPaletteHelpTriggers.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteHelpTriggers.vue
@@ -3,7 +3,7 @@
 		<kbd
 			v-for="trigger in sortedTriggers"
 			:key="trigger"
-			class="citizen-command-palette-help__trigger-chip"
+			class="citizen-keyboard-hint-key citizen-keyboard-hint-key--literal"
 		>{{ trigger }}</kbd>
 	</div>
 </template>

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteHelpView.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteHelpView.vue
@@ -217,16 +217,6 @@ module.exports = exports = defineComponent( {
 		gap: var( --space-xs );
 	}
 
-	&__trigger-chip {
-		padding: var( --space-xxs ) var( --space-sm );
-		font-family: var( --font-family-monospace );
-		font-size: var( --font-size-medium );
-		color: var( --color-base );
-		background-color: var( --background-color-interactive );
-		border: var( --border-subtle );
-		border-radius: var( --border-radius-pill );
-	}
-
 	&__long-description {
 		code {
 			padding: 0 var( --space-xxs );

--- a/resources/skins.citizen.commandPalette/components/CommandPaletteKeyboardHints.vue
+++ b/resources/skins.citizen.commandPalette/components/CommandPaletteKeyboardHints.vue
@@ -6,7 +6,13 @@
 			class="citizen-keyboard-hint"
 		>
 			<span class="citizen-keyboard-hint-label">{{ hint.label }}</span>
-			<kbd class="citizen-keyboard-hint-key">{{ hint.kbd }}</kbd>
+			<span class="citizen-keyboard-hint-keys">
+				<kbd
+					v-for="( key, i ) in hint.keys"
+					:key="`${ hint.kbd }-${ i }`"
+					class="citizen-keyboard-hint-key"
+				>{{ key }}</kbd>
+			</span>
 		</div>
 	</div>
 </template>
@@ -27,7 +33,8 @@ module.exports = exports = defineComponent( {
 		/* eslint-disable mediawiki/msg-doc -- msgKeys are all documented; passed dynamically from useKeyboard */
 		const resolvedHints = computed( () => props.hints.map( ( hint ) => ( {
 			label: mw.message( hint.msgKey ).text(),
-			kbd: hint.kbd
+			kbd: hint.kbd,
+			keys: hint.keys
 		} ) ) );
 		/* eslint-enable mediawiki/msg-doc */
 

--- a/resources/skins.citizen.commandPalette/composables/useKeyboard.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboard.js
@@ -97,6 +97,30 @@ function mirrorHint( kbd, rtl ) {
 }
 
 /**
+ * Break a hint's `kbd` into the individual keys it advertises, one per cap.
+ *
+ * Splits on `+`, then keeps each run of ASCII alphanumerics together and gives
+ * every other character its own key: `esc` stays one, `↑↓←→` becomes four,
+ * `⌘C` and `Ctrl+C` become two.
+ *
+ * @param {string} kbd
+ * @return {string[]}
+ */
+function splitKbd( kbd ) {
+	if ( typeof kbd !== 'string' || kbd === '' ) {
+		return [];
+	}
+	const keys = [];
+	for ( const part of kbd.split( '+' ) ) {
+		const matches = part.match( /[0-9A-Za-z]+|[^0-9A-Za-z]/g );
+		if ( matches ) {
+			keys.push( ...matches );
+		}
+	}
+	return keys;
+}
+
+/**
  * Core keybinding registry for the command palette.
  *
  * Each binding is data: { id, zone, keys, when, worksDuringHelp, handle, hint }.
@@ -858,10 +882,11 @@ function useKeyboard( options ) {
 		const hints = resolveHints( state, zone, activeBindings.value );
 		const rtl = hints.some( ( hint ) => /[←→]/.test( hint.kbd ) ) &&
 			isRtlDirection( state.inputElement );
-		return hints.map( ( hint ) => ( {
-			msgKey: hint.msgKey,
-			kbd: mirrorHint( hint.kbd, rtl )
-		} ) );
+		return hints.map( ( hint ) => {
+			// `kbd` stays the authored string; it is what dedupes hints.
+			const kbd = mirrorHint( hint.kbd, rtl );
+			return { msgKey: hint.msgKey, kbd: kbd, keys: splitKbd( kbd ) };
+		} );
 	} );
 
 	/**

--- a/resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js
+++ b/resources/skins.citizen.commandPalette/composables/useKeyboardBindings.js
@@ -7,7 +7,7 @@
  *
  * @typedef {Object} KeyHint
  * @property {string} msgKey i18n message key for the label.
- * @property {string} kbd Glyph(s) shown in the <kbd> chip.
+ * @property {string} kbd Glyph(s) the hint advertises; split into one cap each.
  * @property {number} [order=100] Ascending sort order in the footer.
  *
  * @typedef {Object} KeyBinding

--- a/resources/skins.citizen.commandPalette/types.js
+++ b/resources/skins.citizen.commandPalette/types.js
@@ -180,9 +180,10 @@
  *
  * @typedef {Object} KeyBindingHint
  * @property {string} msgKey i18n message key for the hint label.
- * @property {string} kbd Keyboard glyph shown next to the label (e.g. '↵', '↑↓', '⌘C').
+ * @property {string} kbd Keyboard glyph(s) next to the label (e.g. '↵', '↑↓', '⌘C').
  *   A lone '←' or '→' is swapped on RTL interface languages so the hint names
  *   the key the user actually presses.
+ * @property {string[]} [keys] `kbd` split into individual keys, one cap each.
  * @property {number} [order] Sort order within the footer (lower = leftmost).
  */
 

--- a/resources/skins.citizen.scripts/dropdown.js
+++ b/resources/skins.citizen.scripts/dropdown.js
@@ -8,6 +8,14 @@ const
 	DROPDOWN_SUMMARY_SELECTOR = '.citizen-dropdown-summary',
 	DROPDOWN_TARGET_SELECTOR = '.citizen-menu__card';
 
+// `alt` is deliberately absent: MediaWiki names both `alt` and `option`, and
+// they are different keys, so ⌥ would advertise a key Windows and Linux lack.
+const MODIFIER_GLYPHS = {
+	ctrl: '⌃',
+	shift: '⇧',
+	option: '⌥'
+};
+
 /**
  * Represents a Dropdown menu with enhanced functionality.
  * Handles dismissing the menu when clicking outside,
@@ -142,18 +150,24 @@ class Dropdown {
 				return;
 			}
 
-			const keyhintText = this.window.jQuery.fn.updateTooltipAccessKeys.getAccessKeyPrefix() + link.getAttribute( 'accesskey' );
-			if ( !keyhintText ) {
+			const accessKey = link.getAttribute( 'accesskey' );
+			if ( !accessKey ) {
 				return;
 			}
-			const keyhint = this.document.createElement( 'kbd' );
-			keyhint.classList.add( 'citizen-keyboard-hint-key' );
-			keyhint.innerText = keyhintText
-				.replace( /-/g, ' ' )
-				.replace( 'ctrl', '⌃' )
-				.replace( 'shift', '⇧' )
-				.replace( 'option', '⌥' );
-			link.append( keyhint );
+			// Dash-separated modifier names: `ctrl-option-` on a Mac,
+			// `alt-shift-` elsewhere. Split before substituting so each
+			// modifier gets its own cap.
+			const prefix = this.window.jQuery.fn.updateTooltipAccessKeys.getAccessKeyPrefix();
+			const tokens = prefix.split( '-' ).filter( Boolean ).concat( accessKey );
+			const keys = this.document.createElement( 'span' );
+			keys.classList.add( 'citizen-keyboard-hint-keys' );
+			tokens.forEach( ( token ) => {
+				const keyhint = this.document.createElement( 'kbd' );
+				keyhint.classList.add( 'citizen-keyboard-hint-key' );
+				keyhint.innerText = MODIFIER_GLYPHS[ token ] || token;
+				keys.append( keyhint );
+			} );
+			link.append( keys );
 		} );
 	}
 

--- a/resources/skins.citizen.styles/components/Dropdown.less
+++ b/resources/skins.citizen.styles/components/Dropdown.less
@@ -1,7 +1,7 @@
 .citizen-dropdown {
 	.citizen-menu__card {
 		z-index: @z-index-dropdown;
-		min-width: 16rem;
+		min-width: 18rem;
 		max-width: 80vw;
 		content-visibility: hidden;
 		transition-timing-function: var( --transition-timing-function-ease-in );

--- a/resources/skins.citizen.styles/components/KeyboardHint.less
+++ b/resources/skins.citizen.styles/components/KeyboardHint.less
@@ -12,21 +12,25 @@
 		color: var( --color-base );
 	}
 
-	// Of the nine glyphs these hints emit (↑ ↓ ← → ↵ ⌫ ⇧ ⌃ ⌥) the bundled
-	// Roboto subsets carry only ↑ and ↓; the rest fall through to the OS
-	// sans-serif, so one hint is routinely drawn by two typefaces at different
-	// widths and weights. The fixed box is what holds them to an even rhythm —
-	// min-width, centring and the em padding are load-bearing, not decoration.
-	// Sizes are in em so a cap tracks whatever font-size its context sets. Note
-	// that the reader font-size preference is not that: features.less scopes
-	// .cdx-mode-*() to .citizen-body, which neither the dropdowns nor the
-	// command palette footer are inside.
+	&-keys {
+		display: inline-flex;
+		flex: none;
+		gap: 3px;
+		align-items: center;
+	}
+
+	// The bundled Roboto subsets carry only ↑ and ↓ of the glyphs these hints
+	// emit; the rest fall back to the OS font, so a hint is often drawn by two
+	// typefaces at once. min-width and centring are what keep them even.
 	&-key {
 		display: inline-block;
 		flex: none;
 		min-width: 1.7em;
 		padding: 0.1em 0.4em;
 		font-family: var( --font-family-base );
+		// A step below its label, as a key legend reads against running text.
+		// Every other dimension here is em-relative, so this sizes the cap too.
+		font-size: var( --font-size-x-small );
 		font-weight: var( --font-weight-medium );
 		line-height: 1.4;
 		color: var( --color-subtle );
@@ -34,31 +38,36 @@
 		// stylelint-disable-next-line declaration-property-value-disallowed-list
 		text-transform: capitalize;
 		background-color: var( --background-color-interactive-subtle );
-		// Width is spelled out because the skin resets `border: 0` on every
-		// element, so a colour-only rule would paint nothing.
+		// Needs the explicit width: the skin resets `border: 0` on every element.
 		border: var( --border-width-base ) solid var( --border-color-base );
 		border-radius: var( --border-radius-base );
-		// A hard bottom edge rather than a blurred drop shadow — at 12px a blur
-		// only muddies the border it sits under.
 		box-shadow: 0 1px 0 var( --border-color-base );
-		// Arrow glyphs are bidi-neutral, so a multi-key hint like `↑↓←` takes
-		// the paragraph direction and renders reversed on an RTL wiki. Isolate
-		// it so the authored order survives. @noflip because CSSJanus would
-		// otherwise rewrite this to `rtl` in the RTL build — the one place the
-		// flip must not happen.
+		// Arrow glyphs are bidi-neutral and would take the paragraph direction
+		// on an RTL wiki. @noflip because CSSJanus would otherwise rewrite this
+		// to `rtl` in the RTL build — the one place the flip must not happen.
 		/* @noflip */
 		direction: ltr;
 		unicode-bidi: isolate;
 	}
+
+	// A trigger is a verbatim string to type. capitalize would turn `/cat:`
+	// into `/Cat:` and advertise a trigger that does not exist.
+	&-key--literal {
+		font-family: var( --font-family-monospace );
+		// A trigger has to be read character by character to be retyped, so it
+		// does not take the cap's step down.
+		font-size: var( --font-size-small );
+		text-transform: none;
+	}
 }
 
 // Align keyhint to the right
-.citizen-menu .mw-list-item .citizen-keyboard-hint-key {
+.citizen-menu .mw-list-item .citizen-keyboard-hint-keys {
 	margin-left: auto;
 }
 
 // Hide key hint in main menu for now
 // It has some wrapping issue with long label text
-#p-navigation .citizen-keyboard-hint-key {
+#p-navigation .citizen-keyboard-hint-keys {
 	display: none;
 }

--- a/resources/skins.citizen.styles/components/KeyboardHint.less
+++ b/resources/skins.citizen.styles/components/KeyboardHint.less
@@ -12,12 +12,35 @@
 		color: var( --color-base );
 	}
 
+	// Of the nine glyphs these hints emit (↑ ↓ ← → ↵ ⌫ ⇧ ⌃ ⌥) the bundled
+	// Roboto subsets carry only ↑ and ↓; the rest fall through to the OS
+	// sans-serif, so one hint is routinely drawn by two typefaces at different
+	// widths and weights. The fixed box is what holds them to an even rhythm —
+	// min-width, centring and the em padding are load-bearing, not decoration.
+	// Sizes are in em so a cap tracks whatever font-size its context sets. Note
+	// that the reader font-size preference is not that: features.less scopes
+	// .cdx-mode-*() to .citizen-body, which neither the dropdowns nor the
+	// command palette footer are inside.
 	&-key {
+		display: inline-block;
+		flex: none;
+		min-width: 1.7em;
+		padding: 0.1em 0.4em;
 		font-family: var( --font-family-base );
 		font-weight: var( --font-weight-medium );
+		line-height: 1.4;
 		color: var( --color-subtle );
+		text-align: center;
 		// stylelint-disable-next-line declaration-property-value-disallowed-list
 		text-transform: capitalize;
+		background-color: var( --background-color-interactive-subtle );
+		// Width is spelled out because the skin resets `border: 0` on every
+		// element, so a colour-only rule would paint nothing.
+		border: var( --border-width-base ) solid var( --border-color-base );
+		border-radius: var( --border-radius-base );
+		// A hard bottom edge rather than a blurred drop shadow — at 12px a blur
+		// only muddies the border it sits under.
+		box-shadow: 0 1px 0 var( --border-color-base );
 		// Arrow glyphs are bidi-neutral, so a multi-key hint like `↑↓←` takes
 		// the paragraph direction and renders reversed on an RTL wiki. Isolate
 		// it so the authored order survives. @noflip because CSSJanus would

--- a/resources/skins.citizen.styles/components/UserInfo.less
+++ b/resources/skins.citizen.styles/components/UserInfo.less
@@ -28,7 +28,7 @@
 			align-items: flex-start;
 		}
 
-		.citizen-keyboard-hint-key {
+		.citizen-keyboard-hint-keys {
 			display: none;
 		}
 	}

--- a/resources/skins.citizen.styles/components/UserMenu.less
+++ b/resources/skins.citizen.styles/components/UserMenu.less
@@ -16,7 +16,7 @@
 		border-radius: var( --border-radius-medium );
 	}
 
-	.citizen-keyboard-hint-key {
+	.citizen-keyboard-hint-keys {
 		display: none;
 	}
 }

--- a/tests/vitest/commandPalette/composables/useKeyboard.test.js
+++ b/tests/vitest/commandPalette/composables/useKeyboard.test.js
@@ -706,7 +706,7 @@ describe( 'useKeyboard', () => {
 			// Enter has nothing to act on here, so advertising it would promise
 			// a keystroke that does nothing.
 			expect( hints ).toEqual( [
-				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc', keys: [ 'esc' ] }
 			] );
 		} );
 
@@ -718,7 +718,7 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints ).toContainEqual(
-				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' }
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', keys: [ '↵' ] }
 			);
 		} );
 
@@ -732,10 +732,10 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints ).toContainEqual(
-				{ msgKey: 'citizen-command-palette-keyhint-enter-search', kbd: '↵' }
+				{ msgKey: 'citizen-command-palette-keyhint-enter-search', kbd: '↵', keys: [ '↵' ] }
 			);
 			expect( hints ).not.toContainEqual(
-				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' }
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', keys: [ '↵' ] }
 			);
 		} );
 
@@ -746,9 +746,9 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints ).toEqual( [
-				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' },
-				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓' },
-				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', keys: [ '↵' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓', keys: [ '↑', '↓' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc', keys: [ 'esc' ] }
 			] );
 		} );
 
@@ -762,10 +762,10 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints ).toEqual( [
-				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' },
-				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓' },
-				{ msgKey: 'citizen-command-palette-keyhint-actions', kbd: '→' },
-				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', keys: [ '↵' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓', keys: [ '↑', '↓' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-actions', kbd: '→', keys: [ '→' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc', keys: [ 'esc' ] }
 			] );
 		} );
 
@@ -780,10 +780,10 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints ).toEqual( [
-				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' },
-				{ msgKey: 'citizen-command-palette-keyhint-return', kbd: '←' },
-				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓' },
-				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', keys: [ '↵' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-return', kbd: '←', keys: [ '←' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓', keys: [ '↑', '↓' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc', keys: [ 'esc' ] }
 			] );
 		} );
 
@@ -798,9 +798,9 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints ).toEqual( [
-				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵' },
-				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓←→' },
-				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-enter-select', kbd: '↵', keys: [ '↵' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-navigate', kbd: '↑↓←→', keys: [ '↑', '↓', '←', '→' ] },
+				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc', keys: [ 'esc' ] }
 			] );
 		} );
 
@@ -812,7 +812,7 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints[ hints.length - 1 ] ).toEqual(
-				{ msgKey: 'citizen-command-palette-keyhint-clear', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-clear', kbd: 'esc', keys: [ 'esc' ] }
 			);
 		} );
 
@@ -825,7 +825,7 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints[ hints.length - 1 ] ).toEqual(
-				{ msgKey: 'citizen-command-palette-keyhint-exit', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-exit', kbd: 'esc', keys: [ 'esc' ] }
 			);
 		} );
 	} );
@@ -1263,7 +1263,7 @@ describe( 'useKeyboard', () => {
 			const hints = keyboard.keyboardHints.value;
 
 			expect( hints[ hints.length - 1 ] ).toEqual(
-				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc' }
+				{ msgKey: 'citizen-command-palette-keyhint-close', kbd: 'esc', keys: [ 'esc' ] }
 			);
 		} );
 	} );

--- a/tests/vitest/skins.citizen.scripts/dropdown.test.js
+++ b/tests/vitest/skins.citizen.scripts/dropdown.test.js
@@ -436,23 +436,43 @@ describe( 'Dropdown', () => {
 			expect( target.querySelectorAll ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should create kbd elements for links with accesskeys', () => {
+		it( 'should create one kbd element per modifier and the access key', () => {
 			const link = {
 				getAttribute: vi.fn().mockReturnValue( 'e' ),
 				append: vi.fn(),
 				querySelector: vi.fn().mockReturnValue( null )
 			};
 			target.querySelectorAll.mockReturnValue( [ link ] );
-			const kbd = { classList: { add: vi.fn() }, innerText: '' };
-			doc.createElement.mockReturnValue( kbd );
+			const made = [];
+			doc.createElement.mockImplementation( ( tag ) => {
+				const el = { tag, classList: { add: vi.fn() }, innerText: '', append: vi.fn() };
+				made.push( el );
+				return el;
+			} );
 
 			const dropdown = create();
 			dropdown.init();
 
-			expect( doc.createElement ).toHaveBeenCalledWith( 'kbd' );
-			expect( kbd.classList.add ).toHaveBeenCalledWith( 'citizen-keyboard-hint-key' );
-			expect( link.append ).toHaveBeenCalledWith( kbd );
-			expect( kbd.innerText ).toBe( '⌃ e' );
+			const wrapper = made.find( ( el ) => el.tag === 'span' );
+			const keys = made.filter( ( el ) => el.tag === 'kbd' );
+			expect( wrapper.classList.add ).toHaveBeenCalledWith( 'citizen-keyboard-hint-keys' );
+			expect( keys.map( ( el ) => el.innerText ) ).toEqual( [ '⌃', 'e' ] );
+			expect( keys[ 0 ].classList.add ).toHaveBeenCalledWith( 'citizen-keyboard-hint-key' );
+			expect( link.append ).toHaveBeenCalledWith( wrapper );
+		} );
+
+		it( 'should not render a hint for a link with an empty accesskey', () => {
+			const link = {
+				getAttribute: vi.fn().mockReturnValue( '' ),
+				append: vi.fn(),
+				querySelector: vi.fn().mockReturnValue( null )
+			};
+			target.querySelectorAll.mockReturnValue( [ link ] );
+
+			const dropdown = create();
+			dropdown.init();
+
+			expect( link.append ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should not add a second hint to a link that already has one', () => {


### PR DESCRIPTION
## Problem

Keyboard shortcuts rendered as bare subtle text everywhere the skin shows them — the palette footer, dropdown accesskey hints — so a key read as more prose rather than as something you press.

The reason it read *badly* turned out to be narrower than styling. Of the nine glyphs these hints emit (`↑ ↓ ← → ↵ ⌫ ⇧ ⌃ ⌥`), the bundled Roboto subsets carry only `↑` and `↓`; everything else falls through to the OS sans-serif. A single hint is routinely drawn by two typefaces at different widths and weights, sitting flush against each other with nothing to hide the seam. That also explains why `KeyboardHint.less` overrides `kbd` back to the base font family — Roboto Mono has none of the nine, so monospace would push all of them into fallback instead of seven.

A fixed box does the work the font cannot: `min-width` plus centred text holds mismatched glyphs to an even rhythm whichever font draws them.

Separately, the skin had three different looks for one idea — the bare hint key, the palette help view's filled monospace pill, and content `kbd`.

## Behaviour

- Shortcut keys render as keycaps: a subtle fill, a border, and a hard bottom edge.
- A chord is one cap per key. `Alt ⇧ J` was a single wide box holding a whole string; it is now three keys.
- Command triggers in the palette help view use the same cap, keeping monospace because a trigger is a literal to retype. This also fixes them rendering as `/Cat:` — the shared rule capitalizes, which would have advertised a trigger that does not exist.
- `alt` keeps its name rather than borrowing the Mac `option` glyph. MediaWiki names both and they are different keys, so `⌥` would advertise a key Windows and Linux machines do not have.
- Dropdown menus widen from 16rem to 18rem, and caps take a size step down from their label. Three caps are wider than the one they replace; at 16rem a label like "What links here" wrapped.
- Content `kbd` in article prose is untouched — it is the one `kbd` the skin does not own.

## Contract

- `hint.kbd` stays the authored string and is still what dedupes hints; `hint.keys` is the same value split for rendering.
- The `.citizen-keyboard-hint-key` cap is now a shared primitive, with a `--literal` modifier for verbatim strings. `.citizen-keyboard-hint-keys` wraps the caps of one hint and is what menu alignment and the `#p-navigation` hide now target.
- **No compat slice needed.** No PHP or Mustache emits these — every instance is written at runtime by `dropdown.js` or rendered by Vue — so even the markup change is not cache-breaking.

## Verification

1490 Vitest tests, `lint:js`, `lint:types` and `lint:styles` all pass. Checked against a live wiki in light and dark at 2× DPR: no cap overflows its box, no menu label wraps, `direction: ltr` survives `?uselang=he`, and the existing `#p-navigation` / `#pt-login` hides still win on ID specificity.

## Follow-ups

- The `#p-navigation` hide is still in place. Its comment cites a wrapping issue with long labels; `flex: none` on the cap plus the width bump may have resolved it, but that was not tested here and is a visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxeW6LKy8BLATVezLhUA7K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Keyboard shortcuts now display as separate, clearly styled key caps, including modifier symbols and literal key names.
  - Dropdown access-key hints use individual key elements and omit hints when no access key is available.
  - Dropdown menus have a wider minimum width for improved hint display.

- **Style**
  - Updated keyboard hint layouts, sizing, borders, typography, and alignment across menus and command palette views.

- **Tests**
  - Updated coverage for individual keyboard keys and empty access-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->