### PR TITLE
feat(pagetools): two mobile navigation surfaces instead of three

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -37,6 +37,7 @@
 	"citizen-sitestats-images-label": "files",
 	"citizen-sitestats-users-label": "users",
 	"citizen-sitestats-edits-label": "edits",
+	"citizen-page-associated-pages": "Related pages",
 	"citizen-page-info-copyright": "Copyright",
 	"citizen-page-info-credits": "Credits",
 	"citizen-page-info-lastmod": "Last modified",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -44,6 +44,7 @@
 	"citizen-sitestats-images-label": "Label for the file statistics",
 	"citizen-sitestats-users-label": "Label for the user statistics",
 	"citizen-sitestats-edits-label": "Label for the edit statistics",
+	"citizen-page-associated-pages": "Heading for the menu of pages associated with the current page: namespace tabs on an article, related special pages elsewhere. Used where MediaWiki core provides no label for the associated-pages menu.",
 	"citizen-page-info-copyright": "Label for the copyright message",
 	"citizen-page-info-credits": "Label for the article credits message",
 	"citizen-page-info-lastmod": "Label for the last modified message",

--- a/includes/SkinCitizen.php
+++ b/includes/SkinCitizen.php
@@ -325,6 +325,17 @@ class SkinCitizen extends SkinMustache {
 		// page so its bottom placement holds from the first streamed paint.
 		$parentData['is-mainpage'] = $title->isMainPage() && $this->getActionName() === 'view';
 
+		// Core has no message for the associated-pages menu, so SkinComponentMenu
+		// falls back to the raw menu name (T252727) and the heading reads
+		// "associated-pages". Nobody saw that while the heading was
+		// screen-reader-only in the bar; it is a visible row heading once the
+		// menu moves into the overflow card. Matched on the fallback rather than
+		// set outright, so a message added upstream would win.
+		if ( ( $parentData['data-portlets']['data-associated-pages']['label'] ?? null ) === 'associated-pages' ) {
+			$parentData['data-portlets']['data-associated-pages']['label'] =
+				$this->msg( 'citizen-page-associated-pages' )->text();
+		}
+
 		$parentData['toc-enabled'] = !empty( $parentData['data-toc'][ 'array-sections' ] );
 		if ( $parentData['toc-enabled'] ) {
 			// This body class depends on template data so it can't move to

--- a/resources/skins.citizen.scripts/pageTools.js
+++ b/resources/skins.citizen.scripts/pageTools.js
@@ -1,0 +1,234 @@
+const
+	MOBILE_QUERY = '( max-width: 1119.98px )',
+	BAR_SELECTOR = '.citizen-page-actions',
+	COLLAPSED_CLASS = 'citizen-page-actions--collapsed',
+	CARD_SELECTOR = '#citizen-page-actions-more__card .citizen-menu__card-content',
+	VIEWS_ID = 'p-views',
+	ASSOCIATED_ID = 'p-associated-pages',
+	LIST_SELECTOR = '.citizen-menu__content-list',
+	// The one action worth a permanent slot. Both ids can be present; the
+	// merged-button rule in Pagetools.less decides which of them is drawn.
+	KEEP_SELECTOR = '#ca-ve-edit, #ca-edit';
+
+/**
+ * Below tablet the page-actions bar is reduced to the one action worth a
+ * permanent slot plus the way to everything else, and the menus it drops are
+ * relocated into the overflow card so nothing becomes unreachable.
+ *
+ * The nodes are moved rather than copied. A copy would duplicate every id in
+ * the menu, and `mw.util.addPortletLink( 'p-views', … )` would keep targeting
+ * the original — so a gadget's tab would land in whichever of the two the
+ * skin happened not to be showing. Moving keeps one DOM and one target.
+ *
+ * Nothing here runs without script, which is the intended fallback: the bar
+ * stays as it renders, and the label fix already makes that legible.
+ */
+class PageTools {
+	constructor( { document, window } ) {
+		this.document = document;
+		this.window = window;
+		/** @type {{node: Element, parent: Element, next: Node|null}[]} */
+		this.moves = [];
+		this.shell = null;
+		this.isCollapsed = false;
+		this.sync = this.sync.bind( this );
+	}
+
+	/**
+	 * The narrow-viewport media query, or null where matchMedia is unavailable.
+	 *
+	 * @return {MediaQueryList|null}
+	 */
+	getMobileQuery() {
+		return typeof this.window.matchMedia === 'function' ?
+			this.window.matchMedia( MOBILE_QUERY ) :
+			null;
+	}
+
+	/**
+	 * Move a node, remembering where it came from so it can go back. A node
+	 * with no parent cannot be put back, so it is not moved either.
+	 *
+	 * @param {Element} node
+	 * @param {Element} parent
+	 * @param {Node|null} before
+	 */
+	moveNode( node, parent, before ) {
+		const origin = node.parentElement;
+		if ( !origin ) {
+			return;
+		}
+		this.moves.push( { node, parent: origin, next: node.nextSibling } );
+		parent.insertBefore( node, before );
+	}
+
+	/**
+	 * An empty copy of a portlet's chrome — heading and list, no items and no
+	 * id, since the original keeps both.
+	 *
+	 * @param {Element} portlet
+	 * @return {Element}
+	 */
+	buildShell( portlet ) {
+		const shell = this.document.createElement( 'nav' );
+		shell.className = portlet.className;
+		const label = portlet.getAttribute( 'aria-label' );
+		if ( label ) {
+			shell.setAttribute( 'aria-label', label );
+		}
+		const heading = portlet.querySelector( '.citizen-menu__heading' );
+		if ( heading ) {
+			shell.appendChild( heading.cloneNode( true ) );
+		}
+		const content = this.document.createElement( 'div' );
+		content.className = 'citizen-menu__content';
+		const list = this.document.createElement( 'ul' );
+		list.className = 'citizen-menu__content-list';
+		content.appendChild( list );
+		shell.appendChild( content );
+		return shell;
+	}
+
+	/**
+	 * The card's list for the views that no longer fit in the bar, built on
+	 * first use — a page whose only view is the editor never needs one.
+	 *
+	 * @return {Element|null}
+	 */
+	ensureShell() {
+		if ( this.shell ) {
+			return this.shell.querySelector( LIST_SELECTOR );
+		}
+		const views = this.document.getElementById( VIEWS_ID );
+		const card = this.document.querySelector( CARD_SELECTOR );
+		if ( !views || !card ) {
+			return null;
+		}
+		this.shell = this.buildShell( views );
+		card.insertBefore( this.shell, card.firstChild );
+		return this.shell.querySelector( LIST_SELECTOR );
+	}
+
+	collapse() {
+		if ( this.isCollapsed ) {
+			return;
+		}
+		const
+			bar = this.document.querySelector( BAR_SELECTOR ),
+			card = this.document.querySelector( CARD_SELECTOR );
+		// No card means no sink, and the bar is then the only place these menus
+		// exist. Leaving it whole is the right failure: it is the bar this
+		// change replaces, not a broken one, and nothing is unreachable.
+		if ( !bar || !card ) {
+			return;
+		}
+		this.isCollapsed = true;
+		bar.classList.add( COLLAPSED_CLASS );
+
+		const associated = this.document.getElementById( ASSOCIATED_ID );
+		if ( associated && associated.parentElement === bar ) {
+			this.moveNode( associated, card, card.firstChild );
+		}
+
+		const views = this.document.getElementById( VIEWS_ID );
+		const list = views && views.querySelector( LIST_SELECTOR );
+		if ( !list ) {
+			return;
+		}
+		// Read the whole list before moving any of it: children is live.
+		const spare = Array.from( list.children )
+			.filter( ( item ) => !item.matches( KEEP_SELECTOR ) );
+		spare.forEach( ( item ) => this.adopt( item ) );
+	}
+
+	/**
+	 * Send one view into the card.
+	 *
+	 * @param {Element} item
+	 */
+	adopt( item ) {
+		const target = this.ensureShell();
+		if ( target ) {
+			this.moveNode( item, target, null );
+		}
+	}
+
+	restore() {
+		if ( !this.isCollapsed ) {
+			return;
+		}
+		this.isCollapsed = false;
+		const bar = this.document.querySelector( BAR_SELECTOR );
+		if ( bar ) {
+			bar.classList.remove( COLLAPSED_CLASS );
+		}
+		// Reverse order, so each node's remembered next sibling is back in
+		// place before it is reinserted.
+		this.moves.reverse().forEach( ( { node, parent, next } ) => {
+			parent.insertBefore( node, next );
+		} );
+		this.moves = [];
+		if ( this.shell ) {
+			this.shell.remove();
+			this.shell = null;
+		}
+	}
+
+	sync() {
+		const query = this.getMobileQuery();
+		if ( query && query.matches ) {
+			this.collapse();
+		} else {
+			this.restore();
+		}
+	}
+
+	/**
+	 * A gadget calling addPortletLink after this has run would drop a tab back
+	 * into the bar, which is the one thing the collapse is for.
+	 */
+	observeLateViews() {
+		const views = this.document.getElementById( VIEWS_ID );
+		const list = views && views.querySelector( LIST_SELECTOR );
+		// Bound to a local first: a guard on the property does not narrow the
+		// type at the construction site.
+		const Observer = this.window.MutationObserver;
+		if ( !list || typeof Observer !== 'function' ) {
+			return;
+		}
+		const observer = new Observer( ( records ) => {
+			if ( !this.isCollapsed ) {
+				return;
+			}
+			records.forEach( ( record ) => {
+				record.addedNodes.forEach( ( node ) => {
+					if ( node.nodeType === 1 && !node.matches( KEEP_SELECTOR ) ) {
+						this.adopt( /** @type {Element} */ ( node ) );
+					}
+				} );
+			} );
+		} );
+		observer.observe( list, { childList: true } );
+	}
+
+	init() {
+		this.sync();
+		this.observeLateViews();
+		const query = this.getMobileQuery();
+		if ( query && typeof query.addEventListener === 'function' ) {
+			query.addEventListener( 'change', this.sync );
+		}
+	}
+}
+
+/**
+ * @param {Object} deps
+ * @param {Document} deps.document
+ * @param {Window} deps.window
+ * @return {PageTools}
+ */
+function createPageTools( { document, window } ) {
+	return new PageTools( { document, window } );
+}
+
+module.exports = { createPageTools };

--- a/resources/skins.citizen.scripts/setupObservers.js
+++ b/resources/skins.citizen.scripts/setupObservers.js
@@ -1,10 +1,11 @@
 // Adopted from Vector 2022
 const
 	{ createDirectionObserver, createScrollObserver } = require( './scrollObserver.js' ),
-	{ StickyHeader, STICKY_HEADER_ID, STICKY_HEADER_VISIBLE_CLASS } = require( './stickyHeader.js' ),
+	{ MOBILE_QUERY, StickyHeader, STICKY_HEADER_ID, STICKY_HEADER_VISIBLE_CLASS } = require( './stickyHeader.js' ),
 	TOC_ID = 'citizen-toc',
 	SCROLL_DOWN_CLASS = 'citizen-scroll--down',
 	SCROLL_UP_CLASS = 'citizen-scroll--up',
+	AUTOHIDE_CLASS = 'citizen-feature-autohide-navigation-clientpref-1',
 	PAGE_TITLE_INTERSECTION_CLASS = 'citizen-below-page-title';
 
 /**
@@ -61,14 +62,34 @@ const init = ( { document, window, mw, IntersectionObserver } ) => {
 		!!stickyIntersection &&
 		shouldStickyHeader;
 
-	const stickyHeaderInstance = isStickyHeaderAllowed ?
-		new StickyHeader( {
-			stickyHeaderElement,
-			document,
-			window,
-			requestIdleCallback: mw.requestIdleCallback
-		} ) :
+	// Bound to a local first: a guard on the expression does not narrow the
+	// type inside the callbacks below.
+	const mobileQuery = typeof window.matchMedia === 'function' ?
+		window.matchMedia( MOBILE_QUERY ) :
 		null;
+	const isNarrow = () => ( mobileQuery ? mobileQuery.matches : false );
+
+	// Built on first use rather than up front, because below tablet the bar is
+	// hidden and there is nothing for it to do — and building it is not free:
+	// it clones the page-tools dropdowns and keeps a MutationObserver on each
+	// for the rest of the page's life. A viewport that never crosses the
+	// breakpoint never pays for either.
+	let stickyHeaderInstance = null;
+	const ensureStickyHeader = () => {
+		if ( !isStickyHeaderAllowed || isNarrow() ) {
+			return null;
+		}
+		if ( !stickyHeaderInstance ) {
+			stickyHeaderInstance = new StickyHeader( {
+				stickyHeaderElement,
+				document,
+				window,
+				requestIdleCallback: mw.requestIdleCallback
+			} );
+			stickyHeaderInstance.init();
+		}
+		return stickyHeaderInstance;
+	};
 
 	const scrollDirectionObserver = createDirectionObserver( {
 		window,
@@ -84,30 +105,30 @@ const init = ( { document, window, mw, IntersectionObserver } ) => {
 		threshold: 10
 	} );
 
-	if ( stickyHeaderInstance ) {
-		stickyHeaderInstance.init();
-	}
-
+	// Autohide moves the page actions and the contents control, which are on
+	// screen at every width. It used to be started and stopped alongside the
+	// sticky header, which was harmless while that bar existed everywhere and
+	// would have taken autohide down with it on mobile once it stopped.
 	const resumeStickyHeader = () => {
-		if (
-			stickyHeaderInstance &&
-			!document.body.classList.contains( STICKY_HEADER_VISIBLE_CLASS ) &&
-			document.body.classList.contains( PAGE_TITLE_INTERSECTION_CLASS )
-		) {
-			stickyHeaderInstance.show();
-			if ( document.documentElement.classList.contains( 'citizen-feature-autohide-navigation-clientpref-1' ) ) {
-				scrollDirectionObserver.resume();
-			}
+		if ( !document.body.classList.contains( PAGE_TITLE_INTERSECTION_CLASS ) ) {
+			return;
+		}
+		if ( document.documentElement.classList.contains( AUTOHIDE_CLASS ) ) {
+			scrollDirectionObserver.resume();
+		}
+		const stickyHeader = ensureStickyHeader();
+		if ( stickyHeader && !document.body.classList.contains( STICKY_HEADER_VISIBLE_CLASS ) ) {
+			stickyHeader.show();
 		}
 	};
 
 	const pauseStickyHeader = () => {
+		scrollDirectionObserver.pause();
 		if (
 			stickyHeaderInstance &&
 			document.body.classList.contains( STICKY_HEADER_VISIBLE_CLASS )
 		) {
 			stickyHeaderInstance.hide();
-			scrollDirectionObserver.pause();
 		}
 	};
 
@@ -124,6 +145,18 @@ const init = ( { document, window, mw, IntersectionObserver } ) => {
 	);
 
 	pageHeaderObserver.observe( stickyIntersection );
+
+	// A rotation can cross the breakpoint, and the bar belongs on screen on
+	// exactly one side of it.
+	if ( mobileQuery && typeof mobileQuery.addEventListener === 'function' ) {
+		mobileQuery.addEventListener( 'change', () => {
+			if ( isNarrow() ) {
+				pauseStickyHeader();
+			} else {
+				resumeStickyHeader();
+			}
+		} );
+	}
 
 	mw.hook( 've.activationStart' ).add( () => {
 		pauseStickyHeader();

--- a/resources/skins.citizen.scripts/skin.js
+++ b/resources/skins.citizen.scripts/skin.js
@@ -78,6 +78,7 @@ function main( window ) {
 		{ createShare } = require( './share.js' ),
 		setupObservers = require( './setupObservers.js' ),
 		deferUntilFrame = require( './deferUntilFrame.js' ),
+		{ createPageTools } = require( './pageTools.js' ),
 		{ createPreferences } = require( './preferences.js' ),
 		{ createCommandPalette } = require( './commandPalette.js' );
 
@@ -94,6 +95,7 @@ function main( window ) {
 		setupObservers.init( { document, window, mw, IntersectionObserver } );
 	}, 2 );
 	dropdown.init( { document, window } );
+	createPageTools( { document, window } ).init();
 	createLastModified( { document, Intl } ).init();
 	createShare( {
 		document,

--- a/resources/skins.citizen.scripts/stickyHeader.js
+++ b/resources/skins.citizen.scripts/stickyHeader.js
@@ -1,6 +1,9 @@
 const
 	STICKY_HEADER_ID = 'citizen-sticky-header',
-	STICKY_HEADER_VISIBLE_CLASS = 'citizen-sticky-header-visible';
+	STICKY_HEADER_VISIBLE_CLASS = 'citizen-sticky-header-visible',
+	// Kept in step with @max-width-breakpoint-tablet, which is core's
+	// @min-width-breakpoint-desktop less the 0.02px it reserves for the seam.
+	MOBILE_QUERY = '( max-width: 1119.98px )';
 
 const { initDropdown } = require( './dropdown.js' );
 
@@ -316,6 +319,7 @@ class StickyHeader {
 }
 
 module.exports = {
+	MOBILE_QUERY,
 	STICKY_HEADER_ID,
 	STICKY_HEADER_VISIBLE_CLASS,
 	StickyHeader

--- a/resources/skins.citizen.styles/components/Menu.less
+++ b/resources/skins.citizen.styles/components/Menu.less
@@ -23,6 +23,13 @@
 		transform: var( --citizen-translate-closed );
 		.mixin-citizen-frosted-glass;
 
+		// A menu that renders as buttons elsewhere arrives here as rows, and
+		// Codex centres a button's content. Every other card starts its labels
+		// at the same edge; a centred row reads as a button in a list of rows.
+		.cdx-button {
+			justify-content: flex-start;
+		}
+
 		&-content {
 			max-width: inherit;
 			max-height: inherit;

--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -134,7 +134,11 @@
 @media ( max-width: @max-width-breakpoint-tablet ) {
 	.citizen-page-actions {
 		position: fixed;
-		right: 0;
+		// Inset by the offsets, not by a margin. A margin here would sit on top
+		// of the block-end offset, which already carries a --space-xs floor, and
+		// the two would read as one gap of twice the size against side gaps of
+		// one.
+		right: var( --space-xs );
 		bottom: ~'calc( var( --header-size-block-end ) + max( env( safe-area-inset-bottom ), var( --space-xs ) ) )';
 		// `safe`: plain flex-end leaves a scroller's start-edge overflow unreachable.
 		justify-content: safe flex-end;
@@ -143,7 +147,6 @@
 		max-inline-size: ~'calc( 100% - var( --space-xs ) * 2 )';
 		// Border-box: a bare --toolbar-size leaves 38px against 40px buttons.
 		height: ~'calc( var( --toolbar-size ) + var( --border-width-base ) * 2 )';
-		margin: var( --space-xs );
 		overflow: auto hidden;
 		// Must not chain into browser back-navigation.
 		overscroll-behavior: contain;
@@ -196,7 +199,8 @@
 	// The gradient ends in the bar's own background, so it is invisible over
 	// empty bar and needs no scroll position. It reaches back over the button's
 	// padding and the gap; the end that meets a neighbour is the transparent
-	// one, so a stray overlap is imperceptible.
+	// one, so a stray overlap is imperceptible — but only over a quiet control,
+	// which is why the collapsed bar opts out below.
 	#citizen-page-more-dropdown,
 	#citizen-page-languages-dropdown {
 		&::before {
@@ -218,12 +222,30 @@
 		background: linear-gradient( to left, transparent, var( --color-surface-1 ) );
 	}
 
+	// A collapsed bar holds two controls and cannot scroll, so the fade has
+	// nothing to soften and only tints whatever sits next to the sink — which
+	// after the collapse is the filled edit button, not a quiet tab. The class
+	// is set by script, so a bar with no script keeps both the scrolling and
+	// the affordance for it.
+	.citizen-page-actions--collapsed {
+		#citizen-page-more-dropdown::before,
+		#citizen-page-languages-dropdown::before {
+			content: none;
+		}
+	}
+
 	// The bar is a scroll container and, with `__item` unset, also the card's
 	// containing block, so it would clip its own dropdown. Promote the card out,
 	// repeating the bar's safe-area term so it still clears a home indicator.
 	.citizen-page-actions .citizen-menu__card {
 		position: fixed;
-		inset: auto var( --space-xs ) ~'calc( var( --header-size-block-end ) + max( env( safe-area-inset-bottom ), var( --space-xs ) ) + var( --toolbar-size ) + var( --space-xs ) * 2 )' var( --space-xs );
+		// Stated once, like the bar itself: .citizen-menu__card's own margin
+		// would land on top of these offsets and put the card 16px from each
+		// side and 14px off the bar it belongs to. The block-end term is the
+		// bar's inset, then the bar's full height — borders included, which
+		// --toolbar-size alone leaves out — then the gap.
+		inset: auto var( --space-xs ) ~'calc( var( --header-size-block-end ) + max( env( safe-area-inset-bottom ), var( --space-xs ) ) + var( --toolbar-size ) + var( --border-width-base ) * 2 + var( --space-xs ) )' var( --space-xs );
+		margin: 0;
 	}
 
 	// ...and autohide must not take it back: a transformed ancestor is the

--- a/resources/skins.citizen.styles/components/StickyHeader.less
+++ b/resources/skins.citizen.styles/components/StickyHeader.less
@@ -41,6 +41,13 @@
 		transition-duration: var( --transition-duration-medium );
 		transition-property: transform, visibility;
 
+		// Below tablet this bar has nothing left to say. It carried the page
+		// title and a way back to the top; the contents control now carries the
+		// section you are in, and the page actions carry the actions.
+		@media ( max-width: @max-width-breakpoint-tablet ) {
+			display: none;
+		}
+
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			margin-right: var( --header-size-inline-end );
 			margin-left: var( --header-size-inline-start );

--- a/resources/skins.citizen.styles/components/TableOfContents.less
+++ b/resources/skins.citizen.styles/components/TableOfContents.less
@@ -125,8 +125,10 @@
 	}
 }
 
-// Sticky header styles
-.citizen-sticky-header-visible {
+// "Back to top" is only worth a row once there is a top to go back to. Keyed on
+// having scrolled past the page header rather than on the sticky header being
+// up, because below tablet that bar does not exist and the row still should.
+.citizen-below-page-title {
 	.citizen-toc .citizen-toc-top.citizen-toc-link {
 		height: 2rem; // 1rem text + 1rem padding
 		padding-block: var( --space-xs );
@@ -138,32 +140,51 @@
 @media ( max-width: ( @max-width-breakpoint-tablet ) ) {
 	.citizen-toc {
 		position: fixed;
+		// Inset by the offsets, not by a margin on the control inside. The
+		// margin made this box 16px larger than the control in both axes, which
+		// is what the pointer-events dance existed to undo, and it stacked on
+		// the block-end offset so the bottom gap was twice the side gap.
 		bottom: ~'calc( var( --header-size-block-end ) + max( env( safe-area-inset-bottom ), var( --space-xs ) ) )';
-		left: 0;
+		left: var( --space-xs );
 		z-index: @z-index-sticky; // Keep ToC above sticky header and page action, but below site header
-		pointer-events: none; // HACK: Make background clickable
 
 		&-card {
-			// Get consistent margin
-			bottom: ~'calc( 100% - var( --space-xs ) )';
+			// Sits on the control with the gap stated here rather than left to
+			// .citizen-menu__card's margin, which would also offset the card
+			// from the control's own inline edge.
+			bottom: ~'calc( 100% + var( --space-xs ) )';
 			width: max-content;
 			// This is not bulletproof since it will get covered by page header
 			// in extremely short height. but it should be good for now
 			max-height: ~'calc( var( --header-card-maxheight ) - 8rem )';
-			padding: var( --space-xs );
+			margin: 0;
 			// Floating button at the bottom; card expands upward.
 			.mixin-citizen-card-expand( up );
+
+			// Padding belongs to the scrolling box, not the card. The content
+			// takes its max-height from the card, so padding out here makes the
+			// two disagree by that much: the list scrolls to what the container
+			// calls the end while its last row is still below the border, and
+			// rows disappear into the padding rather than at the border.
+			.citizen-menu__card-content {
+				padding: var( --space-xs );
+			}
 		}
 
 		.citizen-dropdown {
 			&-summary {
 				box-sizing: border-box;
-				display: grid;
-				place-content: center;
-				width: var( --toolbar-size );
-				height: var( --toolbar-size );
-				margin: var( --space-xs );
-				pointer-events: auto; // HACK: Make button clickable
+				display: flex;
+				gap: var( --space-xs );
+				align-items: center;
+				justify-content: center;
+				width: auto;
+				// Border-box with a 1px border, so a bare --toolbar-size would
+				// leave a 38px content box and stand 2px shorter than the page
+				// actions beside it. Same expression they use, so the two agree
+				// by construction rather than by coincidence.
+				min-width: ~'calc( var( --toolbar-size ) + var( --border-width-base ) * 2 )';
+				height: ~'calc( var( --toolbar-size ) + var( --border-width-base ) * 2 )';
 				background-color: var( --color-surface-1 );
 				border: 1px solid var( --border-color-base );
 				border-radius: var( --border-radius-medium );
@@ -180,10 +201,6 @@
 			}
 
 			&-details[ open ] {
-				+ .citizen-menu__card {
-					pointer-events: auto; // HACK: Make ToC clickable after ToC is expanded
-				}
-
 				> .citizen-dropdown-summary {
 					background: ~'linear-gradient( var( --background-color-button-quiet--active ), var( --background-color-button-quiet--active ) ) var( --color-surface-1 )';
 				}
@@ -226,5 +243,123 @@
 		.citizen-dropdown-summary {
 			display: none;
 		}
+	}
+}
+
+// The contents control's current section. Below tablet only: above it the
+// outline is a standing list in the margin and the control is not a pill.
+@media ( max-width: ( @max-width-breakpoint-tablet ) ) {
+	// Absent until there is a section to name, which is also the state of every
+	// page with no headings — the control is then the glyph it has always been.
+	.citizen-toc-current {
+		display: none;
+	}
+
+	// The control carries the section you are in as its value, so it is a pill
+	// that grows rather than a fixed square. Sized from content rather than
+	// left to shrink-to-fit: the summary is a flex item inside a fixed,
+	// shrink-to-fit block, and an auto width resolves through that chain to the
+	// min-content of a track that is allowed to reach zero — which is zero.
+	// Bounded so it can never reach the page actions at the other edge; both
+	// are fixed to the same block position and neither knows the other is there.
+	.citizen-toc--tracking .citizen-dropdown-summary {
+		inline-size: max-content;
+		// Against the viewport, not the parent: this control's own ancestors are
+		// content-sized, so a percentage here resolves against a box that is
+		// itself waiting on this one.
+		max-inline-size: ~'calc( 100vw - var( --toolbar-size ) * 4 - var( --space-xs ) * 4 )';
+		padding-inline: var( --space-sm );
+		overflow: hidden;
+	}
+
+	.citizen-toc--tracking {
+		// The chevron says the same thing as the list glyph and says it about
+		// the value beside it, so the glyph is redundant once there is one.
+		.citizen-dropdown-summary > .citizen-ui-icon {
+			display: none;
+		}
+
+		.citizen-toc-current {
+			display: flex;
+			gap: var( --space-xs );
+			align-items: center;
+			min-width: 0;
+
+			> .citizen-ui-icon {
+				flex: none;
+			}
+		}
+	}
+
+	.citizen-toc-current__track {
+		position: relative;
+		flex: 0 1 auto;
+		min-width: 0;
+		height: 1lh;
+		overflow: hidden;
+		font-size: var( --font-size-small );
+		font-weight: var( --font-weight-semi-bold );
+		line-height: 1lh;
+		color: var( --color-emphasized );
+		text-align: start;
+		white-space: nowrap;
+	}
+
+	// The arriving label stays in flow: it is what gives the track a width, and
+	// so the pill a width. Only the one on its way out is taken out of flow,
+	// which also stops the two stacking during the change.
+	.citizen-toc-current__line {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+
+		&.is-leaving {
+			position: absolute;
+			inset: 0;
+		}
+	}
+
+	@media ( prefers-reduced-motion: no-preference ) {
+		.citizen-toc-current__line {
+			&.is-entering-below {
+				animation: citizen-toc-line-in-below var( --transition-duration-medium ) var( --transition-timing-function-ease-out );
+			}
+
+			&.is-entering-above {
+				animation: citizen-toc-line-in-above var( --transition-duration-medium ) var( --transition-timing-function-ease-out );
+			}
+
+			&.is-leaving-above {
+				animation: citizen-toc-line-out-above var( --transition-duration-medium ) var( --transition-timing-function-ease-out ) forwards;
+			}
+
+			&.is-leaving-below {
+				animation: citizen-toc-line-out-below var( --transition-duration-medium ) var( --transition-timing-function-ease-out ) forwards;
+			}
+		}
+	}
+}
+
+@keyframes citizen-toc-line-in-below {
+	from {
+		transform: translateY( 100% );
+	}
+}
+
+@keyframes citizen-toc-line-in-above {
+	from {
+		transform: translateY( -100% );
+	}
+}
+
+@keyframes citizen-toc-line-out-above {
+	to {
+		transform: translateY( -100% );
+	}
+}
+
+@keyframes citizen-toc-line-out-below {
+	to {
+		transform: translateY( 100% );
 	}
 }

--- a/resources/skins.citizen.toc/index.js
+++ b/resources/skins.citizen.toc/index.js
@@ -2,6 +2,7 @@
 const
 	{ createSectionObserver } = require( './sectionObserver.js' ),
 	{ TableOfContents } = require( './tableOfContents.js' ),
+	{ createSectionLabel } = require( './sectionLabel.js' ),
 	// deferUntilFrame.js is listed in both this module's and
 	// skins.citizen.scripts' packageFiles — keep the two in sync
 	deferUntilFrame = require( '../skins.citizen.scripts/deferUntilFrame.js' ),
@@ -132,6 +133,9 @@ const setupTableOfContents = (
 	// its live state is authoritative and the deferred pass must not run.
 	let sectionsActivated = false;
 
+	const sectionLabel = createSectionLabel( { document, window } );
+	sectionLabel.init();
+
 	const sectionObserver = createSectionObserver( {
 		window,
 		mw,
@@ -141,11 +145,15 @@ const setupTableOfContents = (
 		onIntersection: getHeadingIntersectionHandler( ( ids ) => {
 			sectionsActivated = true;
 			tableOfContents.changeActiveSections( ids );
+			sectionLabel.syncFromCard();
 		} )
 	} );
 	const updateElements = () => {
 		sectionObserver.resume();
 		sectionObserver.setElements( elements() );
+		// A rebuild reactivates its sections internally, so the control has to
+		// be told to read the card again.
+		sectionLabel.syncFromCard();
 	};
 
 	mw.hook( 've.activationStart' ).add( () => {
@@ -160,42 +168,18 @@ const setupTableOfContents = (
 		updateElements();
 	} );
 
-	// On narrow viewports the ToC is a collapsed popover — pause the scroll spy
-	// to avoid unnecessary work. Resume + recalculate when returning to desktop.
-	// Uses @min-width-breakpoint-desktop from MediaWiki core (1120px).
-	const desktopMql = window.matchMedia( '(min-width: 1120px)' );
-	let tocCollapsed = !desktopMql.matches;
-
-	if ( tocCollapsed ) {
-		sectionObserver.pause();
-	}
-
-	desktopMql.addEventListener( 'change', ( e ) => {
-		if ( e.matches ) {
-			// Crossed into desktop — resume scroll spy.
-			tocCollapsed = false;
-			sectionObserver.resume();
-			sectionObserver.calcIntersection();
-		} else {
-			// Crossed into narrow — pause scroll spy.
-			tocCollapsed = true;
-			sectionObserver.pause();
-		}
-	} );
-
+	// The spy used to be paused below desktop, where the ToC is a collapsed
+	// popover and nobody could see which row was active. The contents control
+	// now carries the active section as its own value, so on a narrow screen
+	// the spy is the only thing telling a reader where they are — the width it
+	// was skipped on is the width it matters most.
+	//
 	// Recalculate active sections on window resize since viewport dimensions change.
 	window.addEventListener( 'resize', mw.util.debounce( () => {
-		if ( !tocCollapsed ) {
-			sectionObserver.calcIntersection();
-		}
+		sectionObserver.calcIntersection();
 	}, 200 ) );
 
-	// Skip initial active section calculation on narrow viewports
-	// since the ToC is collapsed and scroll spy is paused.
 	const setInitialActiveSection = () => {
-		if ( tocCollapsed ) {
-			return;
-		}
 		const hash = window.location.hash.slice( 1 );
 		// If hash fragment is blank, determine the active section with section
 		// observer.
@@ -225,6 +209,7 @@ const setupTableOfContents = (
 			Math.round( window.innerHeight + window.scrollY ) >= document.body.scrollHeight
 		) {
 			tableOfContents.changeActiveSection( hashSection.id );
+			sectionLabel.syncFromCard();
 		} else {
 			// Fallback to section observer's calculation for the active section.
 			sectionObserver.calcIntersection();

--- a/resources/skins.citizen.toc/sectionLabel.js
+++ b/resources/skins.citizen.toc/sectionLabel.js
@@ -1,0 +1,176 @@
+const
+	{ TableOfContents } = require( './tableOfContents.js' ),
+	TOC_ID = 'citizen-toc',
+	SUMMARY_SELECTOR = '.citizen-dropdown-summary',
+	TRACKING_CLASS = 'citizen-toc--tracking',
+	CURRENT_CLASS = 'citizen-toc-current',
+	TRACK_CLASS = 'citizen-toc-current__track',
+	LINE_CLASS = 'citizen-toc-current__line',
+	HEADING_SELECTOR = '.citizen-toc-heading',
+	LIST_ITEM_SELECTOR = '.citizen-toc-list-item';
+
+/**
+ * The contents control's current value: the section you are in.
+ *
+ * Below tablet the control is a pill with nothing but a glyph, which names
+ * what it opens but not where you are. This gives it a value, and the value
+ * moving with the document is what makes it read as an outline rather than a
+ * label — a static one could not.
+ *
+ * The text is taken from the table of contents' own rendered rows, so it is
+ * already escaped and in the reader's language, and it can only ever say
+ * something the card also says.
+ *
+ * Injected rather than served, so a page with no script keeps the glyph it
+ * has always had and nothing is left half-built.
+ */
+class SectionLabel {
+	constructor( { document, window } ) {
+		this.document = document;
+		this.window = window;
+		this.toc = null;
+		this.track = null;
+		this.currentId = null;
+	}
+
+	/**
+	 * Position of a row in the outline, for deciding which way a change
+	 * travelled. -1 for anything not in the list.
+	 *
+	 * @param {string|null} id
+	 * @return {number}
+	 */
+	indexOf( id ) {
+		if ( !id || !this.toc ) {
+			return -1;
+		}
+		const rows = Array.from( this.toc.querySelectorAll( LIST_ITEM_SELECTOR ) );
+		return rows.findIndex( ( row ) => row.id === id );
+	}
+
+	/**
+	 * @param {string|null} id
+	 * @return {string}
+	 */
+	textFor( id ) {
+		if ( !id ) {
+			return '';
+		}
+		const row = this.document.getElementById( id );
+		const heading = row && row.querySelector( HEADING_SELECTOR );
+		return heading ? heading.textContent.trim() : '';
+	}
+
+	/**
+	 * @return {boolean}
+	 */
+	prefersReducedMotion() {
+		return typeof this.window.matchMedia === 'function' &&
+			this.window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches;
+	}
+
+	/**
+	 * Show a section, displacing whatever the line said before. Both labels
+	 * move together in the direction of travel, so it reads as the outline
+	 * advancing rather than one word being swapped for another.
+	 *
+	 * @param {string|null} id A table of contents row id, or null for the lead.
+	 */
+	update( id ) {
+		if ( !this.track || id === this.currentId ) {
+			return;
+		}
+		const text = this.textFor( id );
+		const forward = this.indexOf( id ) > this.indexOf( this.currentId );
+		this.currentId = text ? id : null;
+
+		this.toc.classList.toggle( TRACKING_CLASS, !!text );
+
+		const leaving = this.track.querySelector( '.' + LINE_CLASS + ':not( .is-leaving )' );
+		const reduced = this.prefersReducedMotion();
+
+		if ( text ) {
+			const line = this.document.createElement( 'span' );
+			line.className = LINE_CLASS;
+			line.textContent = text;
+			this.track.appendChild( line );
+			if ( !reduced ) {
+				line.classList.add( forward ? 'is-entering-below' : 'is-entering-above' );
+			}
+		}
+
+		if ( !leaving ) {
+			return;
+		}
+		if ( reduced || !text ) {
+			leaving.remove();
+			return;
+		}
+		// Drop the enter classes first: two animations on one element is a
+		// cascade race, and the one it arrived with is meaningless now.
+		leaving.classList.remove( 'is-entering-below', 'is-entering-above' );
+		leaving.classList.add( 'is-leaving', forward ? 'is-leaving-above' : 'is-leaving-below' );
+		leaving.addEventListener( 'animationend', () => leaving.remove(), { once: true } );
+	}
+
+	/**
+	 * Take the value from the row the card marks as active, so the control and
+	 * the card it opens cannot disagree about where the reader is. Several
+	 * paths activate a section without going through the scroll spy — a load
+	 * with a hash, and a rebuild after VisualEditor — and they all end with the
+	 * card marked, so reading the mark covers each of them.
+	 */
+	syncFromCard() {
+		if ( !this.toc ) {
+			return;
+		}
+		const active = this.toc.querySelector( '.' + TableOfContents.ACTIVE_SECTION_CLASS );
+		this.update( active ? active.id : null );
+	}
+
+	/**
+	 * @return {boolean} Whether there was a control to give a value to.
+	 */
+	init() {
+		this.toc = this.document.getElementById( TOC_ID );
+		const summary = this.toc && this.toc.querySelector( SUMMARY_SELECTOR );
+		if ( !summary ) {
+			return false;
+		}
+
+		// A div, not a span: Dropdown.less screen-reader-onlys every non-icon
+		// span that is a direct child of a summary, which is how the "Contents"
+		// label beside this is hidden. A span here would be clipped to 1px and
+		// the control would never grow.
+		const current = this.document.createElement( 'div' );
+		current.className = CURRENT_CLASS;
+		// The control is already named "Contents" by its own label. Announcing
+		// the section here would name it twice, and the card marks the active
+		// row anyway.
+		current.setAttribute( 'aria-hidden', 'true' );
+
+		this.track = this.document.createElement( 'span' );
+		this.track.className = TRACK_CLASS;
+		current.appendChild( this.track );
+
+		const chevron = this.document.createElement( 'span' );
+		// Points up: the card opens upward from a control at the block end.
+		chevron.className = 'citizen-ui-icon mw-ui-icon-wikimedia-collapse';
+		current.appendChild( chevron );
+
+		summary.appendChild( current );
+		return true;
+	}
+}
+
+/**
+ * @param {Object} deps
+ * @param {Document} deps.document
+ * @param {Window} deps.window
+ * @return {SectionLabel}
+ */
+function createSectionLabel( { document, window } ) {
+	return new SectionLabel( { document, window } );
+}
+
+module.exports = { createSectionLabel };

--- a/skin.json
+++ b/skin.json
@@ -212,6 +212,7 @@
 				"resources/skins.citizen.scripts/overflowElements/state.js",
 				"resources/skins.citizen.scripts/overflowElements/stickyRows.js",
 				"resources/skins.citizen.scripts/performance.js",
+				"resources/skins.citizen.scripts/pageTools.js",
 				"resources/skins.citizen.scripts/preferences.js",
 				"resources/skins.citizen.scripts/scrollObserver.js",
 				"resources/skins.citizen.scripts/search.js",

--- a/skin.json
+++ b/skin.json
@@ -240,6 +240,7 @@
 			"packageFiles": [
 				"resources/skins.citizen.toc/index.js",
 				"resources/skins.citizen.toc/sectionObserver.js",
+				"resources/skins.citizen.toc/sectionLabel.js",
 				"resources/skins.citizen.toc/tableOfContents.js",
 				"resources/skins.citizen.toc/tableOfContentsSections.js",
 				{

--- a/tests/vitest/skins.citizen.scripts/pageTools.test.js
+++ b/tests/vitest/skins.citizen.scripts/pageTools.test.js
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+/* global document */
+
+const { createPageTools } = require( '../../../resources/skins.citizen.scripts/pageTools.js' );
+
+const BAR = `
+<div class="citizen-page-actions">
+	<nav id="p-views" class="citizen-menu mw-portlet mw-portlet-views" aria-label="Views">
+		<div class="citizen-menu__heading">Views</div>
+		<div class="citizen-menu__content">
+			<ul class="citizen-menu__content-list">
+				<li id="ca-view" class="mw-list-item"><a href="/wiki/Foo">Read</a></li>
+				<li id="ca-ve-edit" class="mw-list-item"><a href="#">Edit</a></li>
+				<li id="ca-history" class="mw-list-item"><a href="#">View history</a></li>
+			</ul>
+		</div>
+	</nav>
+	<nav id="p-associated-pages" class="citizen-menu mw-portlet" aria-label="Associated">
+		<div class="citizen-menu__content">
+			<ul class="citizen-menu__content-list">
+				<li id="ca-talk" class="mw-list-item"><a href="#">Discussion</a></li>
+			</ul>
+		</div>
+	</nav>
+	<div id="citizen-page-more-dropdown">
+		<div id="citizen-page-actions-more__card" class="citizen-menu__card">
+			<div class="citizen-menu__card-content">
+				<nav id="p-cactions"><ul class="citizen-menu__content-list"><li id="ca-move"></li></ul></nav>
+			</div>
+		</div>
+	</div>
+</div>`;
+
+function makeWindow( matches ) {
+	return {
+		matchMedia: () => ( { matches, addEventListener: () => {} } ),
+		MutationObserver: class {
+			observe() {}
+			disconnect() {}
+		}
+	};
+}
+
+const card = () => document.querySelector( '#citizen-page-actions-more__card .citizen-menu__card-content' );
+const barIds = () => Array.from( document.querySelectorAll( '.citizen-page-actions > *' ) ).map( ( n ) => n.id );
+const cardViewIds = () => Array.from( card().querySelectorAll( 'li' ) ).map( ( n ) => n.id );
+
+describe( 'pageTools', () => {
+	beforeEach( () => {
+		document.body.innerHTML = BAR;
+	} );
+
+	it( 'leaves the bar alone above tablet', () => {
+		const tools = createPageTools( { document, window: makeWindow( false ) } );
+
+		tools.init();
+
+		expect( barIds() ).toEqual( [ 'p-views', 'p-associated-pages', 'citizen-page-more-dropdown' ] );
+		expect( cardViewIds() ).toEqual( [ 'ca-move' ] );
+	} );
+
+	it( 'keeps only the editor in the bar below tablet', () => {
+		const tools = createPageTools( { document, window: makeWindow( true ) } );
+
+		tools.init();
+
+		const remaining = Array.from(
+			document.querySelectorAll( '#p-views .citizen-menu__content-list > li' )
+		).map( ( n ) => n.id );
+		expect( remaining ).toEqual( [ 'ca-ve-edit' ] );
+	} );
+
+	it( 'moves the displaced views and the associated pages into the card', () => {
+		const tools = createPageTools( { document, window: makeWindow( true ) } );
+
+		tools.init();
+
+		expect( cardViewIds() ).toEqual( [ 'ca-view', 'ca-history', 'ca-talk', 'ca-move' ] );
+		expect( document.getElementById( 'p-associated-pages' ).closest( '.citizen-menu__card' ) ).not.toBeNull();
+	} );
+
+	it( 'gives the displaced views the portlet chrome, without repeating its id', () => {
+		const tools = createPageTools( { document, window: makeWindow( true ) } );
+
+		tools.init();
+
+		const shell = document.getElementById( 'ca-view' ).closest( 'nav' );
+		expect( shell.id ).toBe( '' );
+		expect( shell.getAttribute( 'aria-label' ) ).toBe( 'Views' );
+		expect( shell.querySelector( '.citizen-menu__heading' ).textContent.trim() ).toBe( 'Views' );
+		expect( document.querySelectorAll( '#p-views' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'puts everything back in its original order on the way to desktop', () => {
+		const query = { matches: true, addEventListener: () => {} };
+		const tools = createPageTools( {
+			document,
+			window: { matchMedia: () => query, MutationObserver: class {
+				observe() {}
+			} }
+		} );
+		tools.init();
+
+		query.matches = false;
+		tools.sync();
+
+		expect( barIds() ).toEqual( [ 'p-views', 'p-associated-pages', 'citizen-page-more-dropdown' ] );
+		const views = Array.from(
+			document.querySelectorAll( '#p-views .citizen-menu__content-list > li' )
+		).map( ( n ) => n.id );
+		expect( views ).toEqual( [ 'ca-view', 'ca-ve-edit', 'ca-history' ] );
+		expect( cardViewIds() ).toEqual( [ 'ca-move' ] );
+	} );
+
+	it( 'marks the bar collapsed so the scroll fade can stand down', () => {
+		const query = { matches: true, addEventListener: () => {} };
+		const tools = createPageTools( {
+			document,
+			window: { matchMedia: () => query, MutationObserver: class {
+				observe() {}
+			} }
+		} );
+		tools.init();
+		const bar = document.querySelector( '.citizen-page-actions' );
+
+		expect( bar.classList.contains( 'citizen-page-actions--collapsed' ) ).toBe( true );
+
+		query.matches = false;
+		tools.sync();
+
+		expect( bar.classList.contains( 'citizen-page-actions--collapsed' ) ).toBe( false );
+	} );
+
+	it( 'builds no shell when the editor is the only view', () => {
+		document.getElementById( 'ca-view' ).remove();
+		document.getElementById( 'ca-history' ).remove();
+		const tools = createPageTools( { document, window: makeWindow( true ) } );
+
+		tools.init();
+
+		expect( card().querySelector( 'nav:not( #p-cactions ):not( #p-associated-pages )' ) ).toBeNull();
+	} );
+
+	it( 'sends a tab added after the split into the card, not the bar', async () => {
+		// A real observer: the whole point of this path is that it fires on a
+		// mutation the skin did not make.
+		const tools = createPageTools( {
+			document,
+			window: { matchMedia: () => ( { matches: true, addEventListener: () => {} } ), MutationObserver }
+		} );
+		tools.init();
+
+		// what mw.util.addPortletLink does, reduced to its effect
+		const late = document.createElement( 'li' );
+		late.id = 'ca-gadget';
+		late.className = 'mw-list-item';
+		late.innerHTML = '<a href="#"><span>Gadget tab</span></a>';
+		document.querySelector( '#p-views .citizen-menu__content-list' ).appendChild( late );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( document.getElementById( 'ca-gadget' ).closest( '.citizen-menu__card' ) ).not.toBeNull();
+		const inBar = Array.from(
+			document.querySelectorAll( '#p-views .citizen-menu__content-list > li' )
+		).map( ( n ) => n.id );
+		expect( inBar ).toEqual( [ 'ca-ve-edit' ] );
+	} );
+
+	it( 'leaves a late editor button in the bar', async () => {
+		const tools = createPageTools( {
+			document,
+			window: { matchMedia: () => ( { matches: true, addEventListener: () => {} } ), MutationObserver }
+		} );
+		tools.init();
+
+		const late = document.createElement( 'li' );
+		late.id = 'ca-edit';
+		document.querySelector( '#p-views .citizen-menu__content-list' ).appendChild( late );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( document.getElementById( 'ca-edit' ).closest( '.citizen-menu__card' ) ).toBeNull();
+	} );
+
+	it( 'survives a viewport with no matchMedia', () => {
+		const tools = createPageTools( { document, window: {} } );
+
+		expect( () => tools.init() ).not.toThrow();
+		expect( barIds() ).toEqual( [ 'p-views', 'p-associated-pages', 'citizen-page-more-dropdown' ] );
+	} );
+} );

--- a/tests/vitest/skins.citizen.toc/index.test.js
+++ b/tests/vitest/skins.citizen.toc/index.test.js
@@ -195,10 +195,11 @@ describe( 'tableOfContents module entry', () => {
 		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( false );
 	} );
 
-	it( 'should not activate at idle on narrow viewports where the spy is paused', () => {
+	it( 'should activate at idle on narrow viewports, where the contents control is the only outline', () => {
 		const { tocItem } = createFixture();
 		win = createMockWindow();
-		// Below the desktop breakpoint the ToC popover is collapsed
+		// Below the desktop breakpoint the outline is a pill rather than a
+		// standing list, and the active section is that pill's value.
 		win.matchMedia = vi.fn( () => ( {
 			matches: false,
 			addEventListener: vi.fn(),
@@ -220,6 +221,6 @@ describe( 'tableOfContents module entry', () => {
 		idleCallbacks.forEach( ( cb ) => cb() );
 		flushFrame();
 
-		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( false );
+		expect( tocItem.classList.contains( 'citizen-toc-list-item--active' ) ).toBe( true );
 	} );
 } );

--- a/tests/vitest/skins.citizen.toc/sectionLabel.test.js
+++ b/tests/vitest/skins.citizen.toc/sectionLabel.test.js
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+/* global document */
+
+const { createSectionLabel } = require( '../../../resources/skins.citizen.toc/sectionLabel.js' );
+
+const FIXTURE = `
+<div id="citizen-toc" class="citizen-toc citizen-dropdown">
+	<details class="citizen-dropdown-details">
+		<summary class="citizen-dropdown-summary">
+			<span class="citizen-ui-icon mw-ui-icon-wikimedia-listBullet"></span>
+			<span>Contents</span>
+		</summary>
+	</details>
+	<nav id="mw-panel-toc">
+		<li id="toc-History" class="citizen-toc-list-item"><a><span class="citizen-toc-heading">History</span></a></li>
+		<li id="toc-Care" class="citizen-toc-list-item"><a><span class="citizen-toc-heading">Care</span></a></li>
+		<li id="toc-Health" class="citizen-toc-list-item"><a><span class="citizen-toc-heading">Health</span></a></li>
+	</nav>
+</div>`;
+
+const win = ( reduced = false ) => ( {
+	matchMedia: () => ( { matches: reduced } )
+} );
+
+const toc = () => document.getElementById( 'citizen-toc' );
+const track = () => document.querySelector( '.citizen-toc-current__track' );
+const lines = () => Array.from( document.querySelectorAll( '.citizen-toc-current__line' ) );
+
+describe( 'sectionLabel', () => {
+	beforeEach( () => {
+		document.body.innerHTML = FIXTURE;
+	} );
+
+	it( 'gives the control a value slot without disturbing its label', () => {
+		const label = createSectionLabel( { document, window: win() } );
+
+		expect( label.init() ).toBe( true );
+
+		const summary = document.querySelector( '.citizen-dropdown-summary' );
+		// A span here would be caught by the rule that screen-reader-onlys the
+		// "Contents" label beside it.
+		expect( document.querySelector( '.citizen-toc-current' ).tagName ).toBe( 'DIV' );
+		expect( summary.querySelector( '.citizen-toc-current' ).getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+		expect( summary.textContent ).toContain( 'Contents' );
+	} );
+
+	it( 'does nothing on a page with no contents control', () => {
+		document.body.innerHTML = '<div></div>';
+		const label = createSectionLabel( { document, window: win() } );
+
+		expect( label.init() ).toBe( false );
+		expect( () => label.update( 'toc-History' ) ).not.toThrow();
+	} );
+
+	it( 'shows the section and marks the control as tracking', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+
+		label.update( 'toc-Care' );
+
+		expect( track().textContent ).toBe( 'Care' );
+		expect( toc().classList.contains( 'citizen-toc--tracking' ) ).toBe( true );
+	} );
+
+	it( 'falls back to no value in the lead, where there is no section yet', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+		label.update( 'toc-Care' );
+
+		label.update( null );
+
+		expect( track().textContent ).toBe( '' );
+		expect( toc().classList.contains( 'citizen-toc--tracking' ) ).toBe( false );
+	} );
+
+	it( 'pushes the arriving label the way the reader is travelling', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+		label.update( 'toc-History' );
+
+		label.update( 'toc-Health' );
+
+		const [ leaving, entering ] = lines();
+		expect( leaving.classList.contains( 'is-leaving-above' ) ).toBe( true );
+		expect( entering.classList.contains( 'is-entering-below' ) ).toBe( true );
+	} );
+
+	it( 'reverses the push when the reader scrolls back up', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+		label.update( 'toc-Health' );
+
+		label.update( 'toc-History' );
+
+		const [ leaving, entering ] = lines();
+		expect( leaving.classList.contains( 'is-leaving-below' ) ).toBe( true );
+		expect( entering.classList.contains( 'is-entering-above' ) ).toBe( true );
+	} );
+
+	it( 'swaps without animating under reduced motion', () => {
+		const label = createSectionLabel( { document, window: win( true ) } );
+		label.init();
+		label.update( 'toc-History' );
+
+		label.update( 'toc-Care' );
+
+		expect( lines() ).toHaveLength( 1 );
+		expect( lines()[ 0 ].className ).toBe( 'citizen-toc-current__line' );
+		expect( track().textContent ).toBe( 'Care' );
+	} );
+
+	it( 'takes the leaving label out once its animation ends', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+		label.update( 'toc-History' );
+		label.update( 'toc-Care' );
+		const leaving = lines().find( ( l ) => l.classList.contains( 'is-leaving' ) );
+
+		leaving.dispatchEvent( new window.Event( 'animationend' ) );
+
+		expect( lines() ).toHaveLength( 1 );
+		expect( track().textContent ).toBe( 'Care' );
+	} );
+
+	it( 'follows the row the card marks active, whoever activated it', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+		// what a hash load or a post-VisualEditor rebuild leaves behind: the
+		// card marked, with no scroll event to follow
+		document.getElementById( 'toc-Health' ).classList.add( 'citizen-toc-list-item--active' );
+
+		label.syncFromCard();
+
+		expect( track().textContent ).toBe( 'Health' );
+		expect( toc().classList.contains( 'citizen-toc--tracking' ) ).toBe( true );
+	} );
+
+	it( 'clears the value when the card marks nothing', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+		label.update( 'toc-Care' );
+
+		label.syncFromCard();
+
+		expect( track().textContent ).toBe( '' );
+		expect( toc().classList.contains( 'citizen-toc--tracking' ) ).toBe( false );
+	} );
+
+	it( 'ignores a repeat of the section already shown', () => {
+		const label = createSectionLabel( { document, window: win() } );
+		label.init();
+		label.update( 'toc-Care' );
+
+		label.update( 'toc-Care' );
+
+		expect( lines() ).toHaveLength( 1 );
+	} );
+} );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
 	"include": [
 		"resources/skins.citizen.commandPalette/**/*.js",
 		"resources/skins.citizen.scripts/keyboardLayout.js",
+		"resources/skins.citizen.scripts/pageTools.js",
 		"resources/types/**/*.d.ts"
 	]
 }


### PR DESCRIPTION
## Problem

The bottom of a phone screen carried three navigation surfaces at once: a floating contents pill, a floating page-actions bar holding every view and associated page the wiki could produce, and a sticky header that arrived on scroll. Together they were 112px of a 740px screen, and they said less than they cost.

The actions bar was the worst of it. It enumerated whatever MediaWiki gave it, so its width was set by the page rather than by the design: 266px on an article, and on `Special:Watchlist` a 344px strip that wanted 505px and scrolled. The contents pill named what it opened but not where you were. The sticky header repeated the page title a third time.

## Behaviour

Two surfaces, both in the floating language the skin already uses.

**The contents pill carries the section you are reading.** It is a glyph until there is a section to name, then it grows to hold it and changes as you pass each heading, the arriving label pushing the leaving one out in the direction you are travelling. That movement is the point: text that tracks your position reads as an outline in a way a static label cannot. On a page with no headings there is no pill at all — no outline, no control, no cost.

**The actions bar carries the one action worth a permanent slot and the way to everything else.** Everything it drops moves into the overflow card rather than disappearing, grouped as MediaWiki groups it. On an article that is 266px → 174px; on `Special:Watchlist`, 344px → 42px.

**The sticky header goes below tablet.** The pill says where you are and the bar holds the actions, so it was repeating both in a third band. It is no longer built there either — building it clones both page-tools dropdowns and keeps a MutationObserver on each for the life of the page, all for a bar that cannot be shown.

Four smaller repairs fell out of putting the two islands side by side, all of them pre-existing:

- The contents card could not scroll to its last row, and clipped rows into padding rather than at its border.
- The contents pill stood 2px shorter than the bar beside it.
- Both islands sat 16px from the block end and 8px from the side, because a margin and an offset each applied the same inset.
- The overflow card sat 16px from each side and 14px off its bar, for the same reason one level down.

## Contract

- **No compat slice.** No class is renamed, no ID removed, and no PHP-emitted markup restructured. Everything added is added at runtime.
- **No script, no change.** Every relocation and the section label are client-side enhancements. Without JS the bar renders exactly as it does today and everything stays reachable — which is why the label fix that shipped in #1858 matters here.
- **Nothing becomes unreachable.** Menus leaving the bar are *moved* into the overflow card, not copied: a copy would duplicate every ID in the menu, and `mw.util.addPortletLink` would keep targeting the original, so a gadget's tab would land in whichever copy the skin happened not to be showing. A MutationObserver catches tabs added after the split.
- **Autohide keeps working on mobile.** Its observer used to be started and stopped alongside the sticky header, which was harmless while that bar existed everywhere and would have taken autohide down with it the moment it stopped. It now follows the page-header sentinel directly.
- **Desktop is untouched**, and both `$wgCitizenHeaderPositionMobile` placements and RTL were verified.

## Performance

Measured against this branch's base at 360x740, on a deliberately pathological page (53 headings, 43,751px, 1,715 elements).

Steady-state scrolling is unchanged: p50 16.6 → 16.7ms, p90 17.9 → 18.8ms at 4x CPU throttle, no long tasks in either. The scroll spy that feeds the pill used to be paused below 1120px; running it costs nothing at the frame level, because its throttled handler hands the geometry to an IntersectionObserver.

The cost is one full-document layout per section change, which scales with page length rather than with this code: ~1.1ms on a normal article, ~3.5ms on the pathological one. At 1x CPU that drops no frames at all (worst frame 21ms). At 4x it costs a frame per section boundary.

Reusing nodes instead of inserting them, `contain: layout`/`content` on the pill's subtree, and a fixed width instead of `max-content` were all measured and none helped — the layout is dirtied by any content change, not by the resize.

## Follow-ups

- A section name longer than the pill ellipsises. The design calls for the edge to fade and the label to scroll itself after a settle delay; that is not in this branch.
- `skins.citizen.toc` is still outside `tsconfig.json`'s `include`. Adding `sectionLabel.js` pulls in `tableOfContents.js` through the import, which has four pre-existing strict-null errors; typing the module means fixing those first.
- `sectionLabel.update()` has no viewport guard, so it does its (bounded, per-heading) work on desktop too, where the pill is `display: none`. Gating it needs a breakpoint-crossing resync to avoid a stale value.
- Share and languages remain separate controls on an article, so it reads `[share] [edit] [⋯]` rather than two. Deliberate for now.

## Test plan

- `Special:Watchlist`, articles with and without headings, both header placements, RTL, desktop at 1400px.
- Viewport crossing 1120px in both directions: menus return to their original order, no duplicate IDs.
- Hit testing after removing the `pointer-events` guards: pill, the gap between the islands, and the bar all target correctly; outside-dismiss still works.
- `npm test` 1511 passing across 80 files (21 new, in 2 new files), `lint:styles`, `lint:types`, `lint:i18n`, `lint:compat` clean. PHP `parallel-lint`, `phpcs` and `minus-x` clean; Phan fails only on three pre-existing `UnusedPluginSuppression` errors in a file this branch does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EE9WSAn6LCMhrwMz6Eb7vN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mobile page actions now collapse into an overflow menu, while keeping the editor action visible.
  - The table of contents displays the current section in its mobile control and updates as you scroll.
  - Added a localized “Related pages” label for associated pages.

- **Improvements**
  - Sticky headers and page tools now respond more smoothly when changing screen size or device orientation.
  - Mobile page tools and table of contents receive improved spacing, positioning, transitions, and reduced-motion support.
  - Menu buttons now align their labels consistently with other menu items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->