### PR TITLE
fix(pagetools): make every page tab visible and reachable on mobile

### DIFF
--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -47,8 +47,17 @@
 			gap: 0;
 			padding-right: var( --space-sm );
 			padding-left: var( --space-sm );
-			font-size: 0;
 			border-radius: var( --border-radius-medium );
+
+			// Collapse a label only where a glyph replaces it: getAssociated-
+			// NavigationLinks() tabs carry only text/href/class, so no icon map
+			// reaches them and collapsing every label left those blank but
+			// tappable (#1847). `link.text-wrapper` guarantees the span keyed on
+			// here. Do not bound the width either — those tabs get no title, so
+			// an ellipsis is unreadable on touch with nothing to recover it from.
+			> .citizen-ui-icon + span {
+				font-size: 0;
+			}
 		}
 	}
 
@@ -127,12 +136,26 @@
 		position: fixed;
 		right: 0;
 		bottom: ~'calc( var( --header-size-block-end ) + max( env( safe-area-inset-bottom ), var( --space-xs ) ) )';
-		height: var( --toolbar-size );
+		// `safe`: plain flex-end leaves a scroller's start-edge overflow unreachable.
+		justify-content: safe flex-end;
+		// Cap, don't pin: pinning both edges destroys the shrink-to-fit, and
+		// uncapped the start edge lands off the viewport with no way back.
+		max-inline-size: ~'calc( 100% - var( --space-xs ) * 2 )';
+		// Border-box: a bare --toolbar-size leaves 38px against 40px buttons.
+		height: ~'calc( var( --toolbar-size ) + var( --border-width-base ) * 2 )';
 		margin: var( --space-xs );
+		overflow: auto hidden;
+		// Must not chain into browser back-navigation.
+		overscroll-behavior: contain;
+		scrollbar-width: none;
 		background: var( --color-surface-1 );
 		border: 1px solid var( --border-color-base );
 		border-radius: var( --border-radius-medium );
 		box-shadow: var( --box-shadow-large );
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
 
 		:not( .citizen-menu__card ) .mw-list-item {
 			--size-icon: 1rem;
@@ -145,11 +168,72 @@
 		&__item {
 			position: unset;
 		}
+	}
 
-		.citizen-menu__card {
-			bottom: 100%;
-			width: max-content; // Fix card width issue when the page tool bar is narrow
+	// Reserve the TOC button's footprint, but only where one is rendered.
+	.citizen-toc-enabled .citizen-page-actions {
+		max-inline-size: ~'calc( 100% - var( --toolbar-size ) - var( --space-xs ) * 3 )';
+	}
+
+	// The way out of the bar must not scroll out of it. By id, not
+	// `> .citizen-dropdown`: languages sits near the start of the template, so a
+	// shared trailing offset would land it on top of the more button.
+	#citizen-page-more-dropdown {
+		position: sticky;
+		inset-inline-end: 0;
+		z-index: @z-index-stacking-1;
+		background: var( --color-surface-1 );
+	}
+
+	#citizen-page-languages-dropdown {
+		position: sticky;
+		inset-inline-start: 0;
+		z-index: @z-index-stacking-1;
+		background: var( --color-surface-1 );
+	}
+
+	// Let a tab dissolve into the pinned button so the bar reads as scrollable.
+	// The gradient ends in the bar's own background, so it is invisible over
+	// empty bar and needs no scroll position. It reaches back over the button's
+	// padding and the gap; the end that meets a neighbour is the transparent
+	// one, so a stray overlap is imperceptible.
+	#citizen-page-more-dropdown,
+	#citizen-page-languages-dropdown {
+		&::before {
+			position: absolute;
+			inset-block: 0;
+			inline-size: var( --space-md );
+			pointer-events: none;
+			content: '';
 		}
+	}
+
+	#citizen-page-more-dropdown::before {
+		inset-inline-start: ~'calc( var( --space-md ) * -1 )';
+		background: linear-gradient( to right, transparent, var( --color-surface-1 ) );
+	}
+
+	#citizen-page-languages-dropdown::before {
+		inset-inline-end: ~'calc( var( --space-md ) * -1 )';
+		background: linear-gradient( to left, transparent, var( --color-surface-1 ) );
+	}
+
+	// The bar is a scroll container and, with `__item` unset, also the card's
+	// containing block, so it would clip its own dropdown. Promote the card out,
+	// repeating the bar's safe-area term so it still clears a home indicator.
+	.citizen-page-actions .citizen-menu__card {
+		position: fixed;
+		inset: auto var( --space-xs ) ~'calc( var( --header-size-block-end ) + max( env( safe-area-inset-bottom ), var( --space-xs ) ) + var( --toolbar-size ) + var( --space-xs ) * 2 )' var( --space-xs );
+	}
+
+	// ...and autohide must not take it back: a transformed ancestor is the
+	// containing block for fixed descendants. Dropdown.less already locks page
+	// scroll while a card is open. Opacity too — the card would inherit the fade.
+	.citizen-page-actions:has( .citizen-dropdown-details[ open ] ) {
+		pointer-events: auto;
+		opacity: 1;
+		transform: none;
+		transition: none;
 	}
 
 	.citizen-page-languages .citizen-dropdown-summary::after {
@@ -162,7 +246,13 @@
 		> .mw-portlet {
 			li > a {
 				gap: var( --space-xs );
-				font-size: inherit;
+
+				// Restate the base rule's selector: it is (0,3,3) and this
+				// block (0,2,2), so a bare font-size reset loses and every
+				// desktop label collapses.
+				> .citizen-ui-icon + span {
+					font-size: inherit;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

Two defects in the mobile page-action bar, fixed together because fixing either alone makes the other worse.

**Tabs without an icon rendered as blank but tappable buttons.** The bar collapsed every label below 1120px and only restored it on desktop, on the assumption that an icon would stand in — but for a whole class of tabs one never can. A special page contributing tabs through `getAssociatedNavigationLinks()` is keyed ordinally as `special-specialAssociatedNavigationLinks-link-N` and carries only `text`, `href` and `class`, so no icon map can ever reach it. That is not an extension edge case: `Special:Watchlist` rendered four blank buttons on stock MediaWiki, and `Special:EditWatchlist` and `Special:Contribute` use the same core API. (#1847)

**The bar laid its overflow off the screen.** Anchored to one edge and shrink-to-fit, with twelve tabs at a 360px viewport it started at `x = -286px` while the document's scroll width stayed at 360 — so those tabs could not be reached by any gesture.

Restoring the labels widens each tab, which would have pushed more of the bar off screen. Hence one change rather than two.

## Behaviour

- A tab's label is now collapsed only where a glyph is actually present. `Special:Watchlist` reads *View and edit watchlist / Edit raw watchlist / Clear the watchlist* instead of three blank pills; an ordinary article is unchanged, since every tab there has an icon.
- An icon-less tab's label is shown in full, never truncated. The same core API that supplies no icon supplies no `title` either, and a tooltip would be hover-only regardless, so an ellipsis on a touch device leaves nowhere to read the label. A long label costs a scroll gesture; a clipped one costs the meaning.
- The bar is capped to the space available rather than pinned to both edges: it still hugs its content on an ordinary page (measured 266px at 360px wide, no scroller) and only becomes a scroller when it would not otherwise fit.
- The overflow button is pinned to the trailing edge, so the way out of the bar cannot scroll away with everything in it. Languages is pinned to the leading edge for the same reason.
- A tab scrolling under a pinned button dissolves into it instead of meeting a hard edge, so the bar reads as scrollable. No script and no scroll position: the gradient ends in the bar's own background, so it is invisible over empty bar and appears only where a tab has actually scrolled underneath.
- Desktop is unchanged.

## Contract

- No class is renamed and no PHP-emitted markup restructured, so **no compat slice** — and because every selector reads markup that already exists, pages sitting in the parser cache are repaired on deploy rather than on purge. A PHP-side fix could not do that.
- Classification is structural, not a list: `link.text-wrapper` in `skin.json` guarantees the label span on every portlet link, and `mw.util.addPortletLink` applies the same option, so gadget-added tabs are covered with no JS hook.
- RTL is handled by logical properties; CSSJanus needs nothing.

## Follow-ups

- The bar can still show a lot of tabs on a special page. Reducing how many reach it at all is a separate question from making the ones that do legible.
- On a multilingual wiki the bar carries edit, languages and overflow as three separate controls; whether languages belongs in the overflow sheet is unresolved.

## Test plan

Verified on the dev wiki at 360×740 and 1400×900:

- `Special:Watchlist` — three tabs, labels complete and unclipped, bar scrolls (505px content in a 342px box), overflow button stays pinned.
- `Main_Page` — bar hugs its content at 266px, no scroller.
- Overflow card opens above the bar at 328px wide with `offsetParent === null`, i.e. escaped the scroll container. Its block-end offset repeats the bar's safe-area term, so it still clears the bar with a home indicator (146px against a 140px bar top at a 34px inset).
- Desktop 1400px — *View history* 131px, *Discussion* 123px; labels intact.
- RTL (`?uselang=he`) — bar hugs the inline-start edge, overflow button pins to the left, and CSSJanus mirrors the fade with it.
- `Main_Page` (bar does not scroll) — the fade lands on the pinned button's own padding and the flex gap; the neighbouring glyph ends 1px clear of it and is undimmed.
- `npm run lint:styles` clean; `npm test` 1490 tests pass.

Fixes #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EE9WSAn6LCMhrwMz6Eb7vN
