### PR TITLE
fix(tokens): restore escape on the dark backdrop token

### DIFF
--- a/resources/skins.citizen.tokens.new/background-color.less
+++ b/resources/skins.citizen.tokens.new/background-color.less
@@ -74,7 +74,10 @@
 	// expression so light-dark() picks one of two finished colors
 	// (color-mix can't span a light-dark() pair).
 	--background-color-backdrop-light: light-dark( ~'color-mix( in oklch, var( --color-neutral-50 ) calc( var( --backdrop-opacity ) * 100% ), transparent )', ~'color-mix( in oklch, var( --color-neutral-1000 ) calc( var( --backdrop-opacity ) * 100% ), transparent )' );
-	--background-color-backdrop-dark: rgba( 0, 0, 0, var( --backdrop-opacity ) );
+	// Escaped: less.php < 5.5.0 (MediaWiki < 1.43.7 / < 1.44.4 / < 1.45.2)
+	// evaluates rgba() itself and rejects a var() argument, taking the whole
+	// module down with it.
+	--background-color-backdrop-dark: ~'rgba( 0, 0, 0, var( --backdrop-opacity ) )';
 
 	// Theme-invariant bg utilities
 	--background-color-transparent: transparent;


### PR DESCRIPTION
### Problem

On MediaWiki versions whose bundled less.php predates 5.5.0, `skins.citizen.preferences` fails to compile and ResourceLoader drops the module entirely — styles and package files together. The preferences panel never mounts and reports *"Couldn't load preferences. Check your connection and try again."* On preview wikis `skins.citizen.tokens.new` fails the same way, so the whole token layer disappears from the page.

`--background-color-backdrop-dark` passed a `var()` to `rgba()` without the `~'...'` escape that its neighbours in the same file and its counterpart in `tokens-codex.less` all carry. less.php below 5.5.0 evaluates `rgba()` itself and rejects a non-numeric argument, aborting the stylesheet.

### Affected versions

| MediaWiki | bundled less.php | affected |
| --- | --- | --- |
| 1.43.0 – 1.43.6 | 5.1.2 | yes |
| 1.44.0 – 1.44.3 | 5.2.1 | yes |
| 1.45.0 – 1.45.1 | 5.2.2 | yes |
| 1.43.7+ / 1.44.4+ / 1.45.2+ / 1.46 | 5.5.0+ | no |

Thirteen released MediaWiki versions across three branches. The pins are exact, so an affected wiki cannot `composer update` out of it. Reachable since Citizen 3.18.0, when `skins.citizen.preferences` gained `themePreview.less` and began importing the token file on every wiki — before that the declaration existed but only inside the preview-gated module.

CSS-variable support in native colour functions landed in less.php 5.5.0 ([T405815](https://phabricator.wikimedia.org/T405815)), which is why this was never seen in development: the dev checkout tracks a branch head and is always newer than the released tarballs most wikis run.

### Behaviour

No visual change on any version. Compiled output is byte-identical between less.php 5.1.2 and 5.5.0, and differs from current 5.5.0 output only in whitespace inside the call.

### Contract

Cache status **clean** — no class or ID renamed or removed, no change to PHP-emitted markup, so no compat slice is required.

Verified by compiling all 258 style entry points — module `styles`, `ResourceModuleSkinStyles`, compat slices and Vue SFC `<style lang="less">` blocks — against less.php 5.1.2, 5.2.1, 5.2.2, 5.4.0 and 5.5.0: 258/258 on each. A separate sweep of all 336 stylesheets finds no other unescaped colour function taking a `var()`.

### Follow-ups

- #1876 tracks removing this escape once the minimum MediaWiki version guarantees less.php 5.5.0 or newer. It is deliberately not a blanket cleanup: of the 153 escapes in the skin, 19 contain a `/` and are permanent on every version, because MediaWiki compiles with `math: always` and the slash is parsed as division.
- The reporter's second symptom in #1873 — the settings icon not rendering — is unrelated to this and remains open. It predates the compile failure and is not reproducible from the source.
- Nothing in CI compiles the skin's LESS against the oldest supported MediaWiki, and `skins.citizen.preferences` has no compile coverage at all. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoZaer9zN7M7DE5y4Y7EbY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backdrop styling compatibility with older platform versions.
  * Prevented the module from failing when CSS variables are used in backdrop color definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->