### PR TITLE
fix(pagetools): undress the rows moved into the mobile overflow card

### DIFF
--- a/resources/skins.citizen.scripts/pageTools.js
+++ b/resources/skins.citizen.scripts/pageTools.js
@@ -8,7 +8,16 @@ const
 	LIST_SELECTOR = '.citizen-menu__content-list',
 	// The one action worth a permanent slot. Both ids can be present; the
 	// merged-button rule in Pagetools.less decides which of them is drawn.
-	KEEP_SELECTOR = '#ca-ve-edit, #ca-edit';
+	KEEP_SELECTOR = '#ca-ve-edit, #ca-edit',
+	// What MenuItemDecorator::addButtonClassesToMenuItems adds. A list, not a
+	// prefix match, so nothing else can be taken by mistake.
+	BUTTON_CLASSES = [
+		'citizen-cdx-button--size-large',
+		'cdx-button',
+		'cdx-button--fake-button',
+		'cdx-button--fake-button--enabled',
+		'cdx-button--weight-quiet'
+	];
 
 /**
  * Below tablet the page-actions bar is reduced to the one action worth a
@@ -29,6 +38,8 @@ class PageTools {
 		this.window = window;
 		/** @type {{node: Element, parent: Element, next: Node|null}[]} */
 		this.moves = [];
+		/** @type {WeakMap<Element, string[]>} */
+		this.buttonChrome = new WeakMap();
 		this.shell = null;
 		this.isCollapsed = false;
 		this.sync = this.sync.bind( this );
@@ -60,6 +71,37 @@ class PageTools {
 		}
 		this.moves.push( { node, parent: origin, next: node.nextSibling } );
 		parent.insertBefore( node, before );
+	}
+
+	/**
+	 * In the bar these links are buttons; in the card they are rows, and
+	 * Codex's button styles would set them apart from every row beside them.
+	 *
+	 * @param {Element} scope
+	 */
+	undress( scope ) {
+		scope.querySelectorAll( 'a' ).forEach( ( link ) => {
+			const worn = BUTTON_CLASSES.filter( ( name ) => link.classList.contains( name ) );
+			if ( worn.length > 0 ) {
+				this.buttonChrome.set( link, worn );
+				link.classList.remove( ...worn );
+			}
+		} );
+	}
+
+	/**
+	 * Put it back on the way out.
+	 *
+	 * @param {Element} scope
+	 */
+	dress( scope ) {
+		scope.querySelectorAll( 'a' ).forEach( ( link ) => {
+			const worn = this.buttonChrome.get( link );
+			if ( worn ) {
+				link.classList.add( ...worn );
+				this.buttonChrome.delete( link );
+			}
+		} );
 	}
 
 	/**
@@ -128,6 +170,7 @@ class PageTools {
 		const associated = this.document.getElementById( ASSOCIATED_ID );
 		if ( associated && associated.parentElement === bar ) {
 			this.moveNode( associated, card, card.firstChild );
+			this.undress( associated );
 		}
 
 		const views = this.document.getElementById( VIEWS_ID );
@@ -150,6 +193,7 @@ class PageTools {
 		const target = this.ensureShell();
 		if ( target ) {
 			this.moveNode( item, target, null );
+			this.undress( item );
 		}
 	}
 
@@ -165,6 +209,7 @@ class PageTools {
 		// Reverse order, so each node's remembered next sibling is back in
 		// place before it is reinserted.
 		this.moves.reverse().forEach( ( { node, parent, next } ) => {
+			this.dress( node );
 			parent.insertBefore( node, next );
 		} );
 		this.moves = [];

--- a/resources/skins.citizen.styles/components/Menu.less
+++ b/resources/skins.citizen.styles/components/Menu.less
@@ -23,13 +23,6 @@
 		transform: var( --citizen-translate-closed );
 		.mixin-citizen-frosted-glass;
 
-		// A menu that renders as buttons elsewhere arrives here as rows, and
-		// Codex centres a button's content. Every other card starts its labels
-		// at the same edge; a centred row reads as a button in a list of rows.
-		.cdx-button {
-			justify-content: flex-start;
-		}
-
 		&-content {
 			max-width: inherit;
 			max-height: inherit;

--- a/resources/skins.citizen.styles/components/Pagetools.less
+++ b/resources/skins.citizen.styles/components/Pagetools.less
@@ -47,6 +47,9 @@
 			gap: 0;
 			padding-right: var( --space-sm );
 			padding-left: var( --space-sm );
+			// Codex sizes its own button from 2.x (MW 1.46); these take theirs
+			// from the menu. Inert below it, where Codex says `inherit` too.
+			font-size: inherit;
 			border-radius: var( --border-radius-medium );
 
 			// Collapse a label only where a glyph replaces it: getAssociated-

--- a/tests/vitest/skins.citizen.scripts/pageTools.test.js
+++ b/tests/vitest/skins.citizen.scripts/pageTools.test.js
@@ -9,16 +9,16 @@ const BAR = `
 		<div class="citizen-menu__heading">Views</div>
 		<div class="citizen-menu__content">
 			<ul class="citizen-menu__content-list">
-				<li id="ca-view" class="mw-list-item"><a href="/wiki/Foo">Read</a></li>
-				<li id="ca-ve-edit" class="mw-list-item"><a href="#">Edit</a></li>
-				<li id="ca-history" class="mw-list-item"><a href="#">View history</a></li>
+				<li id="ca-view" class="mw-list-item"><a href="/wiki/Foo" class="citizen-cdx-button--size-large cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet">Read</a></li>
+				<li id="ca-ve-edit" class="mw-list-item"><a href="#" class="cdx-button cdx-button--weight-quiet">Edit</a></li>
+				<li id="ca-history" class="mw-list-item"><a href="#" class="citizen-cdx-button--size-large cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet">View history</a></li>
 			</ul>
 		</div>
 	</nav>
 	<nav id="p-associated-pages" class="citizen-menu mw-portlet" aria-label="Associated">
 		<div class="citizen-menu__content">
 			<ul class="citizen-menu__content-list">
-				<li id="ca-talk" class="mw-list-item"><a href="#">Discussion</a></li>
+				<li id="ca-talk" class="mw-list-item"><a href="#" class="new citizen-cdx-button--size-large cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet">Discussion</a></li>
 			</ul>
 		</div>
 	</nav>
@@ -178,6 +178,47 @@ describe( 'pageTools', () => {
 		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 		expect( document.getElementById( 'ca-edit' ).closest( '.citizen-menu__card' ) ).toBeNull();
+	} );
+
+	it( 'takes the button chrome off the rows it moves into the card', () => {
+		const tools = createPageTools( { document, window: makeWindow( true ) } );
+
+		tools.init();
+
+		const moved = [ ...card().querySelectorAll( 'li > a' ) ]
+			.filter( ( a ) => a.closest( 'li' ).id !== 'ca-move' );
+		expect( moved.length ).toBeGreaterThan( 0 );
+		moved.forEach( ( a ) => {
+			expect( a.className ).not.toMatch( /cdx-button/ );
+		} );
+		// classes the decorator did not add are left alone
+		expect( document.querySelector( '#ca-talk > a' ).classList.contains( 'new' ) ).toBe( true );
+	} );
+
+	it( 'leaves the button chrome on what stays in the bar', () => {
+		const tools = createPageTools( { document, window: makeWindow( true ) } );
+
+		tools.init();
+
+		expect( document.querySelector( '#ca-ve-edit > a' ).className ).toMatch( /cdx-button/ );
+	} );
+
+	it( 'puts the button chrome back on the way to desktop', () => {
+		const query = { matches: true, addEventListener: () => {} };
+		const tools = createPageTools( {
+			document,
+			window: { matchMedia: () => query, MutationObserver: class {
+				observe() {}
+			} }
+		} );
+		const original = document.querySelector( '#ca-view > a' ).className;
+		tools.init();
+
+		query.matches = false;
+		tools.sync();
+
+		expect( document.querySelector( '#ca-view > a' ).className ).toBe( original );
+		expect( document.querySelector( '#ca-talk > a' ).className ).toMatch( /^new / );
 	} );
 
 	it( 'survives a viewport with no matchMedia', () => {


### PR DESCRIPTION
## Problem

Two faults in the mobile overflow card, one of them shipped by #1860.

**Rows moved into the card kept their button chrome.** The views and associated-pages links are decorated as Codex buttons for the bar, and script relocates them into the overflow card below tablet. They arrived still dressed as buttons, so they read as a different kind of thing from every row beside them — their own font size, their own padding, a centred label. #1860 straightened them with a rule at the wrong level:

```css
.citizen-menu__card .cdx-button { justify-content: flex-start; }
```

That reaches every Codex button in every card in the skin, including the notifications panel, whose footer buttons should be centred and were not.

**MediaWiki 1.46 sizes the page tabs.** It is the first release to bundle Codex 2.x, which added `.cdx-button { font-size: var( --font-size-medium, 1rem ) }`. Citizen sizes these from the menu around them, so the tabs went from 14px to 16px against a 14px bar.

## Behaviour

The button chrome now comes off on the way into the card and goes back on the way out, which is where the difference belongs. In the card the rows are indistinguishable from the ones already there; in the bar and on desktop nothing changes.

Only what `MenuItemDecorator::addButtonClassesToMenuItems` added is taken, and only from links wearing it, so a class from anywhere else survives the trip and a link a gadget added is left alone.

With the chrome gone at the source, the `justify-content` rule has nothing left to do and is removed — the decorator touches only views and associated-pages, so nothing else in the skin puts a decorated button in a card. Notification buttons are centred again.

The page tabs keep the menu's text size on 1.46.

## Contract

- **Restoring, not overriding.** Codex 1.x sets `font-size: inherit` on the same property, so the size rule is inert on 1.43–1.45 rather than a second opinion.
- **Scoped to what shows.** Applied to the two menus that carry a text label, not to every button in the skin. A blanket rule changes 25 buttons on an article and 19 of them are icon-only, where the size is not visible at all — icons take theirs from `--size-icon`. Of the six that do show text, five are these tabs and the sixth belongs to a wiki template.
- **The round trip is exact.** Crossing the breakpoint restores every class, including ones the decorator did not add, with no duplicate ids.
- No markup is restructured and no class renamed, so no compat slice.

## Follow-ups

- Section heading buttons, ToC toggles and footer buttons are also 1rem on 1.46. All are icon-only, so nothing is visibly wrong; if any of them gains a label, it will need the same treatment.

## Test plan

- Dev wiki at 360×740: moved rows render with no button classes, at 14px, left-aligned at the same edge as the card's own rows; `ca-talk` keeps its `new` class.
- Desktop 1400px: every class restored exactly, tab widths unchanged (View history 131px, Discussion 123px), no duplicate ids.
- Notifications panel: footer buttons back to `justify-content: center`.
- Checked against a live 1.46 wiki for the size fault and its scope, and against the bundled Codex 1.x CSS to confirm the rule is inert there.
- `npm test` 1514 passing across 80 files, `lint:styles`, `lint:types`, `lint:compat` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EE9WSAn6LCMhrwMz6Eb7vN
